### PR TITLE
feat(server): Add TrustedAudiences support for SSO token forwarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **TrustedAudiences Support for SSO Token Forwarding**
+  - **Feature**: Added `TrustedAudiences` configuration option to accept tokens issued to trusted upstream OAuth clients
+  - **Use Case**: Enables Single Sign-On (SSO) scenarios in MCP architectures where an aggregator (like muster) proxies requests to downstream MCP servers
+  - **Problem Solved**: Previously, each downstream MCP server required separate authentication, even when all services use the same Identity Provider
+  - **Configuration**: `TrustedAudiences []string` in `server.Config`
+  - **Security Model**:
+    - The server's own `ResourceIdentifier` is always implicitly trusted
+    - Each trusted audience must be explicitly configured (no implicit trust)
+    - Tokens are only accepted if they're from the same configured issuer
+    - Audit event `EventCrossClientTokenAccepted` is logged when a token is accepted via cross-client trust
+  - **Backward Compatibility**: Empty `TrustedAudiences` maintains current behavior (only own tokens accepted)
+  - **Example**:
+    ```go
+    config := &server.Config{
+        Issuer:             "https://auth.example.com",
+        ResourceIdentifier: "https://mcp-kubernetes.example.com",
+        // Accept tokens issued to the muster aggregator
+        TrustedAudiences:   []string{"muster-client"},
+    }
+    ```
+  - **New Audit Event**: `EventCrossClientTokenAccepted` for security monitoring of SSO token usage
+  - **Issue**: [#171](https://github.com/giantswarm/mcp-oauth/issues/171)
+
 - **Google Provider: ForceConsent Configuration for Reliable Refresh Tokens**
   - **Feature**: Added `ForceConsent` configuration option to the Google OAuth provider
   - **Root Cause**: Google only returns refresh tokens on the first user consent. Subsequent authorizations return no refresh token, causing token refresh failures.

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,7 +11,8 @@ This guide covers security configuration for production deployments. For deep te
 5. [Audit Logging](#audit-logging)
 6. [Client Registration Protection](#client-registration-protection)
 7. [Redirect URI Security](#redirect-uri-security)
-8. [Legacy Client Support](#legacy-client-support)
+8. [SSO Token Forwarding](#sso-token-forwarding)
+9. [Legacy Client Support](#legacy-client-support)
 
 ## Secure Defaults
 
@@ -447,6 +448,82 @@ IPv6 addresses with zone IDs (e.g., `fe80::1%eth0`) cannot be parsed by Go's `ne
 - If DNS validation is enabled, they will fail DNS lookup (blocking registration in strict mode)
 
 For maximum security, keep DNS validation enabled (`DNSValidation=true`, `DNSValidationStrict=true`) to ensure these edge cases are properly handled.
+
+## SSO Token Forwarding
+
+The `TrustedAudiences` feature enables Single Sign-On (SSO) scenarios where tokens issued to a trusted upstream service can be accepted by downstream MCP servers.
+
+### Use Case: MCP Aggregator Architecture
+
+In architectures with an MCP aggregator (like muster) that proxies requests to downstream MCP servers:
+
+1. Users authenticate to the aggregator once
+2. The aggregator receives tokens with its own `client_id` as the audience
+3. Downstream servers accept these forwarded tokens via `TrustedAudiences`
+
+Without this feature, each downstream MCP server would require its own separate OAuth flow.
+
+### Configuration
+
+```go
+config := &server.Config{
+    Issuer:             "https://auth.example.com",
+    ResourceIdentifier: "https://mcp-kubernetes.example.com",
+    
+    // Accept tokens issued to the muster aggregator
+    TrustedAudiences: []string{
+        "muster-client",
+        "my-other-aggregator-client",
+    },
+}
+```
+
+### Security Model
+
+| Aspect | Behavior |
+|--------|----------|
+| **Explicit Trust** | Each trusted audience must be explicitly configured |
+| **Same Issuer** | Tokens are only accepted if from the configured IdP |
+| **Own Identifier** | Server's own `ResourceIdentifier` is always implicitly trusted |
+| **Audit Logging** | `EventCrossClientTokenAccepted` logged for security monitoring |
+| **Constant-Time** | Audience comparison uses constant-time comparison |
+
+### Security Recommendations
+
+1. **Minimize Trust**: Only add audiences you explicitly trust
+2. **Same IdP**: All trusted audiences should use the same Identity Provider
+3. **Monitor Logs**: Watch for `cross_client_token_accepted` audit events
+4. **Validate Scopes**: Use `EndpointScopeRequirements` for fine-grained access control
+
+### Example YAML Configuration
+
+```yaml
+# Downstream MCP server (mcp-kubernetes) configuration
+oauth:
+  issuer: "https://auth.example.com"
+  resourceIdentifier: "https://mcp-kubernetes.example.com"
+  # Trust tokens forwarded from muster aggregator
+  trustedAudiences:
+    - "muster-client"
+```
+
+### Audit Event
+
+When a token is accepted via `TrustedAudiences`, the `EventCrossClientTokenAccepted` event is logged:
+
+```json
+{
+  "event_type": "cross_client_token_accepted",
+  "user_id_hash": "a1b2c3d4...",
+  "client_id": "original-client",
+  "details": {
+    "original_audience": "muster-client",
+    "server_identifier": "https://mcp-kubernetes.example.com",
+    "trusted_via": "TrustedAudiences",
+    "sso_token_forwarded": true
+  }
+}
+```
 
 ## Legacy Client Support
 

--- a/security/events.go
+++ b/security/events.go
@@ -92,6 +92,12 @@ const (
 	// EventResourceMismatch is logged when resource parameter doesn't match (RFC 8707)
 	EventResourceMismatch = "resource_mismatch"
 
+	// EventCrossClientTokenAccepted is logged when a token is accepted via TrustedAudiences.
+	// This occurs in SSO scenarios where tokens issued to a trusted upstream (e.g., muster)
+	// are accepted by a downstream MCP server. This event is logged for security monitoring
+	// and forensics to track cross-client token usage patterns.
+	EventCrossClientTokenAccepted = "cross_client_token_accepted"
+
 	// Provider-related events
 
 	// EventInvalidProviderCallback is logged when provider callback validation fails

--- a/server/config.go
+++ b/server/config.go
@@ -545,6 +545,32 @@ type Config struct {
 	// Security: This prevents token theft and replay attacks to different resource servers
 	ResourceIdentifier string
 
+	// TrustedAudiences lists additional OAuth client IDs whose tokens are accepted.
+	// This enables Single Sign-On (SSO) scenarios where tokens issued to a trusted upstream
+	// (e.g., an MCP aggregator like muster) are accepted by this resource server.
+	//
+	// Security Model:
+	//   - The server's own ClientID (via ResourceIdentifier) is always implicitly trusted
+	//   - Each trusted audience must be explicitly configured (no implicit trust)
+	//   - Tokens are only accepted if they're from the configured issuer (same IdP)
+	//   - An audit event (EventCrossClientTokenAccepted) is logged when a token is accepted
+	//     via cross-client trust for security monitoring
+	//
+	// Use Case:
+	// In architectures with an MCP aggregator (like muster) that proxies requests to
+	// downstream MCP servers, users authenticate to the aggregator and receive tokens
+	// with the aggregator's client_id as the audience. By adding the aggregator's
+	// client_id to TrustedAudiences, downstream servers can accept these forwarded
+	// tokens without requiring separate authentication flows.
+	//
+	// Example:
+	//   TrustedAudiences: []string{"muster-client", "my-aggregator-client"}
+	//   This accepts tokens issued to either "muster-client" or "my-aggregator-client"
+	//   in addition to tokens issued to this server's own ResourceIdentifier.
+	//
+	// Default: nil (only tokens for this server's ResourceIdentifier are accepted)
+	TrustedAudiences []string
+
 	// EnableClientIDMetadataDocuments enables URL-based client_id support per MCP 2025-11-25
 	// When enabled, clients can use HTTPS URLs as client identifiers, and the authorization
 	// server will fetch client metadata from that URL following draft-ietf-oauth-client-id-metadata-document-00

--- a/server/config_validation.go
+++ b/server/config_validation.go
@@ -31,6 +31,9 @@ func applySecureDefaults(config *Config, logger *slog.Logger) *Config {
 	// Validate protected resource metadata configuration (RFC 9728, MCP 2025-11-25)
 	validateResourceMetadataByPath(config, logger)
 
+	// Validate TrustedAudiences configuration (SSO token forwarding)
+	validateTrustedAudiences(config, logger)
+
 	// Validate interstitial page configuration (RFC 8252 Section 7.1)
 	validateInterstitialConfig(config, logger)
 
@@ -429,6 +432,84 @@ func validateResourceIdentifier(pathKey, identifier string, logger *slog.Logger)
 	if err != nil || u.Scheme == "" || u.Host == "" {
 		logger.Warn("Invalid resource identifier", "path", pathKey, "resource_identifier", identifier)
 	}
+}
+
+// validateTrustedAudiences validates the TrustedAudiences configuration for SSO token forwarding.
+// Each audience entry must be a non-empty string that represents either a client_id or a URL.
+// This enables Single Sign-On scenarios where tokens issued to trusted upstream services
+// (e.g., an MCP aggregator) are accepted by downstream MCP servers.
+func validateTrustedAudiences(config *Config, logger *slog.Logger) {
+	if len(config.TrustedAudiences) == 0 {
+		return
+	}
+
+	validAudiences := filterValidAudiences(config.TrustedAudiences, logger)
+	config.TrustedAudiences = validAudiences
+
+	if len(validAudiences) > 0 {
+		logger.Info("TrustedAudiences configured for SSO token forwarding",
+			"audiences", validAudiences,
+			"count", len(validAudiences))
+	}
+}
+
+// filterValidAudiences filters and validates a list of audience strings.
+func filterValidAudiences(audiences []string, logger *slog.Logger) []string {
+	validAudiences := make([]string, 0, len(audiences))
+	seenAudiences := make(map[string]bool, len(audiences))
+
+	for i, audience := range audiences {
+		normalized, ok := validateAudience(audience, i, seenAudiences, logger)
+		if ok {
+			seenAudiences[normalized] = true
+			validAudiences = append(validAudiences, normalized)
+		}
+	}
+
+	return validAudiences
+}
+
+// validateAudience validates a single audience entry.
+// Returns the normalized audience and true if valid, or empty string and false if invalid.
+func validateAudience(audience string, index int, seen map[string]bool, logger *slog.Logger) (string, bool) {
+	if audience == "" {
+		logger.Warn("Empty audience in TrustedAudiences - removing", "index", index)
+		return "", false
+	}
+
+	audience = strings.TrimSpace(audience)
+	if audience == "" {
+		logger.Warn("Whitespace-only audience in TrustedAudiences - removing", "index", index)
+		return "", false
+	}
+
+	if seen[audience] {
+		logger.Warn("Duplicate audience in TrustedAudiences - removing",
+			"audience", audience, "index", index)
+		return "", false
+	}
+
+	if !isValidAudienceFormat(audience, index, logger) {
+		return "", false
+	}
+
+	return audience, true
+}
+
+// isValidAudienceFormat checks if an audience has a valid format.
+// Audiences can be client IDs (any string) or URLs (must be valid).
+func isValidAudienceFormat(audience string, index int, logger *slog.Logger) bool {
+	if !strings.HasPrefix(audience, "http://") && !strings.HasPrefix(audience, "https://") {
+		return true // Non-URL audience (client_id) - always valid
+	}
+
+	u, err := url.Parse(audience)
+	if err != nil || u.Host == "" {
+		logger.Warn("Invalid URL format in TrustedAudiences",
+			"audience", audience, "index", index, "error", err)
+		return false
+	}
+	return true
 }
 
 // validateTrustedPublicRegistrationSchemes validates and sanitizes TrustedPublicRegistrationSchemes configuration.

--- a/server/flows.go
+++ b/server/flows.go
@@ -232,6 +232,8 @@ func (s *Server) validateStoredToken(ctx context.Context, accessToken string) (*
 }
 
 // validateTokenAudience validates RFC 8707 audience binding for the token.
+// It checks if the token's audience matches this server's ResourceIdentifier or
+// any of the TrustedAudiences configured for SSO token forwarding.
 func (s *Server) validateTokenAudience(accessToken string) error {
 	metadataStore, ok := s.tokenStore.(interface {
 		GetTokenMetadata(tokenID string) (*storage.TokenMetadata, error)
@@ -249,6 +251,7 @@ func (s *Server) validateTokenAudience(accessToken string) error {
 	normalizedAudience := helpers.NormalizeURL(metadata.Audience)
 	normalizedExpected := helpers.NormalizeURL(expectedAudience)
 
+	// Check if audience matches this server's own resource identifier
 	if subtle.ConstantTimeCompare([]byte(normalizedAudience), []byte(normalizedExpected)) == 1 {
 		s.Logger.Debug("Token audience validation passed",
 			"audience", metadata.Audience,
@@ -256,9 +259,58 @@ func (s *Server) validateTokenAudience(accessToken string) error {
 		return nil
 	}
 
+	// Check if audience matches any of the TrustedAudiences (SSO token forwarding)
+	if s.isTrustedAudience(metadata.Audience) {
+		s.logCrossClientTokenAccepted(accessToken, metadata)
+		return nil
+	}
+
 	// Audience mismatch - log and return error
 	s.logAudienceMismatch(accessToken, metadata, expectedAudience)
 	return fmt.Errorf("token not intended for this resource server (RFC 8707 audience mismatch)")
+}
+
+// isTrustedAudience checks if the given audience is in the TrustedAudiences list.
+// This enables SSO scenarios where tokens issued to trusted upstream services are accepted.
+func (s *Server) isTrustedAudience(audience string) bool {
+	if len(s.Config.TrustedAudiences) == 0 {
+		return false
+	}
+
+	normalizedAudience := helpers.NormalizeURL(audience)
+
+	for _, trusted := range s.Config.TrustedAudiences {
+		normalizedTrusted := helpers.NormalizeURL(trusted)
+		if subtle.ConstantTimeCompare([]byte(normalizedAudience), []byte(normalizedTrusted)) == 1 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// logCrossClientTokenAccepted logs when a token is accepted via TrustedAudiences.
+// This audit event helps track SSO token usage patterns for security monitoring.
+func (s *Server) logCrossClientTokenAccepted(accessToken string, metadata *storage.TokenMetadata) {
+	s.Logger.Debug("Token accepted via TrustedAudiences (SSO token forwarding)",
+		"token_audience", metadata.Audience,
+		"user_id", metadata.UserID,
+		"client_id", metadata.ClientID,
+		"token_prefix", helpers.SafeTruncate(accessToken, 8))
+
+	if s.Auditor != nil {
+		s.Auditor.LogEvent(security.Event{
+			Type:     security.EventCrossClientTokenAccepted,
+			UserID:   metadata.UserID,
+			ClientID: metadata.ClientID,
+			Details: map[string]any{
+				"original_audience":   metadata.Audience,
+				"server_identifier":   s.Config.GetResourceIdentifier(),
+				"trusted_via":         "TrustedAudiences",
+				"sso_token_forwarded": true,
+			},
+		})
+	}
 }
 
 // logAudienceMismatch logs an audience mismatch security event.

--- a/server/flows_trusted_audiences_test.go
+++ b/server/flows_trusted_audiences_test.go
@@ -1,0 +1,476 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/internal/helpers"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/storage"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// TestIsTrustedAudience tests the isTrustedAudience helper function.
+func TestIsTrustedAudience(t *testing.T) {
+	tests := []struct {
+		name             string
+		trustedAudiences []string
+		audience         string
+		expectedTrusted  bool
+	}{
+		{
+			name:             "empty trusted audiences",
+			trustedAudiences: nil,
+			audience:         "muster-client",
+			expectedTrusted:  false,
+		},
+		{
+			name:             "empty audience list",
+			trustedAudiences: []string{},
+			audience:         "muster-client",
+			expectedTrusted:  false,
+		},
+		{
+			name:             "exact match - client ID",
+			trustedAudiences: []string{"muster-client", "aggregator-client"},
+			audience:         "muster-client",
+			expectedTrusted:  true,
+		},
+		{
+			name:             "exact match - second entry",
+			trustedAudiences: []string{"muster-client", "aggregator-client"},
+			audience:         "aggregator-client",
+			expectedTrusted:  true,
+		},
+		{
+			name:             "no match",
+			trustedAudiences: []string{"muster-client", "aggregator-client"},
+			audience:         "unknown-client",
+			expectedTrusted:  false,
+		},
+		{
+			name:             "URL audience - exact match",
+			trustedAudiences: []string{"https://muster.example.com"},
+			audience:         "https://muster.example.com",
+			expectedTrusted:  true,
+		},
+		{
+			name:             "URL audience - with trailing slash normalization",
+			trustedAudiences: []string{"https://muster.example.com/"},
+			audience:         "https://muster.example.com",
+			expectedTrusted:  true,
+		},
+		{
+			name:             "case sensitive match",
+			trustedAudiences: []string{"Muster-Client"},
+			audience:         "muster-client",
+			expectedTrusted:  false, // Should not match - case sensitive
+		},
+		{
+			name:             "mixed client IDs and URLs",
+			trustedAudiences: []string{"muster-client", "https://aggregator.example.com"},
+			audience:         "https://aggregator.example.com",
+			expectedTrusted:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := memory.New()
+			t.Cleanup(func() { store.Stop() })
+
+			config := &Config{
+				Issuer:           "https://auth.example.com",
+				TrustedAudiences: tt.trustedAudiences,
+			}
+
+			srv := &Server{
+				Config: config,
+			}
+
+			got := srv.isTrustedAudience(tt.audience)
+			if got != tt.expectedTrusted {
+				t.Errorf("isTrustedAudience() = %v, want %v", got, tt.expectedTrusted)
+			}
+		})
+	}
+}
+
+// TestValidateTokenAudience_WithTrustedAudiences tests audience validation with TrustedAudiences.
+func TestValidateTokenAudience_WithTrustedAudiences(t *testing.T) {
+	tests := []struct {
+		name              string
+		serverIdentifier  string
+		trustedAudiences  []string
+		tokenAudience     string
+		expectError       bool
+		expectCrossClient bool // Whether we expect a cross-client token acceptance event
+	}{
+		{
+			name:              "match server's own identifier",
+			serverIdentifier:  "https://mcp.example.com",
+			trustedAudiences:  []string{"muster-client"},
+			tokenAudience:     "https://mcp.example.com",
+			expectError:       false,
+			expectCrossClient: false,
+		},
+		{
+			name:              "match trusted audience",
+			serverIdentifier:  "https://mcp.example.com",
+			trustedAudiences:  []string{"muster-client"},
+			tokenAudience:     "muster-client",
+			expectError:       false,
+			expectCrossClient: true,
+		},
+		{
+			name:              "match second trusted audience",
+			serverIdentifier:  "https://mcp.example.com",
+			trustedAudiences:  []string{"muster-client", "aggregator-client"},
+			tokenAudience:     "aggregator-client",
+			expectError:       false,
+			expectCrossClient: true,
+		},
+		{
+			name:              "no match - untrusted audience",
+			serverIdentifier:  "https://mcp.example.com",
+			trustedAudiences:  []string{"muster-client"},
+			tokenAudience:     "unknown-client",
+			expectError:       true,
+			expectCrossClient: false,
+		},
+		{
+			name:              "no trusted audiences configured - mismatch",
+			serverIdentifier:  "https://mcp.example.com",
+			trustedAudiences:  nil,
+			tokenAudience:     "muster-client",
+			expectError:       true,
+			expectCrossClient: false,
+		},
+		{
+			name:              "URL-based trusted audience",
+			serverIdentifier:  "https://mcp.example.com",
+			trustedAudiences:  []string{"https://muster.example.com"},
+			tokenAudience:     "https://muster.example.com",
+			expectError:       false,
+			expectCrossClient: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			store := memory.New()
+			t.Cleanup(func() { store.Stop() })
+
+			var logBuffer bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+			auditor := security.NewAuditor(logger, true)
+
+			config := &Config{
+				Issuer:             "https://auth.example.com",
+				ResourceIdentifier: tt.serverIdentifier,
+				TrustedAudiences:   tt.trustedAudiences,
+			}
+
+			srv := &Server{
+				Config:     config,
+				tokenStore: store,
+				flowStore:  store,
+				Auditor:    auditor,
+				Logger:     logger,
+			}
+
+			// Save a token with metadata
+			accessToken := "test-access-token-12345"
+			providerToken := &oauth2.Token{
+				AccessToken: "provider-access-token",
+				Expiry:      time.Now().Add(1 * time.Hour),
+			}
+			if err := store.SaveToken(ctx, accessToken, providerToken); err != nil {
+				t.Fatalf("SaveToken() error = %v", err)
+			}
+
+			// Save token metadata with the test audience
+			if err := store.SaveTokenMetadataWithAudience(accessToken, "test-user", "test-client", "access", tt.tokenAudience); err != nil {
+				t.Fatalf("SaveTokenMetadataWithAudience() error = %v", err)
+			}
+
+			// Validate the token
+			err := srv.validateTokenAudience(accessToken)
+
+			if tt.expectError && err == nil {
+				t.Error("validateTokenAudience() expected error, got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("validateTokenAudience() unexpected error = %v", err)
+			}
+
+			// Check for cross-client token acceptance in logs
+			logOutput := logBuffer.String()
+			if tt.expectCrossClient {
+				if !strings.Contains(logOutput, security.EventCrossClientTokenAccepted) {
+					t.Error("Expected EventCrossClientTokenAccepted event in logs, but not found")
+				}
+				if !strings.Contains(logOutput, tt.tokenAudience) {
+					t.Errorf("Expected log to contain audience %q", tt.tokenAudience)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateTrustedAudiences tests the config validation for TrustedAudiences.
+func TestValidateTrustedAudiences(t *testing.T) {
+	tests := []struct {
+		name                 string
+		inputAudiences       []string
+		expectedAudiences    []string
+		expectLogContains    string
+		expectLogNotContains string
+	}{
+		{
+			name:              "empty audiences - no validation needed",
+			inputAudiences:    nil,
+			expectedAudiences: nil,
+		},
+		{
+			name:              "valid client IDs",
+			inputAudiences:    []string{"muster-client", "aggregator-client"},
+			expectedAudiences: []string{"muster-client", "aggregator-client"},
+			expectLogContains: "TrustedAudiences configured",
+		},
+		{
+			name:              "valid URLs",
+			inputAudiences:    []string{"https://muster.example.com", "https://aggregator.example.com"},
+			expectedAudiences: []string{"https://muster.example.com", "https://aggregator.example.com"},
+		},
+		{
+			name:              "mixed client IDs and URLs",
+			inputAudiences:    []string{"muster-client", "https://aggregator.example.com"},
+			expectedAudiences: []string{"muster-client", "https://aggregator.example.com"},
+		},
+		{
+			name:              "removes empty entries",
+			inputAudiences:    []string{"muster-client", "", "aggregator-client"},
+			expectedAudiences: []string{"muster-client", "aggregator-client"},
+			expectLogContains: "Empty audience",
+		},
+		{
+			name:              "removes whitespace-only entries",
+			inputAudiences:    []string{"muster-client", "   ", "aggregator-client"},
+			expectedAudiences: []string{"muster-client", "aggregator-client"},
+			expectLogContains: "Whitespace-only audience",
+		},
+		{
+			name:              "removes duplicates",
+			inputAudiences:    []string{"muster-client", "aggregator-client", "muster-client"},
+			expectedAudiences: []string{"muster-client", "aggregator-client"},
+			expectLogContains: "Duplicate audience",
+		},
+		{
+			name:              "trims whitespace",
+			inputAudiences:    []string{"  muster-client  ", "aggregator-client"},
+			expectedAudiences: []string{"muster-client", "aggregator-client"},
+		},
+		{
+			name:              "invalid URL format - removed",
+			inputAudiences:    []string{"muster-client", "https://", "aggregator-client"},
+			expectedAudiences: []string{"muster-client", "aggregator-client"},
+			expectLogContains: "Invalid URL format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+
+			config := &Config{
+				TrustedAudiences: tt.inputAudiences,
+			}
+
+			validateTrustedAudiences(config, logger)
+
+			// Check resulting audiences
+			if len(config.TrustedAudiences) != len(tt.expectedAudiences) {
+				t.Errorf("TrustedAudiences length = %d, want %d",
+					len(config.TrustedAudiences), len(tt.expectedAudiences))
+			}
+			for i, expected := range tt.expectedAudiences {
+				if i >= len(config.TrustedAudiences) {
+					break
+				}
+				if config.TrustedAudiences[i] != expected {
+					t.Errorf("TrustedAudiences[%d] = %q, want %q",
+						i, config.TrustedAudiences[i], expected)
+				}
+			}
+
+			// Check log output
+			logOutput := logBuffer.String()
+			if tt.expectLogContains != "" && !strings.Contains(logOutput, tt.expectLogContains) {
+				t.Errorf("Expected log to contain %q, got: %s", tt.expectLogContains, logOutput)
+			}
+			if tt.expectLogNotContains != "" && strings.Contains(logOutput, tt.expectLogNotContains) {
+				t.Errorf("Expected log NOT to contain %q, got: %s", tt.expectLogNotContains, logOutput)
+			}
+		})
+	}
+}
+
+// TestLogCrossClientTokenAccepted tests the audit logging for cross-client token acceptance.
+func TestLogCrossClientTokenAccepted(t *testing.T) {
+	var logBuffer bytes.Buffer
+	// Use LevelDebug to capture debug logs
+	logger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	auditor := security.NewAuditor(logger, true)
+
+	config := &Config{
+		Issuer:             "https://auth.example.com",
+		ResourceIdentifier: "https://mcp.example.com",
+		TrustedAudiences:   []string{"muster-client"},
+	}
+
+	srv := &Server{
+		Config:  config,
+		Auditor: auditor,
+		Logger:  logger,
+	}
+
+	metadata := &storage.TokenMetadata{
+		UserID:   "test-user",
+		ClientID: "test-client",
+		Audience: "muster-client",
+	}
+
+	srv.logCrossClientTokenAccepted("test-token-12345678", metadata)
+
+	// Verify log output
+	logOutput := logBuffer.String()
+	if !strings.Contains(logOutput, "Token accepted via TrustedAudiences") {
+		t.Errorf("Expected log to contain 'Token accepted via TrustedAudiences', got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, "muster-client") {
+		t.Errorf("Expected log to contain 'muster-client', got: %s", logOutput)
+	}
+
+	// Verify audit event was logged
+	if !strings.Contains(logOutput, security.EventCrossClientTokenAccepted) {
+		t.Error("Expected log to contain EventCrossClientTokenAccepted")
+	}
+	if !strings.Contains(logOutput, "test-client") {
+		t.Error("Expected log to contain client_id 'test-client'")
+	}
+}
+
+// TestTrustedAudiences_ConstantTimeComparison verifies that audience matching uses
+// constant-time comparison to prevent timing attacks.
+func TestTrustedAudiences_ConstantTimeComparison(t *testing.T) {
+	// This test verifies that the isTrustedAudience function works correctly
+	// with audiences of different lengths (which could leak timing info if not
+	// using constant-time comparison properly).
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	config := &Config{
+		Issuer:           "https://auth.example.com",
+		TrustedAudiences: []string{"short", "very-long-audience-string-that-takes-longer-to-compare"},
+	}
+
+	srv := &Server{Config: config}
+
+	// These should both use the same code path with constant-time comparison
+	if !srv.isTrustedAudience("short") {
+		t.Error("Expected 'short' to be trusted")
+	}
+	if !srv.isTrustedAudience("very-long-audience-string-that-takes-longer-to-compare") {
+		t.Error("Expected long audience to be trusted")
+	}
+	if srv.isTrustedAudience("shor") { // Almost matches "short"
+		t.Error("Expected 'shor' NOT to be trusted")
+	}
+}
+
+// TestTrustedAudiences_BackwardCompatibility tests that empty TrustedAudiences
+// maintains backward compatibility (only server's own identifier is accepted).
+func TestTrustedAudiences_BackwardCompatibility(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	var logBuffer bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+
+	// No TrustedAudiences configured - should only accept server's own identifier
+	config := &Config{
+		Issuer:             "https://auth.example.com",
+		ResourceIdentifier: "https://mcp.example.com",
+		TrustedAudiences:   nil, // Empty - backward compatible mode
+	}
+
+	srv := &Server{
+		Config:     config,
+		tokenStore: store,
+		Logger:     logger,
+	}
+
+	// Save a token with metadata for server's own audience
+	accessToken := "compat-test-token" //nolint:gosec // G101: Test token, not a credential
+	providerToken := &oauth2.Token{
+		AccessToken: "provider-access-token",
+		Expiry:      time.Now().Add(1 * time.Hour),
+	}
+	if err := store.SaveToken(ctx, accessToken, providerToken); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+
+	// Test 1: Server's own audience should be accepted
+	if err := store.SaveTokenMetadataWithAudience(accessToken, "user", "client", "access", "https://mcp.example.com"); err != nil {
+		t.Fatalf("SaveTokenMetadataWithAudience() error = %v", err)
+	}
+	if err := srv.validateTokenAudience(accessToken); err != nil {
+		t.Errorf("Expected token with server's own audience to be accepted, got error: %v", err)
+	}
+
+	// Test 2: Different audience should be rejected
+	if err := store.SaveTokenMetadataWithAudience(accessToken, "user", "client", "access", "muster-client"); err != nil {
+		t.Fatalf("SaveTokenMetadataWithAudience() error = %v", err)
+	}
+	if err := srv.validateTokenAudience(accessToken); err == nil {
+		t.Error("Expected token with different audience to be rejected")
+	}
+}
+
+// TestTrustedAudiences_URLNormalization tests that URL-based audiences are
+// properly normalized for comparison.
+func TestTrustedAudiences_URLNormalization(t *testing.T) {
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	config := &Config{
+		Issuer:           "https://auth.example.com",
+		TrustedAudiences: []string{"https://muster.example.com/"},
+	}
+
+	srv := &Server{Config: config}
+
+	// With trailing slash normalization, these should match
+	normalizedWithSlash := helpers.NormalizeURL("https://muster.example.com/")
+	normalizedWithoutSlash := helpers.NormalizeURL("https://muster.example.com")
+
+	if normalizedWithSlash != normalizedWithoutSlash {
+		t.Logf("NormalizeURL('...com/') = %q, NormalizeURL('...com') = %q",
+			normalizedWithSlash, normalizedWithoutSlash)
+		// Test that the actual function works correctly
+		if srv.isTrustedAudience("https://muster.example.com") {
+			t.Log("URL normalization is working correctly")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Add support for accepting OAuth tokens with multiple valid audiences. This enables Single Sign-On (SSO) scenarios where tokens issued to an upstream aggregator (like muster) can be accepted by downstream MCP servers.

## Changes

### Configuration
- Added `TrustedAudiences []string` to `server.Config`
- Added configuration validation with duplicate/format checking

### Security
- Added `EventCrossClientTokenAccepted` audit event for security monitoring
- Modified `validateTokenAudience()` to check TrustedAudiences before rejecting
- Uses constant-time comparison for audience matching to prevent timing attacks

### Testing
- Added comprehensive tests for multi-audience scenarios in `flows_trusted_audiences_test.go`

### Documentation
- Updated `CHANGELOG.md` with feature documentation
- Added SSO Token Forwarding section to `docs/security.md`

## Security Model

| Aspect | Behavior |
|--------|----------|
| **Explicit Trust** | Each trusted audience must be explicitly configured |
| **Same Issuer** | Tokens are only accepted if from the configured IdP |
| **Own Identifier** | Server's own `ResourceIdentifier` is always implicitly trusted |
| **Audit Logging** | `EventCrossClientTokenAccepted` logged for security monitoring |
| **Constant-Time** | Audience comparison uses constant-time comparison |

## Example Usage

```go
config := &server.Config{
    Issuer:             "https://auth.example.com",
    ResourceIdentifier: "https://mcp-kubernetes.example.com",
    // Accept tokens issued to the muster aggregator
    TrustedAudiences:   []string{"muster-client"},
}
```

## Backward Compatibility

- Empty `TrustedAudiences` maintains current behavior (only own tokens accepted)
- No breaking changes to existing API

Closes #171