### PR TITLE
Fix RFC 8252 port-agnostic matching for loopback redirect URIs

### DIFF
--- a/server/validation.go
+++ b/server/validation.go
@@ -162,7 +162,17 @@ func isLocalhostHostname(hostname string) bool {
 	return isLoopbackAddress(hostname)
 }
 
-// validateRedirectURI validates that a redirect URI is registered and secure
+// validateRedirectURI validates that a redirect URI is registered and secure.
+//
+// Per RFC 8252 Section 7.3, loopback redirect URIs (localhost, 127.0.0.1, [::1])
+// MUST allow any port at authorization time. The authorization server MUST allow
+// any port to be specified for loopback redirect URIs to accommodate native apps
+// that obtain an available ephemeral port from the OS at request time.
+//
+// For loopback URIs, matching compares only scheme, host, and path — the port is
+// excluded from comparison (RFC 8252 Section 8.3).
+//
+// For all other URIs, exact string matching is used per OAuth 2.1.
 func (s *Server) validateRedirectURI(client *storage.Client, redirectURI string) error {
 	// First check if URI is registered
 	found := false
@@ -172,12 +182,76 @@ func (s *Server) validateRedirectURI(client *storage.Client, redirectURI string)
 			break
 		}
 	}
+
+	// If exact match failed and localhost redirect URIs are allowed,
+	// try RFC 8252 port-agnostic matching for loopback addresses
+	if !found && s.Config.AllowLocalhostRedirectURIs {
+		if matchesLoopbackRedirectURI(redirectURI, client.RedirectURIs) {
+			found = true
+		}
+	}
+
 	if !found {
 		return fmt.Errorf("redirect URI not registered for client")
 	}
 
 	// Perform security validation on the URI with custom scheme support
 	return validateRedirectURISecurityEnhanced(redirectURI, s.Config.Issuer, s.Config.AllowedCustomSchemes)
+}
+
+// matchesLoopbackRedirectURI checks if a redirect URI matches any registered URI
+// using RFC 8252 Section 7.3 port-agnostic matching for loopback addresses.
+//
+// Per RFC 8252:
+//   - Section 7.3: "The authorization server MUST allow any port to be specified at
+//     the time of the request for loopback IP redirect URIs, to accommodate clients
+//     that obtain an available ephemeral port from the operating system at the time
+//     of the request."
+//   - Section 8.3: "The redirect URI MUST NOT be compared against pre-registered
+//     URIs using simple string matching [...] the comparison MUST be done by comparing
+//     scheme, host, and path."
+//
+// This function only applies port-agnostic matching when the requested redirect URI
+// targets a loopback address (localhost, 127.0.0.0/8, ::1). Non-loopback URIs are
+// never matched by this function — they require exact string matching.
+func matchesLoopbackRedirectURI(requestedURI string, registeredURIs []string) bool {
+	parsed, err := url.Parse(requestedURI)
+	if err != nil {
+		return false
+	}
+
+	// Only apply port-agnostic matching for loopback addresses
+	hostname := parsed.Hostname()
+	if !isLoopbackAddress(hostname) {
+		return false
+	}
+
+	requestedScheme := strings.ToLower(parsed.Scheme)
+	requestedHost := strings.ToLower(hostname)
+	requestedPath := parsed.Path
+
+	for _, registered := range registeredURIs {
+		registeredParsed, err := url.Parse(registered)
+		if err != nil {
+			continue
+		}
+
+		registeredHost := registeredParsed.Hostname()
+
+		// Only match against registered URIs that are also loopback
+		if !isLoopbackAddress(registeredHost) {
+			continue
+		}
+
+		// Compare scheme, host, and path — exclude port (RFC 8252 Section 8.3)
+		if strings.ToLower(registeredParsed.Scheme) == requestedScheme &&
+			strings.ToLower(registeredHost) == requestedHost &&
+			registeredParsed.Path == requestedPath {
+			return true
+		}
+	}
+
+	return false
 }
 
 // validateScopes validates that requested scopes are allowed

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/storage"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
 
@@ -954,6 +955,185 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 			t.Error("Expected error for short state when AllowNoStateParameter=false")
 		}
 	})
+}
+
+// TestMatchesLoopbackRedirectURI tests RFC 8252 Section 7.3 port-agnostic
+// matching for loopback redirect URIs.
+func TestMatchesLoopbackRedirectURI(t *testing.T) {
+	tests := []struct {
+		name           string
+		requestedURI   string
+		registeredURIs []string
+		want           bool
+	}{
+		// RFC 8252 Section 7.3: Port MUST be allowed to vary for loopback
+		{
+			name:           "localhost with ephemeral port matches registered without port",
+			requestedURI:   "http://localhost:49567/callback",
+			registeredURIs: []string{"http://localhost/callback"},
+			want:           true,
+		},
+		{
+			name:           "localhost with different ephemeral port",
+			requestedURI:   "http://localhost:12345/callback",
+			registeredURIs: []string{"http://localhost/callback"},
+			want:           true,
+		},
+		{
+			name:           "127.0.0.1 with ephemeral port matches registered without port",
+			requestedURI:   "http://127.0.0.1:49567/callback",
+			registeredURIs: []string{"http://127.0.0.1/callback"},
+			want:           true,
+		},
+		{
+			name:           "IPv6 loopback with port",
+			requestedURI:   "http://[::1]:49567/callback",
+			registeredURIs: []string{"http://[::1]/callback"},
+			want:           true,
+		},
+		{
+			name:           "registered with port matches request with different port",
+			requestedURI:   "http://localhost:49567/callback",
+			registeredURIs: []string{"http://localhost:3000/callback"},
+			want:           true,
+		},
+		{
+			name:           "exact match still works",
+			requestedURI:   "http://localhost/callback",
+			registeredURIs: []string{"http://localhost/callback"},
+			want:           true,
+		},
+		// Path must match
+		{
+			name:           "different path does not match",
+			requestedURI:   "http://localhost:49567/other",
+			registeredURIs: []string{"http://localhost/callback"},
+			want:           false,
+		},
+		// Scheme must match
+		{
+			name:           "different scheme does not match",
+			requestedURI:   "https://localhost:49567/callback",
+			registeredURIs: []string{"http://localhost/callback"},
+			want:           false,
+		},
+		// Host must match
+		{
+			name:           "localhost does not match 127.0.0.1",
+			requestedURI:   "http://localhost:49567/callback",
+			registeredURIs: []string{"http://127.0.0.1/callback"},
+			want:           false,
+		},
+		// Non-loopback URIs are never matched by this function
+		{
+			name:           "non-loopback URI is not matched",
+			requestedURI:   "https://example.com:8080/callback",
+			registeredURIs: []string{"https://example.com/callback"},
+			want:           false,
+		},
+		{
+			name:           "non-loopback registered URI is skipped",
+			requestedURI:   "http://localhost:49567/callback",
+			registeredURIs: []string{"https://example.com/callback"},
+			want:           false,
+		},
+		// Multiple registered URIs
+		{
+			name:         "matches one of multiple registered URIs",
+			requestedURI: "http://localhost:49567/callback",
+			registeredURIs: []string{
+				"https://example.com/callback",
+				"http://localhost/callback",
+			},
+			want: true,
+		},
+		// Empty/invalid
+		{
+			name:           "empty registered URIs",
+			requestedURI:   "http://localhost:49567/callback",
+			registeredURIs: []string{},
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesLoopbackRedirectURI(tt.requestedURI, tt.registeredURIs)
+			if got != tt.want {
+				t.Errorf("matchesLoopbackRedirectURI(%q, %v) = %v, want %v",
+					tt.requestedURI, tt.registeredURIs, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestValidateRedirectURI_RFC8252LoopbackPort tests the full validateRedirectURI
+// flow with RFC 8252 port-agnostic matching enabled via AllowLocalhostRedirectURIs.
+func TestValidateRedirectURI_RFC8252LoopbackPort(t *testing.T) {
+	tests := []struct {
+		name                      string
+		redirectURI               string
+		registeredURIs            []string
+		allowLocalhostRedirectURIs bool
+		wantErr                   bool
+	}{
+		{
+			name:                      "loopback port matching enabled - matches",
+			redirectURI:               "http://localhost:49567/callback",
+			registeredURIs:            []string{"http://localhost/callback"},
+			allowLocalhostRedirectURIs: true,
+			wantErr:                   false,
+		},
+		{
+			name:                      "loopback port matching disabled - rejects",
+			redirectURI:               "http://localhost:49567/callback",
+			registeredURIs:            []string{"http://localhost/callback"},
+			allowLocalhostRedirectURIs: false,
+			wantErr:                   true,
+		},
+		{
+			name:                      "non-loopback is never port-agnostic even when enabled",
+			redirectURI:               "https://example.com:8080/callback",
+			registeredURIs:            []string{"https://example.com/callback"},
+			allowLocalhostRedirectURIs: true,
+			wantErr:                   true,
+		},
+		{
+			name:                      "exact match works regardless of setting",
+			redirectURI:               "http://localhost/callback",
+			registeredURIs:            []string{"http://localhost/callback"},
+			allowLocalhostRedirectURIs: false,
+			wantErr:                   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup := newTestServerSetup(false)
+			config := &Config{
+				AllowLocalhostRedirectURIs: tt.allowLocalhostRedirectURIs,
+				AllowInsecureHTTP:          true,
+				Issuer:                     "http://localhost:8080",
+			}
+			srv, err := setup.createServer(config)
+			if err != nil {
+				t.Fatalf("Failed to create server: %v", err)
+			}
+
+			client := &storage.Client{
+				ClientID:     "test-client",
+				RedirectURIs: tt.registeredURIs,
+			}
+
+			err = srv.validateRedirectURI(client, tt.redirectURI)
+			if tt.wantErr && err == nil {
+				t.Error("Expected error but got none")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Expected no error but got: %v", err)
+			}
+		})
+	}
 }
 
 // TestValidateProviderStateParameter tests that provider state validation always

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -1010,6 +1010,19 @@ func TestMatchesLoopbackRedirectURI(t *testing.T) {
 			registeredURIs: []string{"http://localhost/callback"},
 			want:           false,
 		},
+		// Path comparison is case-sensitive and exact — trailing slashes differ
+		{
+			name:           "trailing slash mismatch does not match (requested has slash)",
+			requestedURI:   "http://localhost:49567/callback/",
+			registeredURIs: []string{"http://localhost/callback"},
+			want:           false,
+		},
+		{
+			name:           "trailing slash mismatch does not match (registered has slash)",
+			requestedURI:   "http://localhost:49567/callback",
+			registeredURIs: []string{"http://localhost/callback/"},
+			want:           false,
+		},
 		// Scheme must match
 		{
 			name:           "different scheme does not match",


### PR DESCRIPTION
## Summary

- Implement RFC 8252 Section 7.3 port-agnostic matching for loopback redirect URIs
- Add `matchesLoopbackRedirectURI()` helper for scheme+host+path comparison (excluding port)
- Add comprehensive tests covering localhost, 127.0.0.1, IPv6 ::1, and edge cases

## Problem

Native OAuth clients like Claude Code obtain an ephemeral port from the OS at request time, producing redirect URIs like `http://localhost:49567/callback`. The client metadata (fetched from `https://claude.ai/oauth/claude-code-client-metadata`) registers:

```json
{
  "redirect_uris": ["http://localhost/callback", "http://127.0.0.1/callback"]
}
```

The existing `validateRedirectURI()` used **exact string matching** (`uri == redirectURI`), which rejected these requests with `"redirect URI not registered for client"` — even though `AllowLocalhostRedirectURIs: true` was configured. That config only controlled whether loopback addresses were *allowed at all* in the security validation layer (`redirect_uri_security.go`), not the URI matching logic.

This broke direct MCP connections to any muster instance (e.g., connecting Claude Code to `https://muster.graveler.gaws2.gigantic.io`). The org-wide connector on Gazelle worked because it uses a different auth flow that doesn't go through dynamic client registration.

## RFC 8252 Requirements

**[Section 7.3](https://www.rfc-editor.org/rfc/rfc8252.html#section-7.3)** (Loopback Interface Redirect):
> The authorization server MUST allow any port to be specified at the time of the request for loopback IP redirect URIs, to accommodate clients that obtain an available ephemeral port from the operating system at the time of the request.

**[Section 8.3](https://www.rfc-editor.org/rfc/rfc8252.html#section-8.3)** (Redirect URI Matching):
> The redirect URI MUST NOT be compared against pre-registered URIs using simple string matching. At a minimum, the comparison MUST be done by comparing scheme, host, and path.

## Solution

When exact string matching fails and `AllowLocalhostRedirectURIs` is enabled, fall back to `matchesLoopbackRedirectURI()` which:

1. Parses the requested URI and checks if the host is a loopback address
2. For each registered URI that is also loopback, compares **scheme + host + path** only (port excluded)
3. Returns true if any registered URI matches

Non-loopback URIs are **never** matched by this function — they continue to require exact string matching per OAuth 2.1.

## Test plan

- [x] `TestMatchesLoopbackRedirectURI` — 13 cases covering localhost, 127.0.0.1, ::1, path/scheme/host mismatches, non-loopback rejection
- [x] `TestValidateRedirectURI_RFC8252LoopbackPort` — 4 integration cases testing the full flow with config enabled/disabled
- [x] Full `./server/` test suite passes (no regressions)