### PR TITLE
feat(providers): add provider-aware scope filtering

### DIFF
--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -257,13 +257,33 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// Apply optional OIDC parameters (Dex supports standard OIDC params)
 	authCodeOpts = append(authCodeOpts, providers.ApplyAuthorizationURLOptions(authOpts)...)
 
-	// SECURITY: Create a deep copy of scopes to prevent potential race conditions
+	// SECURITY: Create a deep copy of scopes to prevent potential race conditions.
+	// CopyScopes also force-merges mandatory scopes (openid, audience:server:client_id:*)
+	// from defaults when clients provide custom scopes.
 	scopesToUse := providers.CopyScopes(scopes, p.Scopes)
+
+	// Defense-in-depth: Ensure "openid" is always present for Dex.
+	// Even if neither the client nor the provider defaults include it (misconfiguration),
+	// Dex requires it per the OIDC spec. This is a safety net beyond CopyScopes.
+	scopesToUse = ensureOpenIDScope(scopesToUse)
 
 	// Create a config with the determined scopes
 	config := *p.Config
 	config.Scopes = scopesToUse
 	return config.AuthCodeURL(state, authCodeOpts...)
+}
+
+// ensureOpenIDScope guarantees that "openid" is present in the scope list.
+// This is defense-in-depth for OIDC compliance: Dex requires "openid" per spec,
+// and this ensures it is always included even if both the client and provider
+// defaults somehow omit it.
+func ensureOpenIDScope(scopes []string) []string {
+	for _, s := range scopes {
+		if s == "openid" {
+			return scopes
+		}
+	}
+	return append(scopes, "openid")
 }
 
 // ensureContextTimeout ensures the context has a deadline, adding one if needed.

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -389,6 +389,110 @@ func TestAuthorizationURL_CustomScopes(t *testing.T) {
 	}
 }
 
+// TestEnsureOpenIDScope tests the defense-in-depth openid injection.
+func TestEnsureOpenIDScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []string
+		wantLen int
+		wantHas string
+	}{
+		{
+			name:    "already has openid",
+			input:   []string{"openid", "email", "profile"},
+			wantLen: 3,
+			wantHas: "openid",
+		},
+		{
+			name:    "missing openid - gets injected",
+			input:   []string{"email", "profile"},
+			wantLen: 3,
+			wantHas: "openid",
+		},
+		{
+			name:    "only non-standard scopes - openid injected",
+			input:   []string{"claudeai"},
+			wantLen: 2,
+			wantHas: "openid",
+		},
+		{
+			name:    "empty scopes - openid injected",
+			input:   []string{},
+			wantLen: 1,
+			wantHas: "openid",
+		},
+		{
+			name:    "nil scopes - openid injected",
+			input:   nil,
+			wantLen: 1,
+			wantHas: "openid",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ensureOpenIDScope(tt.input)
+			if len(result) != tt.wantLen {
+				t.Errorf("ensureOpenIDScope() returned %d scopes, want %d: %v", len(result), tt.wantLen, result)
+			}
+			found := false
+			for _, s := range result {
+				if s == tt.wantHas {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("ensureOpenIDScope() result %v does not contain %q", result, tt.wantHas)
+			}
+		})
+	}
+}
+
+// TestAuthorizationURL_OpenIDAlwaysPresent verifies that the Dex provider always
+// includes "openid" in the authorization URL, even when clients send non-standard
+// scopes that don't include it.
+func TestAuthorizationURL_OpenIDAlwaysPresent(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	provider, err := NewProvider(testConfig(server))
+	if err != nil {
+		t.Fatalf("NewProvider() failed: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		scopes []string
+	}{
+		{
+			name:   "client sends only non-standard scope",
+			scopes: []string{"claudeai"},
+		},
+		{
+			name:   "client sends Dex-specific scopes without openid",
+			scopes: []string{"groups", "email"},
+		},
+		{
+			name:   "client sends openid explicitly",
+			scopes: []string{"openid", "email"},
+		},
+		{
+			name:   "nil scopes uses defaults which include openid",
+			scopes: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authURL := provider.AuthorizationURL("state", "challenge", "S256", tt.scopes, nil)
+			if !strings.Contains(authURL, "openid") {
+				t.Errorf("AuthorizationURL() should always contain openid scope, got URL: %s", authURL)
+			}
+		})
+	}
+}
+
 // TestExchangeCode tests code exchange (mock only, as we can't test actual OAuth flow)
 func TestExchangeCode(t *testing.T) {
 	server := setupMockDexServer(t)

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -110,14 +110,33 @@ func (p *Provider) DefaultScopes() []string {
 	return scopes
 }
 
-// filterGoogleScopes creates a deep copy of scopes and filters out "offline_access".
-// Google doesn't support offline_access as a scope; it uses access_type=offline instead.
+// isGoogleSupportedScope returns true if the scope is recognized by Google's OAuth endpoints.
+// Supported scopes:
+//   - "openid", "email", "profile": Standard OIDC scopes
+//   - Scopes starting with "https://www.googleapis.com/": Google API scopes
+//
+// Unsupported scopes (filtered out):
+//   - "offline_access": Google uses access_type=offline parameter instead
+//   - "groups": Dex-specific scope not recognized by Google
+//   - Any other non-Google scopes (e.g., "claudeai", custom provider scopes)
+func isGoogleSupportedScope(scope string) bool {
+	switch scope {
+	case "openid", "email", "profile":
+		return true
+	default:
+		return strings.HasPrefix(scope, "https://www.googleapis.com/")
+	}
+}
+
+// filterGoogleScopes creates a deep copy of scopes and filters out any scopes that
+// Google does not support. This prevents authorization failures when clients send
+// provider-specific scopes (e.g., Dex's "groups") or non-standard scopes (e.g., "claudeai")
+// to a Google provider.
 func filterGoogleScopes(requestedScopes, defaultScopes []string) []string {
 	sourceScopes := providers.CopyScopes(requestedScopes, defaultScopes)
-	// Filter out offline_access - Google uses access_type=offline parameter instead
 	filtered := make([]string, 0, len(sourceScopes))
 	for _, s := range sourceScopes {
-		if s != "offline_access" {
+		if isGoogleSupportedScope(s) {
 			filtered = append(filtered, s)
 		}
 	}

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -349,6 +349,116 @@ func TestProvider_AuthorizationURL_FiltersOfflineAccess(t *testing.T) {
 	}
 }
 
+// TestFilterGoogleScopes_DropsUnsupportedScopes verifies that filterGoogleScopes
+// drops scopes that Google does not recognize, preventing authorization failures.
+func TestFilterGoogleScopes_DropsUnsupportedScopes(t *testing.T) {
+	defaultScopes := []string{"openid", "email", "profile"}
+
+	tests := []struct {
+		name           string
+		requested      []string
+		wantContain    []string
+		wantNotContain []string
+	}{
+		{
+			name:           "drops Dex-specific groups scope",
+			requested:      []string{"openid", "email", "groups"},
+			wantContain:    []string{"openid", "email"},
+			wantNotContain: []string{"groups"},
+		},
+		{
+			name:           "drops non-standard scopes like claudeai",
+			requested:      []string{"openid", "claudeai"},
+			wantContain:    []string{"openid"},
+			wantNotContain: []string{"claudeai"},
+		},
+		{
+			name:           "keeps Google API scopes",
+			requested:      []string{"openid", "https://www.googleapis.com/auth/gmail.readonly"},
+			wantContain:    []string{"openid", "https://www.googleapis.com/auth/gmail.readonly"},
+			wantNotContain: nil,
+		},
+		{
+			name:           "drops offline_access",
+			requested:      []string{"openid", "offline_access"},
+			wantContain:    []string{"openid"},
+			wantNotContain: []string{"offline_access"},
+		},
+		{
+			name:           "drops multiple unsupported scopes",
+			requested:      []string{"openid", "groups", "claudeai", "offline_access", "custom:scope"},
+			wantContain:    []string{"openid"},
+			wantNotContain: []string{"groups", "claudeai", "offline_access", "custom:scope"},
+		},
+		{
+			name:        "keeps all standard OIDC scopes",
+			requested:   []string{"openid", "email", "profile"},
+			wantContain: []string{"openid", "email", "profile"},
+		},
+		{
+			name:        "uses defaults when requested is nil",
+			requested:   nil,
+			wantContain: []string{"openid", "email", "profile"},
+		},
+		{
+			name:           "injects openid from defaults when missing in requested",
+			requested:      []string{"email", "groups"},
+			wantContain:    []string{"email", "openid"},
+			wantNotContain: []string{"groups"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterGoogleScopes(tt.requested, defaultScopes)
+
+			resultSet := make(map[string]bool, len(result))
+			for _, s := range result {
+				resultSet[s] = true
+			}
+
+			for _, want := range tt.wantContain {
+				if !resultSet[want] {
+					t.Errorf("filterGoogleScopes() should contain %q, got %v", want, result)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if resultSet[notWant] {
+					t.Errorf("filterGoogleScopes() should NOT contain %q, got %v", notWant, result)
+				}
+			}
+		})
+	}
+}
+
+// TestIsGoogleSupportedScope tests the scope classification function.
+func TestIsGoogleSupportedScope(t *testing.T) {
+	tests := []struct {
+		scope    string
+		expected bool
+	}{
+		{"openid", true},
+		{"email", true},
+		{"profile", true},
+		{"https://www.googleapis.com/auth/gmail.readonly", true},
+		{"https://www.googleapis.com/auth/drive", true},
+		{"groups", false},
+		{"claudeai", false},
+		{"offline_access", false},
+		{"custom:scope", false},
+		{"audience:server:client_id:test", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scope, func(t *testing.T) {
+			if got := isGoogleSupportedScope(tt.scope); got != tt.expected {
+				t.Errorf("isGoogleSupportedScope(%q) = %v, want %v", tt.scope, got, tt.expected)
+			}
+		})
+	}
+}
+
 // TestProvider_AuthorizationURL_DeepCopySafety verifies that the provider creates
 // deep copies of scopes to prevent race conditions and unexpected modifications
 func TestProvider_AuthorizationURL_DeepCopySafety(t *testing.T) {
@@ -379,7 +489,7 @@ func TestProvider_AuthorizationURL_DeepCopySafety(t *testing.T) {
 	}
 
 	// Test 2: Using custom scopes - should not affect provider defaults
-	customScopes := []string{"custom:scope1", "custom:scope2"}
+	customScopes := []string{"https://www.googleapis.com/auth/gmail.readonly", "https://www.googleapis.com/auth/drive.readonly"}
 	authURL2 := provider.AuthorizationURL("state2", "challenge2", "S256", customScopes, nil)
 
 	// Verify provider's scopes are still unchanged
@@ -388,7 +498,7 @@ func TestProvider_AuthorizationURL_DeepCopySafety(t *testing.T) {
 	}
 
 	// Test 3: Modifying input slice shouldn't affect provider
-	inputScopes := []string{"input:scope1", "input:scope2"}
+	inputScopes := []string{"openid", "email"}
 	authURL3 := provider.AuthorizationURL("state3", "challenge3", "S256", inputScopes, nil)
 
 	// Modify the input slice after the call
@@ -396,14 +506,14 @@ func TestProvider_AuthorizationURL_DeepCopySafety(t *testing.T) {
 	_ = append(inputScopes, "APPENDED") // Intentionally not using result to test isolation
 
 	// Generate another URL - should not be affected by the modification
-	authURL4 := provider.AuthorizationURL("state4", "challenge4", "S256", []string{"input:scope1", "input:scope2"}, nil)
+	authURL4 := provider.AuthorizationURL("state4", "challenge4", "S256", []string{"openid", "email"}, nil)
 
 	// URLs 3 and 4 should have the same scopes (ignoring state/challenge differences)
-	if !strings.Contains(authURL3, "input%3Ascope1") {
-		t.Errorf("URL 3 should contain input:scope1")
+	if !strings.Contains(authURL3, "openid") {
+		t.Errorf("URL 3 should contain openid")
 	}
-	if !strings.Contains(authURL4, "input%3Ascope1") {
-		t.Errorf("URL 4 should contain input:scope1")
+	if !strings.Contains(authURL4, "openid") {
+		t.Errorf("URL 4 should contain openid")
 	}
 
 	// Verify all URLs were generated successfully

--- a/providers/helpers.go
+++ b/providers/helpers.go
@@ -70,26 +70,33 @@ func ApplyAuthorizationURLOptions(opts *AuthorizationURLOptions) []oauth2.AuthCo
 // be valid for the "k8s-auth" client, even if the requesting client didn't ask for it.
 const CrossClientAudienceScopePrefix = "audience:server:client_id:"
 
+// isMandatoryScope returns true if the scope must always be force-merged into the
+// resolved scope set when present in the provider's defaults. Currently mandatory:
+//   - "openid": Required by OIDC-compliant providers per the OpenID Connect spec.
+//   - CrossClientAudienceScopePrefix: Required for SSO token forwarding scenarios.
+func isMandatoryScope(scope string) bool {
+	return scope == "openid" || strings.HasPrefix(scope, CrossClientAudienceScopePrefix)
+}
+
 // CopyScopes creates a deep copy of scopes to prevent race conditions.
 // If requestedScopes is empty, copies defaultScopes.
 // If requestedScopes is non-empty, copies those and merges in any mandatory scopes
-// from defaultScopes. Mandatory scopes are cross-client audience scopes (prefixed with
-// "audience:server:client_id:") which are required for SSO token forwarding scenarios.
-//
-// Mandatory Scope Merging:
-//
-// Cross-client audience scopes (prefixed with CrossClientAudienceScopePrefix) from
-// defaultScopes are ALWAYS merged into the result, even when the client provides
-// custom scopes. This ensures SSO token forwarding scenarios work correctly.
+// from defaultScopes. Mandatory scopes are:
+//   - "openid": Always force-merged when present in defaults, ensuring OIDC-compliant
+//     providers always receive the required openid scope regardless of what the client
+//     requested (e.g., clients sending only "claudeai" will still get "openid" injected).
+//   - Cross-client audience scopes (prefixed with CrossClientAudienceScopePrefix):
+//     Required for SSO token forwarding scenarios.
 //
 // Example:
 //
 //	defaultScopes: ["openid", "profile", "audience:server:client_id:k8s-auth"]
-//	requestedScopes: ["openid", "email"]
-//	result: ["openid", "email", "audience:server:client_id:k8s-auth"]
+//	requestedScopes: ["claudeai"]
+//	result: ["claudeai", "openid", "audience:server:client_id:k8s-auth"]
 //
-// Note that "profile" is NOT merged (it's not an audience scope), but the audience
-// scope IS merged because it's mandatory for SSO token forwarding.
+// Note that "profile" is NOT merged (it's not mandatory), but "openid" and the
+// audience scope ARE merged because they are mandatory for OIDC compliance and
+// SSO token forwarding respectively.
 func CopyScopes(requestedScopes, defaultScopes []string) []string {
 	// If no requested scopes, use defaults entirely
 	if len(requestedScopes) == 0 {
@@ -99,7 +106,7 @@ func CopyScopes(requestedScopes, defaultScopes []string) []string {
 	}
 
 	// Start with a copy of requested scopes
-	// Pre-allocate with extra capacity for potential audience scopes to avoid reallocation
+	// Pre-allocate with extra capacity for potential mandatory scopes to avoid reallocation
 	result := make([]string, len(requestedScopes), len(requestedScopes)+len(defaultScopes))
 	copy(result, requestedScopes)
 
@@ -109,10 +116,9 @@ func CopyScopes(requestedScopes, defaultScopes []string) []string {
 		requestedSet[s] = struct{}{}
 	}
 
-	// Merge mandatory scopes from defaults (cross-client audience scopes)
-	// These scopes are required for SSO token forwarding and must not be omitted
+	// Merge mandatory scopes from defaults
 	for _, s := range defaultScopes {
-		if strings.HasPrefix(s, CrossClientAudienceScopePrefix) {
+		if isMandatoryScope(s) {
 			if _, exists := requestedSet[s]; !exists {
 				result = append(result, s)
 			}

--- a/providers/provider_test.go
+++ b/providers/provider_test.go
@@ -433,6 +433,97 @@ func TestCopyScopes(t *testing.T) {
 			t.Errorf("expected fourth scope to be audience:server:client_id:second-client, got %q", result[3])
 		}
 	})
+
+	t.Run("merges openid from defaults when client omits it", func(t *testing.T) {
+		requested := []string{"claudeai"}
+		defaults := []string{testScopeOpenID, testScopeProfile, testScopeEmail}
+
+		result := CopyScopes(requested, defaults)
+
+		if len(result) != 2 {
+			t.Errorf("expected 2 scopes, got %d: %v", len(result), result)
+		}
+		if result[0] != "claudeai" {
+			t.Errorf("expected first scope to be %q, got %q", "claudeai", result[0])
+		}
+		if result[1] != testScopeOpenID {
+			t.Errorf("expected second scope to be %q, got %q", testScopeOpenID, result[1])
+		}
+	})
+
+	t.Run("does not duplicate openid when already in requested", func(t *testing.T) {
+		requested := []string{testScopeOpenID, testScopeEmail}
+		defaults := []string{testScopeOpenID, testScopeProfile}
+
+		result := CopyScopes(requested, defaults)
+
+		if len(result) != 2 {
+			t.Errorf("expected 2 scopes (no duplicate openid), got %d: %v", len(result), result)
+		}
+	})
+
+	t.Run("does not inject openid when not in defaults", func(t *testing.T) {
+		requested := []string{"custom:scope"}
+		defaults := []string{testScopeProfile, testScopeEmail}
+
+		result := CopyScopes(requested, defaults)
+
+		if len(result) != 1 {
+			t.Errorf("expected 1 scope, got %d: %v", len(result), result)
+		}
+		if result[0] != "custom:scope" {
+			t.Errorf("unexpected scope: %v", result)
+		}
+	})
+
+	t.Run("merges both openid and audience scopes", func(t *testing.T) {
+		requested := []string{"claudeai"}
+		defaults := []string{
+			testScopeOpenID,
+			testScopeProfile,
+			"audience:server:client_id:k8s-auth",
+		}
+
+		result := CopyScopes(requested, defaults)
+
+		if len(result) != 3 {
+			t.Errorf("expected 3 scopes, got %d: %v", len(result), result)
+		}
+		if result[0] != "claudeai" {
+			t.Errorf("expected first scope to be %q, got %q", "claudeai", result[0])
+		}
+		if result[1] != testScopeOpenID {
+			t.Errorf("expected second scope to be %q, got %q", testScopeOpenID, result[1])
+		}
+		if result[2] != "audience:server:client_id:k8s-auth" {
+			t.Errorf("expected third scope to be audience scope, got %q", result[2])
+		}
+	})
+}
+
+func TestIsMandatoryScope(t *testing.T) {
+	tests := []struct {
+		scope    string
+		expected bool
+	}{
+		{"openid", true},
+		{"audience:server:client_id:k8s-auth", true},
+		{"audience:server:client_id:", true},
+		{"profile", false},
+		{"email", false},
+		{"groups", false},
+		{"claudeai", false},
+		{"offline_access", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scope, func(t *testing.T) {
+			if got := isMandatoryScope(tt.scope); got != tt.expected {
+				t.Errorf("isMandatoryScope(%q) = %v, want %v", tt.scope, got, tt.expected)
+			}
+		})
+	}
 }
 
 // TestAuthorizationURLOptions_Struct tests the AuthorizationURLOptions struct.


### PR DESCRIPTION
## Summary

- **`CopyScopes()`** now force-merges `openid` from provider defaults into client-requested scopes (same pattern as cross-client audience scopes), ensuring OIDC providers always receive the mandatory `openid` scope even when clients send non-standard scopes like `claudeai`
- **`filterGoogleScopes()`** now only keeps scopes Google actually supports (`openid`, `email`, `profile`, `https://www.googleapis.com/*`), dropping Dex-specific scopes like `groups` and arbitrary custom scopes that would cause authorization failures
- **Dex provider** adds defense-in-depth `ensureOpenIDScope()` to guarantee `openid` is always present in authorization requests, even if misconfigured defaults omit it

## Test plan

- [x] Unit tests for `isMandatoryScope()` covering all scope categories
- [x] Unit tests for `CopyScopes()` openid merging: injection when missing, no-duplication, no-injection when not in defaults, combined with audience scopes
- [x] Unit tests for `isGoogleSupportedScope()` and `filterGoogleScopes()` covering Dex scopes, non-standard scopes, Google API scopes, offline_access
- [x] Unit tests for `ensureOpenIDScope()` and `AuthorizationURL_OpenIDAlwaysPresent` for Dex
- [x] All existing tests pass (no regressions)

Closes #242

Made with [Cursor](https://cursor.com)