### PR TITLE
ci: derive Go versions dynamically from go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,44 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  # Determine Go versions from go.mod for consistent testing
+  setup:
+    name: Setup Go Versions
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.go-version.outputs.version }}
+      go-matrix: ${{ steps.go-version.outputs.matrix }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+    
+    - name: Extract Go version from go.mod
+      id: go-version
+      run: |
+        # Extract version from go.mod (e.g., "1.24.0" -> "1.24")
+        GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}' | cut -d. -f1,2)
+        echo "version=${GO_VERSION}" >> $GITHUB_OUTPUT
+        
+        # Calculate previous minor version for compatibility testing
+        MAJOR=$(echo $GO_VERSION | cut -d. -f1)
+        MINOR=$(echo $GO_VERSION | cut -d. -f2)
+        PREV_MINOR=$((MINOR - 1))
+        PREV_VERSION="${MAJOR}.${PREV_MINOR}"
+        
+        # Create matrix JSON array with current and previous versions
+        echo "matrix=[\"${PREV_VERSION}\", \"${GO_VERSION}\"]" >> $GITHUB_OUTPUT
+        
+        echo "Go version from go.mod: ${GO_VERSION}"
+        echo "Previous version: ${PREV_VERSION}"
+        echo "Test matrix: [\"${PREV_VERSION}\", \"${GO_VERSION}\"]"
+
   test:
     name: Test
     runs-on: ubuntu-latest
+    needs: setup
     strategy:
       matrix:
-        go-version: ['1.23', '1.24']
+        go-version: ${{ fromJson(needs.setup.outputs.go-matrix) }}
     
     steps:
     - name: Checkout code
@@ -59,7 +91,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
     
     - name: Run golangci-lint
       uses: golangci/golangci-lint-action@v9
@@ -81,10 +113,9 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version-file: go.mod
     
     - name: Build example
       run: |
         cd examples/${{ matrix.example }}
         go build -v ./...
-


### PR DESCRIPTION
## Summary

Replace hardcoded Go versions in CI workflow with dynamic extraction from `go.mod`. This prevents Renovate from creating PRs to update CI when the Go version is pinned in `go.mod`.

## Changes

- Add `setup` job to extract Go version from `go.mod`
- Calculate test matrix with current and previous Go versions automatically
- Use `go-version-file: go.mod` for lint and build-examples jobs
- Test job now uses dynamic matrix from setup job output

## How it works

1. The `setup` job extracts the Go version from `go.mod` (e.g., `1.24`)
2. It calculates the previous minor version (e.g., `1.23`)
3. Creates a JSON matrix for test compatibility: `["1.23", "1.24"]`
4. The `test` job uses this dynamic matrix
5. The `lint` and `build-examples` jobs use `go-version-file: go.mod` to read the version directly

## Benefits

- Single source of truth: Go version in `go.mod` drives CI
- Renovate won't try to update CI workflow when Go version changes
- Automatic backward compatibility testing with previous Go version
- When upgrading Go in `go.mod`, CI automatically updates

Closes #64