### PR TITLE
fix(security): lower MinStateLength absolute floor from 32 to 24 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Lower MinStateLength absolute floor from 32 to 24 characters (#228)**
+  - The absolute minimum floor for `MinStateLength` has been lowered from 32 to 24 characters.
+  - 24 characters still provides 144 bits of entropy, exceeding OAuth 2.1's 128-bit minimum recommendation.
+  - This unblocks VS Code web (`vscode.dev`) as an MCP client, which uses 24-character state parameters.
+  - The default `MinStateLength` is also lowered from 32 to 24 to align with the new floor.
+  - The `AllowNoStateParameter` workaround is no longer needed for VS Code web clients.
+
 ### Added
 
 - **Limit HTTP request body size in handler (gosec G120) (#220)**

--- a/SECURITY_ARCHITECTURE.md
+++ b/SECURITY_ARCHITECTURE.md
@@ -980,7 +980,7 @@ done
 - [ ] Set appropriate token lifetimes (shorter = more secure)
 - [ ] Enable refresh token rotation (`AllowRefreshTokenRotation=true`)
 - [ ] Review and test revoked token cleanup
-- [ ] Set `MinStateLength` >= 16 (default)
+- [ ] Set `MinStateLength` >= 24 (default)
 - [ ] Enforce PKCE (`RequirePKCE=true`, default)
 - [ ] Disable plain PKCE (`AllowPKCEPlain=false`, default)
 

--- a/constants.go
+++ b/constants.go
@@ -83,8 +83,9 @@ const (
 	// MinStateLength is the minimum length for state parameters to prevent
 	// timing attacks and ensure sufficient entropy for CSRF protection.
 	// OAuth 2.1 recommends at least 128 bits (16 bytes) of entropy.
+	// 24 characters provides 144 bits of entropy in base64, exceeding the 128-bit minimum.
 	// This value is used as the default for server.Config.MinStateLength.
-	MinStateLength = 32
+	MinStateLength = 24
 )
 
 // Redirect URI validation constants

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ config := &server.Config{
 | `RequirePKCE` | `bool` | `true` | Require PKCE for all authorization requests |
 | `AllowPKCEPlain` | `bool` | `false` | Allow insecure 'plain' PKCE method |
 | `AllowRefreshTokenRotation` | `bool` | `true` | Enable refresh token rotation |
-| `MinStateLength` | `int` | `16` | Minimum length for state parameter |
+| `MinStateLength` | `int` | `24` | Minimum length for state parameter |
 
 ### Discovery Settings
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -2556,14 +2556,14 @@ func TestHandler_ServeAuthorization_StateLength(t *testing.T) {
 			wantError:  true,
 		},
 		{
-			name:       "state too short (31 chars, just under minimum)",
-			state:      "0123456789012345678901234567890",
+			name:       "state too short (23 chars, just under minimum)",
+			state:      "01234567890123456789012",
 			wantStatus: http.StatusBadRequest,
 			wantError:  true,
 		},
 		{
-			name:       "state exactly minimum length (32 chars)",
-			state:      "01234567890123456789012345678901",
+			name:       "state exactly minimum length (24 chars)",
+			state:      "012345678901234567890123",
 			wantStatus: http.StatusFound,
 			wantError:  false,
 		},
@@ -2611,13 +2611,13 @@ func TestHandler_ServeCallback_StateLength(t *testing.T) {
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "state too short (31 chars)",
-			state:      "0123456789012345678901234567890",
+			name:       "state too short (23 chars)",
+			state:      "01234567890123456789012",
 			wantStatus: http.StatusBadRequest,
 		},
 		{
-			name:       "state exactly minimum length (32 chars) - will fail with invalid state since not in storage",
-			state:      "01234567890123456789012345678901",
+			name:       "state exactly minimum length (24 chars) - will fail with invalid state since not in storage",
+			state:      "012345678901234567890123",
 			wantStatus: http.StatusInternalServerError, // Will fail at state lookup, but passed length validation
 		},
 	}

--- a/server/config.go
+++ b/server/config.go
@@ -315,8 +315,8 @@ type Config struct {
 	// MinStateLength is the minimum length for state parameters to prevent
 	// timing attacks and ensure sufficient entropy for CSRF protection.
 	// OAuth 2.1 recommends at least 128 bits (16 bytes) of entropy.
-	// Default: 32 characters (192 bits of entropy)
-	MinStateLength int // default: 32
+	// Default: 24 characters (144 bits of entropy)
+	MinStateLength int // default: 24
 
 	// AllowNoStateParameter allows authorization requests without the state parameter.
 	// WARNING: Disabling state parameter validation weakens CSRF protection!

--- a/server/config_validation_security.go
+++ b/server/config_validation_security.go
@@ -28,7 +28,7 @@ func applySecurityDefaults(config *Config, logger *slog.Logger) {
 		config.RequirePKCE = true
 	}
 	if config.MinStateLength == 0 {
-		config.MinStateLength = 32 // OAuth 2.1: 128+ bits entropy recommended, 32 chars = 192 bits
+		config.MinStateLength = 24 // OAuth 2.1: 128+ bits entropy recommended, 24 chars = 144 bits
 	}
 
 	// Redirect URI security defaults - SECURE BY DEFAULT
@@ -67,9 +67,9 @@ func applySecurityDefaults(config *Config, logger *slog.Logger) {
 
 	// SECURITY: Enforce absolute minimum state length to ensure CSRF protection entropy
 	// OAuth 2.1 recommends at least 128 bits (16 bytes) of entropy
-	// 32 characters provides 192 bits of entropy in base64, which exceeds OAuth 2.1 recommendations
-	// and provides sufficient margin for high-security deployments.
-	const absoluteMinStateLength = 32
+	// 24 characters provides 144 bits of entropy in base64, exceeding OAuth 2.1's 128-bit minimum.
+	// This supports VS Code web (vscode.dev) which uses 24-character state parameters.
+	const absoluteMinStateLength = 24
 	if config.MinStateLength < absoluteMinStateLength {
 		logger.Warn("SECURITY WARNING: MinStateLength below recommended minimum, enforcing floor",
 			"configured", config.MinStateLength,

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -499,22 +499,32 @@ func TestValidateClientStateParameter(t *testing.T) {
 			name:    "state too short - 1 character",
 			state:   "x",
 			wantErr: true,
-			errMsg:  "state parameter must be at least 32 characters for security",
+			errMsg:  "state parameter must be at least 24 characters for security",
 		},
 		{
 			name:    "state too short - 10 characters",
 			state:   "0123456789",
 			wantErr: true,
-			errMsg:  "state parameter must be at least 32 characters for security",
+			errMsg:  "state parameter must be at least 24 characters for security",
 		},
 		{
-			name:    "state too short - 31 characters (just under minimum)",
-			state:   "0123456789012345678901234567890",
+			name:    "state too short - 23 characters (just under minimum)",
+			state:   "01234567890123456789012",
 			wantErr: true,
-			errMsg:  "state parameter must be at least 32 characters for security",
+			errMsg:  "state parameter must be at least 24 characters for security",
 		},
 		{
-			name:    "state exactly minimum length - 32 characters",
+			name:    "state exactly minimum length - 24 characters",
+			state:   "012345678901234567890123",
+			wantErr: false,
+		},
+		{
+			name:    "state 31 characters (above minimum)",
+			state:   "0123456789012345678901234567890",
+			wantErr: false,
+		},
+		{
+			name:    "state above minimum - 32 characters",
 			state:   "01234567890123456789012345678901",
 			wantErr: false,
 		},
@@ -529,12 +539,12 @@ func TestValidateClientStateParameter(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "state with special characters and minimum length",
+			name:    "state with special characters above minimum length",
 			state:   "abcdef-GHIJKL_mnopqr.stuvwxyz",
-			wantErr: true, // This is 31 chars
+			wantErr: false, // 29 chars, above 24-char minimum
 		},
 		{
-			name:    "state with base64url characters and minimum length",
+			name:    "state with base64url characters and above minimum length",
 			state:   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdef", // 32 chars
 			wantErr: false,
 		},
@@ -591,10 +601,11 @@ func TestValidateClientStateParameter_TimingAttackResistance(t *testing.T) {
 	}
 
 	validStates := []string{
-		strings.Repeat("a", 32),  // Exactly minimum
-		strings.Repeat("b", 43),  // PKCE verifier length
-		strings.Repeat("c", 64),  // Double minimum
-		strings.Repeat("d", 128), // Very long
+		strings.Repeat("a", 24),  // Exactly minimum
+		strings.Repeat("b", 32),  // Previous default
+		strings.Repeat("c", 43),  // PKCE verifier length
+		strings.Repeat("d", 64),  // Well above minimum
+		strings.Repeat("e", 128), // Very long
 	}
 
 	for _, state := range validStates {


### PR DESCRIPTION
## Summary

- Lowers the `absoluteMinStateLength` floor from 32 to 24 characters in `config_validation_security.go`
- Lowers the default `MinStateLength` from 32 to 24 to align with the new floor
- 24 characters provides 144 bits of entropy, exceeding OAuth 2.1's 128-bit minimum (RFC 9101)
- Unblocks VS Code web (`vscode.dev`) which uses 24-character state parameters, without requiring `AllowNoStateParameter` (which disables state validation entirely)

## Test plan

- [x] All existing tests updated to reflect new 24-character minimum
- [x] `go test ./...` passes
- [ ] CI checks pass

Closes #228

Made with [Cursor](https://cursor.com)