### PR TITLE
fix(handler): advertise registration_endpoint when trusted schemes configured

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -972,7 +972,13 @@ func (h *Handler) ServeAuthorizationServerMetadata(w http.ResponseWriter, r *htt
 
 	// Only advertise registration_endpoint if client registration is actually available
 	// RFC 8414: registration_endpoint is OPTIONAL and should only be included if supported
-	if h.server.Config.AllowPublicClientRegistration || h.server.Config.RegistrationAccessToken != "" {
+	// Registration is available when:
+	// - AllowPublicClientRegistration=true (open registration), OR
+	// - RegistrationAccessToken is set (token-based registration), OR
+	// - TrustedPublicRegistrationSchemes is configured (Cursor/VSCode can register via trusted URI schemes)
+	if h.server.Config.AllowPublicClientRegistration ||
+		h.server.Config.RegistrationAccessToken != "" ||
+		len(h.server.Config.TrustedPublicRegistrationSchemes) > 0 {
 		metadata["registration_endpoint"] = h.server.Config.RegistrationEndpoint()
 	}
 


### PR DESCRIPTION
## Summary

- Fix missing `registration_endpoint` in OAuth Authorization Server Metadata when `TrustedPublicRegistrationSchemes` is configured
- Add test case for trusted schemes metadata advertising

## Problem

When `--trusted-public-registration-schemes=cursor` is configured (without `--allow-public-registration` or `--registration-token`), the `registration_endpoint` was not being advertised in `/.well-known/oauth-authorization-server` metadata.

This caused Cursor to report:
```
Incompatible auth server: does not support dynamic client registration
```

The DCR endpoint `/oauth/register` existed and would accept registrations from Cursor's trusted URI scheme, but Cursor couldn't discover it via metadata.

## Solution

Added `TrustedPublicRegistrationSchemes` to the condition that determines whether to advertise `registration_endpoint`:

```go
// Before:
if h.server.Config.AllowPublicClientRegistration || h.server.Config.RegistrationAccessToken != "" {

// After:
if h.server.Config.AllowPublicClientRegistration ||
    h.server.Config.RegistrationAccessToken != "" ||
    len(h.server.Config.TrustedPublicRegistrationSchemes) > 0 {
```

## Test plan

- [x] Added `TestHandler_ServeAuthorizationServerMetadata_TrustedSchemes` test
- [x] Updated `TestHandler_ServeAuthorizationServerMetadata_NoRegistration` to explicitly clear trusted schemes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)