### PR TITLE
fix(providers): Filter out offline_access scope in Google provider

### DIFF
--- a/examples/cimd/client.json
+++ b/examples/cimd/client.json
@@ -20,5 +20,3 @@
     "support@example.com"
   ]
 }
-
-

--- a/examples/cimd/go.mod
+++ b/examples/cimd/go.mod
@@ -46,4 +46,3 @@ require (
 )
 
 replace github.com/giantswarm/mcp-oauth => ../..
-

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -116,13 +116,14 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// IMPORTANT: Filter out "offline_access" scope - Google doesn't support it as a scope.
 	// Google uses access_type=offline (added above) instead of the offline_access scope.
 	// Passing offline_access to Google causes: Error 400: invalid_scope
-	var scopesToUse []string
 	var sourceScopes []string
 	if len(scopes) > 0 {
 		sourceScopes = scopes
 	} else {
 		sourceScopes = p.Scopes
 	}
+	// Pre-allocate with capacity hint to avoid reallocations
+	scopesToUse := make([]string, 0, len(sourceScopes))
 	for _, s := range sourceScopes {
 		if s != "offline_access" {
 			scopesToUse = append(scopesToUse, s)


### PR DESCRIPTION
## Summary

Google does not support `offline_access` as a scope - it uses `access_type=offline` as a URL parameter instead. The parameter was already being set correctly, but `offline_access` was still being passed as a scope, causing `Error 400: invalid_scope`.

## Changes

- Filter out `offline_access` from the scopes array in `AuthorizationURL` before passing them to Google's authorization endpoint
- Pre-allocate slice capacity to avoid reallocations during filtering
- Added comprehensive tests with expected scope verification
- Updated CHANGELOG

## Testing

- Added test case in `TestProvider_AuthorizationURL` to verify `offline_access` is filtered out
- Added dedicated `TestProvider_AuthorizationURL_FiltersOfflineAccess` test with multiple edge cases:
  - Filters from requested scopes
  - Filters from provider defaults
  - Handles only `offline_access` scope (empty result)
  - Handles `offline_access` with OIDC scopes
- All tests verify both that `offline_access` is NOT present and that expected scopes ARE present
- All existing tests continue to pass

## Code Quality

- Pre-allocated slice capacity to avoid reallocations
- Comprehensive test assertions verify expected scopes are present in URL

## Impact

OIDC-compliant clients that request `offline_access` scope (like Muster Agent) will now work correctly with the Google provider.

Closes #156