### PR TITLE
chore(makefile): speed up local test execution

### DIFF
--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -2,8 +2,11 @@
 
 ##@ Library Development
 
-.PHONY: test test-coverage test-race test-all
-test: ## Run tests
+# NOTE: 'make test' is defined in Makefile.gen.go.mk and runs with -race (slow but thorough)
+# For faster local iteration, use 'make test-fast' instead
+
+.PHONY: test-fast test-coverage test-race test-all
+test-fast: ## Run tests (fast, no race detector) - RECOMMENDED for local dev
 	@echo "====> $@"
 	go test -v ./...
 

--- a/Makefile.local.mk
+++ b/Makefile.local.mk
@@ -1,0 +1,12 @@
+# Local development overrides
+# This file loads after Makefile.gen.go.mk to override the slow test target
+
+##@ Local Development
+
+# Override the generated test target for faster local development
+# The generated target in Makefile.gen.go.mk runs with -race which is very slow
+.PHONY: test
+test: ## Run tests (fast version for local dev, use test-race for full CI checks)
+	@echo "====> $@"
+	go test -v ./...
+


### PR DESCRIPTION
## Summary

This PR speeds up local test execution by removing the race detector from the default `make test` target, reducing test time from ~60s to ~8s.

## Changes

- **Added** `Makefile.local.mk` - Overrides the generated test target (loads alphabetically after Makefile.gen.go.mk)
- **Updated** `Makefile.custom.mk` - Added documentation about test-fast target

## Impact

### Local Development (Faster)
- `make test` now runs without `-race` flag (8 seconds)
- `make test-fast` explicitly runs fast tests (8 seconds)
- `make test-race` still available for race detection (60+ seconds)
- `make verify` still uses test-race (full local CI simulation)

### CI (Unchanged)
- CI workflow uses direct `go test -race` command
- No Makefile targets are used in `.github/workflows/ci.yml`
- Race detection still runs in CI for every PR

## Rationale

The race detector adds 3-5x overhead, making rapid local iteration slow. For quick feedback during development, the race detector is overkill. CI still catches race conditions before merge.

## Testing

Verified that:
- `make test` runs fast (no -race)
- `make test-race` still works (with -race)
- `make verify` still runs test-race
- CI workflow unchanged (checked .github/workflows/ci.yml)