### PR TITLE
🔴 CRITICAL: Fix authorization code reuse token revocation (OAuth 2.1)

### DIFF
--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -63,11 +63,11 @@ func TestNewProvider(t *testing.T) {
 				t.Errorf("NewProvider() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-		if !tt.wantErr && provider != nil {
-			if provider.httpClient == nil {
-				t.Error("NewProvider() httpClient is nil")
+			if !tt.wantErr && provider != nil {
+				if provider.httpClient == nil {
+					t.Error("NewProvider() httpClient is nil")
+				}
 			}
-		}
 		})
 	}
 }
@@ -140,8 +140,8 @@ func TestProvider_AuthorizationURL(t *testing.T) {
 			},
 		},
 		{
-			name:         "without PKCE",
-			state:        "test-state",
+			name:  "without PKCE",
+			state: "test-state",
 			wantContains: []string{
 				"state=test-state",
 				"access_type=offline",
@@ -504,4 +504,3 @@ func (r *revokeTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 	return http.DefaultTransport.RoundTrip(req)
 }
-

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -694,10 +694,17 @@ func TestStore_GetAuthorizationCode_Used(t *testing.T) {
 		t.Fatalf("SaveAuthorizationCode() error = %v", err)
 	}
 
-	// Should return error for used code
-	_, err := store.GetAuthorizationCode(code.Code)
-	if err == nil {
-		t.Error("GetAuthorizationCode() should return error for used code")
+	// Should return the code even if used (for OAuth 2.1 reuse detection)
+	// The caller is responsible for checking the Used flag and revoking tokens
+	retrievedCode, err := store.GetAuthorizationCode(code.Code)
+	if err != nil {
+		t.Errorf("GetAuthorizationCode() error = %v, want nil (should return used code for reuse detection)", err)
+	}
+	if retrievedCode == nil {
+		t.Fatal("GetAuthorizationCode() returned nil code")
+	}
+	if !retrievedCode.Used {
+		t.Error("Retrieved code should have Used=true")
 	}
 }
 

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -62,6 +62,19 @@ type RefreshTokenFamilyMetadata struct {
 	Revoked    bool
 }
 
+// TokenRevocationStore supports bulk token revocation operations (OAuth 2.1 security).
+// This is optional - only implemented by stores that support token revocation.
+// Used for critical security scenarios like authorization code reuse detection.
+type TokenRevocationStore interface {
+	// RevokeAllTokensForUserClient revokes all tokens (access + refresh) for a specific user+client combination.
+	// This is called when authorization code reuse is detected (OAuth 2.1 requirement).
+	// Returns the number of tokens revoked and any error encountered.
+	RevokeAllTokensForUserClient(userID, clientID string) (int, error)
+
+	// GetTokensByUserClient retrieves all token IDs for a user+client combination (for testing/debugging).
+	GetTokensByUserClient(userID, clientID string) ([]string, error)
+}
+
 // ClientStore defines the interface for managing OAuth client registrations.
 type ClientStore interface {
 	// SaveClient saves a registered client


### PR DESCRIPTION
## Critical Security Fix

Implements OAuth 2.1 requirement to revoke all tokens when authorization code reuse is detected.

Closes #16

## Summary

When an authorization code is reused (indicating a potential token theft attack), the system now:
1. Detects the reuse attempt
2. Revokes ALL tokens for that user+client combination
3. Revokes entire refresh token families
4. Logs detailed audit events
5. Returns an error to the attacker

## Changes

### Storage Layer
- Added `TokenRevocationStore` interface for bulk token revocation
- Implemented token metadata tracking (`userID`, `clientID`, `tokenType`)
- Added `RevokeAllTokensForUserClient` and `GetTokensByUserClient` methods
- Modified `GetAuthorizationCode` to return used codes (needed for reuse detection)

### Server Layer  
- Implemented `RevokeAllTokensForUserClient` method with graceful degradation
- Updated authorization code exchange flow to call revocation on reuse
- Changed behavior to keep authorization codes marked as "Used" instead of deleting
- Added comprehensive audit logging for security events

### Tests
- `TestServer_AuthorizationCodeReuseRevokesTokens` - basic reuse detection
- `TestServer_AuthorizationCodeReuseRevokesMultipleTokens` - with refresh token rotation
- `TestServer_RevokeAllTokensForUserClient` - direct revocation testing

## Security Impact

✅ Fulfills OAuth 2.1 Section 4.1.2 requirement  
✅ Prevents token theft via code interception  
✅ Revokes access tokens, refresh tokens, and token families  
✅ Provides detailed audit trail for incident investigation  
✅ No false positives - only triggers on actual code reuse

## Backward Compatibility

✅ No breaking changes to public APIs  
✅ `TokenRevocationStore` is optional - graceful degradation  
✅ Existing code continues to work  
✅ Revocation is an additive security feature

## Test Results

```
✅ All tests pass (22s with race detector)
✅ No new linting errors introduced
✅ Test coverage: Authorization code reuse scenarios
✅ Test coverage: Multi-token revocation
✅ Test coverage: Refresh token family revocation
```

## OAuth 2.1 Compliance

This change brings the library into full compliance with OAuth 2.1 Section 4.1.2:

> If an authorization code is used more than once, the authorization server
> MUST deny the request and SHOULD revoke (when possible) all tokens previously
> issued based on that authorization code.

## References

- OAuth 2.1 Draft Section 4.1.2
- RFC 6749 Section 10.5
- Security Audit Report (November 23, 2025) - CRITICAL-01