### PR TITLE
fix(providers): add Dex scope filtering to strip non-standard client scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dex provider scope filtering to strip non-standard client scopes (#245)**
+  - Added `filterDexScopes()` mirroring the Google provider's `filterGoogleScopes()` pattern.
+  - Non-standard scopes (e.g., `claudeai`) are now stripped before forwarding to Dex.
+  - Supported scopes: standard OIDC (`openid`, `profile`, `email`, `offline_access`), Dex-specific (`groups`, `federated:id`), and cross-client audience scopes.
+
 - **SessionCreationHandler callback for session initialization during login (#239)**
   - `SetSessionCreationHandler` registers a callback that fires synchronously during authorization code exchange when a new token family is created.
   - Consumers can use this to initialize per-session state (e.g., establish SSO connections) as part of the login flow itself.

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -174,7 +174,7 @@ var defaultDexScopes = []string{
 // Supported: standard OIDC scopes, Dex-specific scopes, and cross-client audience scopes.
 func isDexSupportedScope(scope string) bool {
 	switch scope {
-	case scopeOpenID, "profile", "email", "offline_access", "groups":
+	case scopeOpenID, "profile", "email", "offline_access", "groups", "federated:id":
 		return true
 	default:
 		return strings.HasPrefix(scope, AudienceScopePrefix)

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -459,6 +459,112 @@ func TestEnsureOpenIDScope(t *testing.T) {
 	}
 }
 
+// TestIsDexSupportedScope tests the scope classification function.
+func TestIsDexSupportedScope(t *testing.T) {
+	tests := []struct {
+		scope    string
+		expected bool
+	}{
+		{"openid", true},
+		{"profile", true},
+		{"email", true},
+		{"offline_access", true},
+		{"groups", true},
+		{"federated:id", true},
+		{"audience:server:client_id:test", true},
+		{"audience:server:client_id:k8s-auth", true},
+		{"claudeai", false},
+		{"custom:scope", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.scope, func(t *testing.T) {
+			if got := isDexSupportedScope(tt.scope); got != tt.expected {
+				t.Errorf("isDexSupportedScope(%q) = %v, want %v", tt.scope, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestFilterDexScopes_DropsUnsupportedScopes verifies that filterDexScopes
+// drops scopes that Dex does not recognize, preventing authorization failures.
+func TestFilterDexScopes_DropsUnsupportedScopes(t *testing.T) {
+	defaultScopes := []string{"openid", "email", "profile", "groups", "offline_access"}
+
+	tests := []struct {
+		name           string
+		requested      []string
+		wantContain    []string
+		wantNotContain []string
+	}{
+		{
+			name:           "drops non-standard scopes like claudeai",
+			requested:      []string{"openid", "claudeai"},
+			wantContain:    []string{"openid"},
+			wantNotContain: []string{"claudeai"},
+		},
+		{
+			name:        "keeps standard OIDC scopes",
+			requested:   []string{"openid", "email", "profile"},
+			wantContain: []string{"openid", "email", "profile"},
+		},
+		{
+			name:        "keeps Dex-specific scopes",
+			requested:   []string{"openid", "groups", "offline_access"},
+			wantContain: []string{"openid", "groups", "offline_access"},
+		},
+		{
+			name:        "keeps federated:id scope",
+			requested:   []string{"openid", "federated:id"},
+			wantContain: []string{"openid", "federated:id"},
+		},
+		{
+			name:        "keeps audience scopes",
+			requested:   []string{"openid", "audience:server:client_id:k8s"},
+			wantContain: []string{"openid", "audience:server:client_id:k8s"},
+		},
+		{
+			name:        "uses defaults when requested is nil",
+			requested:   nil,
+			wantContain: []string{"openid", "email", "profile", "groups", "offline_access"},
+		},
+		{
+			name:        "injects openid from defaults when missing in requested",
+			requested:   []string{"email", "groups"},
+			wantContain: []string{"email", "groups", "openid"},
+		},
+		{
+			name:           "drops multiple unsupported scopes",
+			requested:      []string{"openid", "claudeai", "custom:scope", "random_scope"},
+			wantContain:    []string{"openid"},
+			wantNotContain: []string{"claudeai", "custom:scope", "random_scope"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := filterDexScopes(tt.requested, defaultScopes)
+
+			resultSet := make(map[string]bool, len(result))
+			for _, s := range result {
+				resultSet[s] = true
+			}
+
+			for _, want := range tt.wantContain {
+				if !resultSet[want] {
+					t.Errorf("filterDexScopes() should contain %q, got %v", want, result)
+				}
+			}
+			for _, notWant := range tt.wantNotContain {
+				if resultSet[notWant] {
+					t.Errorf("filterDexScopes() should NOT contain %q, got %v", notWant, result)
+				}
+			}
+		})
+	}
+}
+
 // TestAuthorizationURL_OpenIDAlwaysPresent verifies that the Dex provider always
 // includes "openid" in the authorization URL, even when clients send non-standard
 // scopes that don't include it.


### PR DESCRIPTION
## Summary

- Add `isDexSupportedScope()` and `filterDexScopes()` to the Dex provider, mirroring the Google provider's `filterGoogleScopes()` pattern
- Update `AuthorizationURL()` to filter scopes before forwarding to Dex, preventing `Unrecognized scope(s)` errors when MCP clients send non-standard scopes (e.g., `claudeai`)
- Supported scopes: standard OIDC (`openid`, `profile`, `email`, `offline_access`), Dex-specific (`groups`, `federated:id`), and cross-client audience scopes (`audience:server:client_id:*`)

### Upstream Dex Scope Research

Deep analysis of the [Dex source code](https://github.com/dexidp/dex/blob/master/server/oauth2.go) confirmed the exhaustive list of scopes Dex accepts at the server level:

| Scope | Purpose |
|-------|---------|
| `openid` | Required by OIDC spec |
| `email` | Include email in ID token |
| `profile` | Include username/preferred_username |
| `groups` | Include groups list |
| `offline_access` | Request refresh token |
| `federated:id` | Include connector_id + upstream user_id |
| `audience:server:client_id:*` | Cross-client trust (dynamic) |

Key findings:
- Scope validation is **uniform across all connectors** -- Dex validates at the server level before any connector is involved
- Connectors receive a structured `connector.Scopes{OfflineAccess bool, Groups bool}` struct, never raw scope strings
- `federated:id` was missing from the initial implementation and has been added

## Test plan

- [x] Unit tests pass (`go test ./providers/dex/...`)
- [x] `TestIsDexSupportedScope` covers all 7 supported scope types including `federated:id`
- [x] `TestFilterDexScopes_DropsUnsupportedScopes` covers 8 scenarios including `federated:id` preservation
- [x] `TestAuthorizationURL_CustomScopes` verifies unsupported scopes are filtered out
- [x] `TestAuthorizationURL_OpenIDAlwaysPresent` verifies openid is always preserved
- [x] `make verify` passes (lint, format, vet, all tests)

Closes #245

Made with [Cursor](https://cursor.com)