### PR TITLE
fix(security): raise DefaultMaxGroups and MaxTokenDataSize for enterprise OIDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Raise DefaultMaxGroups from 500 to 600 and MaxTokenDataSize from 64KB to 256KB (#248)**
+  - `DefaultMaxGroups` raised from 500 to 600 to accommodate enterprise OIDC environments where users have 500+ group memberships (e.g., large GitHub organizations with many teams).
+  - `MaxTokenDataSize` raised from 64KB to 256KB. When Dex issues an `id_token` JWT containing hundreds of groups, the serialized token can exceed 64KB, causing all Valkey save operations to fail and breaking authentication entirely. 256KB still provides DoS protection while accommodating enterprise token sizes.
+
 - **Lower MinStateLength absolute floor from 32 to 24 characters (#228)**
   - The absolute minimum floor for `MinStateLength` has been lowered from 32 to 24 characters.
   - 24 characters still provides 144 bits of entropy, exceeding OAuth 2.1's 128-bit minimum recommendation.

--- a/SECURITY_ARCHITECTURE.md
+++ b/SECURITY_ARCHITECTURE.md
@@ -579,7 +579,7 @@ func ValidateScopes(scopes []string) error {
 // Truncates to maxGroups instead of rejecting; returns a defensive copy.
 // Individual group names exceeding DefaultMaxGroupNameLength are rejected.
 func ValidateGroups(groups []string, maxGroups int) ([]string, bool, error) {
-    // If maxGroups <= 0, uses DefaultMaxGroups (500)
+    // If maxGroups <= 0, uses DefaultMaxGroups (600)
     // Validates all name lengths (rejects oversized names)
     // Truncates to maxGroups if exceeded, returns truncated=true
     // Always returns a defensive copy

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -63,7 +63,7 @@ type Config struct {
 
 	// MaxGroups is the maximum number of groups to accept from the OIDC groups claim.
 	// Groups beyond this limit are truncated (not rejected) and a warning is logged.
-	// Default: oidc.DefaultMaxGroups (500). Set higher for enterprise environments
+	// Default: oidc.DefaultMaxGroups (600). Set higher for enterprise environments
 	// with very large group counts (e.g., Active Directory).
 	MaxGroups int
 

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -748,7 +748,7 @@ func TestValidateToken_GroupsWithinLimit(t *testing.T) {
 	}
 }
 
-// TestValidateToken_EnterpriseGroupCount tests that the default limit (500)
+// TestValidateToken_EnterpriseGroupCount tests that the default limit (600)
 // accommodates enterprise group counts.
 func TestValidateToken_EnterpriseGroupCount(t *testing.T) {
 	groups := make([]string, enterpriseGroupCount)

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -176,16 +176,16 @@ func ValidateScopes(scopes []string) error {
 // Default limits for groups validation.
 const (
 	// DefaultMaxGroups is the default maximum number of groups accepted in an OIDC groups claim.
-	// Set to 500 to accommodate enterprise environments (Active Directory, Azure AD, LDAP)
-	// where users commonly have hundreds of group memberships.
-	DefaultMaxGroups = 500
+	// Set to 600 to accommodate enterprise environments (Active Directory, Azure AD, LDAP,
+	// large GitHub organizations) where users commonly have 500+ group memberships.
+	DefaultMaxGroups = 600
 
 	// DefaultMaxGroupNameLength is the default maximum length of a single group name.
 	DefaultMaxGroupNameLength = 256
 )
 
 // ValidateGroups validates and truncates an OIDC groups claim.
-// If maxGroups is <= 0, DefaultMaxGroups (500) is used.
+// If maxGroups is <= 0, DefaultMaxGroups (600) is used.
 //
 // Groups exceeding maxGroups are truncated (not rejected) so authentication
 // can proceed. The second return value indicates whether truncation occurred.

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -50,9 +50,10 @@ const (
 	// MaxIDLength is the maximum allowed length for identifiers (userID, clientID, familyID)
 	MaxIDLength = 256
 
-	// MaxTokenDataSize is the maximum size of serialized token data (64KB)
-	// This prevents memory exhaustion from large token payloads
-	MaxTokenDataSize = 64 * 1024
+	// MaxTokenDataSize is the maximum size of serialized token data (256KB).
+	// This prevents memory exhaustion from large token payloads while accommodating
+	// enterprise OIDC tokens that embed large groups claims in signed JWTs.
+	MaxTokenDataSize = 256 * 1024
 )
 
 // Validation error messages (generic to prevent information leakage)


### PR DESCRIPTION
## Summary

- Raise `DefaultMaxGroups` from 500 to 600 to accommodate enterprise OIDC environments where users have 500+ group memberships (e.g., large GitHub organizations with many teams).
- Raise `MaxTokenDataSize` from 64KB to 256KB. When Dex issues an `id_token` JWT containing hundreds of groups, the serialized token exceeds 64KB, causing all Valkey save operations to fail and breaking the entire auth session. 256KB still provides DoS protection while accommodating enterprise token sizes.

## Changes

- `providers/oidc/validation.go` -- `DefaultMaxGroups`: 500 -> 600
- `storage/valkey/store.go` -- `MaxTokenDataSize`: 64KB -> 256KB
- Updated all comment references to match new values
- Updated `CHANGELOG.md` and `SECURITY_ARCHITECTURE.md`

## Test plan

- [x] All existing tests pass (`make verify` green)
- [x] `TestValidateGroups` passes with new default limit
- [x] `TestValidateToken_EnterpriseGroupCount` passes
- [x] `TestNewProvider_MaxGroupsConfig` passes
- [x] No test code changes needed (tests reference `DefaultMaxGroups` constant, not hardcoded values)

Closes #248

Made with [Cursor](https://cursor.com)