### PR TITLE
fix(server): always save tokens by email when email is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Root Cause**: The condition `userInfo.Email != userInfo.ID` prevented email storage when the comparison was not properly evaluated. With Dex, the subject claim is a base64-encoded identifier (e.g., `Cg1tYXJrdGVzdGVyQGdtYWlsLmNvbQoFbG9jYWw`), not the email
   - **Fix**: Always save tokens by email when email is available, regardless of whether it equals the ID. This is idempotent and ensures downstream consumers can reliably use email for lookups
   - **Affected Components**: `server/flows.go` - `saveUserInfoAndToken` function
-  - **Testing**: Added test `TestServer_HandleProviderCallback_TokenLookupByEmail` that simulates Dex's base64-encoded subject claims
+  - **Testing**: Added test `TestServer_HandleProviderCallback_EmailLookup` that simulates Dex's base64-encoded subject claims
 
 ### Security
 

--- a/server/flows_test.go
+++ b/server/flows_test.go
@@ -305,12 +305,12 @@ func TestServer_HandleProviderCallback(t *testing.T) {
 	}
 }
 
-// TestServer_HandleProviderCallback_TokenLookupByEmail tests that tokens can be
+// TestServer_HandleProviderCallback_EmailLookup tests that tokens can be
 // looked up by email when the OIDC provider's subject claim differs from the email.
 // This is common with Dex which uses base64-encoded subjects like "Cg1tYXJrdGVzdGVyQGdtYWlsLmNvbQoFbG9jYWw".
 //
 // See: https://github.com/giantswarm/mcp-oauth/issues/154
-func TestServer_HandleProviderCallback_TokenLookupByEmail(t *testing.T) {
+func TestServer_HandleProviderCallback_EmailLookup(t *testing.T) {
 	ctx := context.Background()
 	srv, store, provider := setupFlowTestServer(t)
 


### PR DESCRIPTION
## Summary

Fixes token lookup by email failing when the OIDC provider's subject claim differs from the email (e.g., Dex uses base64-encoded subjects).

## Problem

When using mcp-oauth with Dex as the OIDC provider, looking up tokens by `userInfo.Email` failed because tokens were stored by `userInfo.ID` (the `sub` claim), which for Dex is typically a base64-encoded subject like `Cg1tYXJrdGVzdGVyQGdtYWlsLmNvbQoFbG9jYWw`, not the email address.

Downstream consumers (like mcp-kubernetes) that call `GetToken(ctx, userInfo.Email)` would fail with "token not found".

## Solution

Modified `saveUserInfoAndToken` in `server/flows.go` to always save tokens by email when email is available, regardless of whether it equals the ID.

**Before:**
```go
// Also save by email if different from ID
if userInfo.Email != "" && userInfo.Email != userInfo.ID {
    // save by email
}
```

**After:**
```go
// Save by ID (required - ID should always be present from provider's subject claim)
if userInfo.ID != "" {
    // save by ID
} else {
    s.Logger.Warn("UserInfo has empty ID, skipping ID-based storage")
}

// Always save by email if available (regardless of whether it equals ID)
if userInfo.Email != "" {
    // save by email
}
```

This is safe because:
- If email == ID, saving twice is idempotent (overwrites with same value)
- Makes the behavior more predictable for downstream consumers
- Added guard for empty ID edge case for robustness
- No breaking changes

## Testing

Added `TestServer_HandleProviderCallback_EmailLookup` that:
- Configures a mock provider to return a base64-encoded subject claim (simulating Dex)
- Completes the OAuth flow
- Verifies tokens can be retrieved by both ID and email

## Checklist

- [x] Tests pass
- [x] Code formatted with `goimports` and `go fmt`
- [x] `make verify` passes
- [x] CHANGELOG.md updated

Closes #154