### PR TITLE
feat(server): Server.AcceptForwardedIDToken for forwarded-token acceptance

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -528,6 +528,42 @@ Providers without JWKS support will always use userinfo endpoint validation.
 4. **Validate Scopes**: Use `EndpointScopeRequirements` for fine-grained access control
 5. **JWKS Caching**: The default 1-hour cache TTL balances performance with key rotation freshness
 
+### Direct Acceptance: `Server.AcceptForwardedIDToken`
+
+`Server.ValidateToken` runs the JWKS/TrustedAudiences path opportunistically — if the token isn't a JWT or the audience doesn't match, it falls back to the userinfo endpoint. `Server.AcceptForwardedIDToken` is the direct, non-fallback entry point for callers that want the library to accept a forwarded token or fail hard.
+
+Use it when an upstream intermediary (aggregator, bridge, sidecar) already holds a valid ID token from the trusted IdP and presents it as the Bearer credential. See [silent-authentication.md](./silent-authentication.md) for the full usage guide; this section covers the security properties and operator-facing configuration.
+
+#### Session-ID correlation property
+
+`AcceptForwardedIDToken` returns a deterministic identifier of the form `"ext-" + hex(sha256(bearerToken))[:16]`. Two MCP servers receiving the same bearer token compute the same identifier, which gives cross-hop audit-log correlation when an aggregator fans a single token out to multiple downstream servers. This is intentional for single-tenant deployments — it lets one correlation ID line up the hops of a distributed request without any coordination.
+
+**Threat model implication:** anyone with audit-log access across two servers in the same correlation set can link a user's sessions across them via the token hash. The hash is one-way (the token cannot be recovered from the identifier), but session linkage is observable. For single-tenant deployments where all servers belong to the same operator and the same audit pipeline, this is a feature. For multi-tenant deployments where different operators run different servers and must not correlate sessions, it is a property to disable.
+
+#### `Config.SessionIDHMACKey`: multi-tenant isolation
+
+Setting `Config.SessionIDHMACKey` replaces the SHA-256 derivation with HMAC-SHA-256 keyed by the configured value. The identifier becomes `"ext-" + hex(hmac-sha256(key, bearerToken))[:16]` — still deterministic, but correlation holds only among servers that share the key.
+
+```go
+config := &server.Config{
+    Issuer:           "https://auth.example.com",
+    TrustedAudiences: []string{"muster-client"},
+
+    // Per-deployment secret. Treat as sensitive; rotate via the same process
+    // you use for EncryptionKey. Must be the same across all MCP servers that
+    // should share session-ID correlation, and different from other tenants'.
+    SessionIDHMACKey: mustReadKey("/etc/mcp/session-id-hmac.key"),
+}
+```
+
+**Operator caveat (critical — the library cannot detect the mistake):** every MCP server in a correlation set must either *all* configure the same `SessionIDHMACKey` **or** *all* leave it empty. A single mismatched key silently breaks correlation with no runtime error — the tokens still validate, the sessions just no longer line up across hops. Treat the key as a deployment-wide constant and version it (e.g. `session-id-hmac-key-v1`) so rotations are explicit and detectable.
+
+Recommended key properties: 32 random bytes from `crypto/rand`, base64-encoded for transport, loaded from a secret manager or mounted file (not from an environment variable).
+
+#### Expiry behavior
+
+`AcceptForwardedIDToken` does not refresh forwarded tokens — the library holds no refresh credential for them. When the JWT `exp` has passed, validation fails and the caller must propagate 401 so the MCP client re-authenticates against the upstream IdP. Callers should use `acceptance.ExpiresAt` to set any session-cache TTLs rather than re-parsing the JWT.
+
 ### Private IdP Deployments
 
 If your Identity Provider (e.g., Dex) runs on a private network, JWKS fetching will fail due to SSRF protection. Use the `AllowPrivateIPJWKS` configuration option to allow JWKS endpoints to resolve to private IP addresses:

--- a/docs/silent-authentication.md
+++ b/docs/silent-authentication.md
@@ -445,8 +445,61 @@ authURL := provider.AuthorizationURL(state, challenge, "S256", scopes, &provider
 })
 ```
 
+## Accepting a Forwarded ID Token Directly
+
+Silent authentication is one half of the "upstream-IdP pass-through" story. The other half is the case where a trusted intermediary (an aggregator, a gateway, an AgentCore Runtime bridge) already holds a valid ID token from the upstream IdP and presents it as the Bearer credential to this server. `Server.AcceptForwardedIDToken` is the library entry point for that case.
+
+Unlike the auth-code flow, this path never touches the authorization_code grant — there is no family, no refresh token, no `SessionCreationHandler` firing, and no entry created in `TokenStore`. It is a pure validation function that returns the verified claims plus a deterministic session identifier.
+
+### When to use it
+
+Use `AcceptForwardedIDToken` when:
+
+- An upstream intermediary (muster, a bridge, a sidecar) receives an MCP request with a Bearer token it obtained from the same IdP this server trusts.
+- The intermediary wants to hand the token directly to this server rather than translate it into a server-issued access token.
+- This server needs to attribute the request to the original end user (per-user RBAC, audit) without running its own auth-code flow.
+
+The classic deployment is the Bedrock AgentCore Runtime bridge: user authenticates to Dex, gets an ID token, presents it to the bridge, bridge forwards it unchanged to an MCP server configured with Dex's audience in `Config.TrustedAudiences`.
+
+### Preconditions
+
+1. The configured `providers.Provider` implements `providers.JWKSProvider`. GitHub's provider does not qualify (OAuth 2.0 only) — the function returns a clear error in that case.
+2. `Config.TrustedAudiences` contains the audience the upstream IdP minted the token for.
+3. The provider's `IssuerURL()` matches the JWT's `iss` claim (the signature check requires this anyway).
+
+### Usage
+
+```go
+acc, err := oauthServer.AcceptForwardedIDToken(r.Context(), bearerToken)
+if err != nil {
+    if errors.Is(err, server.ErrTrustedAudienceMismatch) {
+        // Audience is not in TrustedAudiences → 401.
+    }
+    // Other errors (sig_invalid, iss_mismatch, expired, no_jwks, parse_error) → 401.
+    http.Error(w, "unauthorized", http.StatusUnauthorized)
+    return
+}
+
+// acc.SessionID is "ext-<hex16>", deterministic from the token.
+// acc.Subject is the validated `sub` claim.
+// acc.UserInfo.TokenSource == providers.TokenSourceSSO.
+// acc.ExpiresAt matches the JWT exp — the library does NOT refresh forwarded tokens.
+```
+
+### What it does NOT do
+
+- **Does not fire `SessionCreationHandler`.** That handler is gated on `RefreshTokenFamilyStore` and the authorization-code family lifecycle. Forwarded tokens have neither. Callers that want a "first time we've seen this session" hook should build that on top with their own seen-set keyed on `acc.SessionID` and TTL bounded by `acc.ExpiresAt`.
+- **Does not mirror the token into `TokenStore`.** `TokenStore.SaveToken` is keyed by userID; two concurrent bridged sessions for the same user would overwrite each other. Aggregators that need to retrieve the forwarded token later (for example, to attach it to downstream MCP calls) must store it in their own structure.
+- **Does not refresh expired tokens.** When the JWT expires, validation fails and the caller must propagate 401 so the MCP client re-authenticates against the upstream IdP.
+
+### Aggregator fan-out
+
+When the caller is itself an aggregator (muster fanning out to mcp-prometheus, mcp-kubernetes, mcp-opsgenie) and forwards the same token to every downstream, each downstream independently calls `AcceptForwardedIDToken` and derives the **same** `SessionID`. That gives cross-hop audit-log correlation without coordination — see the session-ID section in [security.md](./security.md) for the correlation property, the `Config.SessionIDHMACKey` escape hatch for multi-tenant isolation, and the operator caveat around key agreement.
+
 ## References
 
 - [OpenID Connect Core 1.0 - Authentication Request](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
 - [OpenID Connect Core 1.0 - Authentication Error Response](https://openid.net/specs/openid-connect-core-1_0.html#AuthError)
 - [RFC 6749 - OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749)
+- [RFC 7517 - JSON Web Key (JWK)](https://datatracker.ietf.org/doc/html/rfc7517)
+- [RFC 8725 - JSON Web Token Best Current Practices](https://datatracker.ietf.org/doc/html/rfc8725)

--- a/examples/dex/main.go
+++ b/examples/dex/main.go
@@ -148,37 +148,40 @@ func main() {
 	// Demonstrates Server.AcceptForwardedIDToken. This endpoint does NOT use
 	// the ValidateToken middleware; it is the entry point aggregators and
 	// bridges use to accept a Dex-issued ID token directly rather than running
-	// their own auth-code flow. Requires TRUSTED_AUDIENCES to be set to match
-	// the audience the upstream IdP minted the token for.
-	mux.HandleFunc("/api/forwarded", func(w http.ResponseWriter, r *http.Request) {
-		bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
-		if bearer == "" || bearer == r.Header.Get("Authorization") {
-			http.Error(w, "missing Bearer token", http.StatusUnauthorized)
-			return
-		}
-
-		acc, err := server.AcceptForwardedIDToken(r.Context(), bearer)
-		if err != nil {
-			status := http.StatusUnauthorized
-			if errors.Is(err, oauth.ErrTrustedAudienceMismatch) {
-				log.Printf("forwarded token rejected: audience mismatch")
-			} else {
-				log.Printf("forwarded token rejected: %v", err)
+	// their own auth-code flow. Registered only when TRUSTED_AUDIENCES is set
+	// — without that, every call would fail with audience-mismatch and the
+	// endpoint would just be a noise source.
+	if len(trustedAudiences) > 0 {
+		mux.HandleFunc("/api/forwarded", func(w http.ResponseWriter, r *http.Request) {
+			bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+			if bearer == "" || bearer == r.Header.Get("Authorization") {
+				http.Error(w, "missing Bearer token", http.StatusUnauthorized)
+				return
 			}
-			http.Error(w, err.Error(), status)
-			return
-		}
 
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"message":    "forwarded token accepted",
-			"session_id": acc.SessionID,
-			"subject":    acc.Subject,
-			"issuer":     acc.Issuer,
-			"audience":   acc.Audience,
-			"expires_at": acc.ExpiresAt,
+			acc, err := server.AcceptForwardedIDToken(r.Context(), bearer)
+			if err != nil {
+				status := http.StatusUnauthorized
+				if errors.Is(err, oauth.ErrTrustedAudienceMismatch) {
+					log.Printf("forwarded token rejected: audience mismatch")
+				} else {
+					log.Printf("forwarded token rejected: %v", err)
+				}
+				http.Error(w, err.Error(), status)
+				return
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"message":    "forwarded token accepted",
+				"session_id": acc.SessionID,
+				"subject":    acc.Subject,
+				"issuer":     acc.Issuer,
+				"audience":   acc.Audience,
+				"expires_at": acc.ExpiresAt,
+			})
 		})
-	})
+	}
 
 	// Home page with login link
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {

--- a/examples/dex/main.go
+++ b/examples/dex/main.go
@@ -7,11 +7,13 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	oauth "github.com/giantswarm/mcp-oauth"
@@ -66,6 +68,11 @@ func main() {
 		Level: slog.LevelInfo,
 	}))
 
+	// Optional: audiences this server accepts in forwarded ID tokens. Typical
+	// values are the upstream aggregator or bridge that fronts this server
+	// (e.g. "muster-client", "agentcore-runtime"). Comma-separated.
+	trustedAudiences := splitCSV(os.Getenv("TRUSTED_AUDIENCES"))
+
 	// Create OAuth server
 	server, err := oauth.NewServer(
 		dexProvider,
@@ -75,6 +82,7 @@ func main() {
 		&oauth.ServerConfig{
 			Issuer:            "http://localhost:8080",
 			AllowInsecureHTTP: true, // Required for HTTP on localhost (development only)
+			TrustedAudiences:  trustedAudiences,
 		},
 		logger,
 	)
@@ -136,6 +144,41 @@ func main() {
 
 	// Wrap with ValidateToken middleware
 	mux.Handle("/api/resource", handler.ValidateToken(resourceHandler))
+
+	// Demonstrates Server.AcceptForwardedIDToken. This endpoint does NOT use
+	// the ValidateToken middleware; it is the entry point aggregators and
+	// bridges use to accept a Dex-issued ID token directly rather than running
+	// their own auth-code flow. Requires TRUSTED_AUDIENCES to be set to match
+	// the audience the upstream IdP minted the token for.
+	mux.HandleFunc("/api/forwarded", func(w http.ResponseWriter, r *http.Request) {
+		bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		if bearer == "" || bearer == r.Header.Get("Authorization") {
+			http.Error(w, "missing Bearer token", http.StatusUnauthorized)
+			return
+		}
+
+		acc, err := server.AcceptForwardedIDToken(r.Context(), bearer)
+		if err != nil {
+			status := http.StatusUnauthorized
+			if errors.Is(err, oauth.ErrTrustedAudienceMismatch) {
+				log.Printf("forwarded token rejected: audience mismatch")
+			} else {
+				log.Printf("forwarded token rejected: %v", err)
+			}
+			http.Error(w, err.Error(), status)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"message":    "forwarded token accepted",
+			"session_id": acc.SessionID,
+			"subject":    acc.Subject,
+			"issuer":     acc.Issuer,
+			"audience":   acc.Audience,
+			"expires_at": acc.ExpiresAt,
+		})
+	})
 
 	// Home page with login link
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
@@ -200,7 +243,25 @@ func main() {
 	addr := ":8080"
 	log.Printf("Starting server on http://localhost%s", addr)
 	log.Printf("Visit http://localhost%s to sign in with Dex", addr)
+	if len(trustedAudiences) > 0 {
+		log.Printf("Forwarded-ID-token acceptance enabled (TrustedAudiences: %v); POST a Dex-issued JWT as Bearer to /api/forwarded", trustedAudiences)
+	}
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
+}
+
+// splitCSV trims and drops empty entries from a comma-separated list.
+func splitCSV(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }

--- a/instrumentation/metrics.go
+++ b/instrumentation/metrics.go
@@ -341,27 +341,35 @@ func (m *Metrics) RecordLegacyRefreshTokenRejected(ctx context.Context) {
 	m.LegacyRefreshTokenRejected.Add(ctx, 1)
 }
 
-// Forwarded-ID-token result enum. Keep this bounded; never pass raw error strings
-// into RecordForwardedIDTokenAccepted as the `result` — label cardinality matters.
+// ForwardedIDTokenResult is the bounded result enum for the
+// oauth.forwarded_id_token.accepted_total counter. Declared as a typed string
+// so the compiler enforces the closed set — callers cannot pass raw error
+// strings (label cardinality matters).
+type ForwardedIDTokenResult string
+
 const (
-	ForwardedIDTokenResultOK            = "ok"
-	ForwardedIDTokenResultAudMismatch   = "aud_mismatch"
-	ForwardedIDTokenResultIssMismatch   = "iss_mismatch"
-	ForwardedIDTokenResultSigInvalid    = "sig_invalid"
-	ForwardedIDTokenResultExpired       = "expired"
-	ForwardedIDTokenResultNoJWKS        = "no_jwks"
-	ForwardedIDTokenResultParseError    = "parse_error"
+	ForwardedIDTokenResultOK          ForwardedIDTokenResult = "ok"
+	ForwardedIDTokenResultAudMismatch ForwardedIDTokenResult = "aud_mismatch"
+	ForwardedIDTokenResultIssMismatch ForwardedIDTokenResult = "iss_mismatch"
+	ForwardedIDTokenResultSigInvalid  ForwardedIDTokenResult = "sig_invalid"
+	ForwardedIDTokenResultExpired     ForwardedIDTokenResult = "expired"
+	ForwardedIDTokenResultNotYetValid ForwardedIDTokenResult = "not_yet_valid"
+	ForwardedIDTokenResultNoJWKS      ForwardedIDTokenResult = "no_jwks"
+	ForwardedIDTokenResultParseError  ForwardedIDTokenResult = "parse_error"
 )
 
 // RecordForwardedIDTokenAccepted records a forwarded ID token acceptance attempt.
-// The `result` argument MUST be one of the ForwardedIDTokenResult* constants.
-// For the unmatched-audience cases, pass the empty string as `audience` rather
-// than a token-derived value to keep label cardinality bounded.
-func (m *Metrics) RecordForwardedIDTokenAccepted(ctx context.Context, issuer, audience, result string) {
+// `provider` is the provider name (e.g. "dex", "google") so the metric is
+// self-describing without consumers having to cross-reference server config.
+// For unmatched-audience / parse-error / no-jwks cases, pass the empty string
+// as `audience` rather than a token-derived value to keep cardinality bounded.
+// Threads ctx through so OTel trace/baggage correlation survives on the metric.
+func (m *Metrics) RecordForwardedIDTokenAccepted(ctx context.Context, provider, issuer, audience string, result ForwardedIDTokenResult) {
 	attrs := []attribute.KeyValue{
+		attribute.String(metricAttrProvider, provider),
 		attribute.String(metricAttrIssuer, issuer),
 		attribute.String(metricAttrAudience, audience),
-		attribute.String(metricAttrResult, result),
+		attribute.String(metricAttrResult, string(result)),
 	}
 	m.ForwardedIDTokenAccepted.Add(ctx, 1, metric.WithAttributes(attrs...))
 }

--- a/instrumentation/metrics.go
+++ b/instrumentation/metrics.go
@@ -196,7 +196,7 @@ func newMetrics(inst *Instrumentation) (*Metrics, error) {
 	m.TokenReuseDetected = b.counter(securityMeter, "oauth.token.reuse_detected", "Number of token reuse attempts detected", "{attempt}")
 	m.RedirectURISecurityRejected = b.counter(securityMeter, "oauth.redirect_uri.security_rejected", "Number of redirect URI validation failures (SSRF/XSS protection)", "{rejection}")
 	m.LegacyRefreshTokenRejected = b.counter(securityMeter, "oauth.refresh_token.legacy_rejected", "Number of legacy refresh tokens rejected due to missing client binding (OAuth 2.1 compliance)", "{token}")
-	m.ForwardedIDTokenAccepted = b.counter(securityMeter, "oauth.forwarded_id_token.accepted_total", "Number of forwarded ID token acceptance attempts (labels: issuer, audience, result — result is a bounded enum: ok|aud_mismatch|iss_mismatch|sig_invalid|expired|no_jwks|parse_error)", "{attempt}")
+	m.ForwardedIDTokenAccepted = b.counter(securityMeter, "oauth.forwarded_id_token.accepted_total", "Number of forwarded ID token acceptance attempts (labels: issuer, audience, result — result is a bounded enum: ok|aud_mismatch|iss_mismatch|sig_invalid|expired|not_yet_valid|no_jwks|parse_error)", "{attempt}")
 
 	// Storage Metrics
 	m.StorageOperationTotal = b.counter(storageMeter, "storage.operation.total", "Total number of storage operations", "{operation}")

--- a/instrumentation/metrics.go
+++ b/instrumentation/metrics.go
@@ -35,6 +35,10 @@ const (
 	metricAttrProvider  = "provider"
 	metricAttrErrorType = "error_type"
 
+	// Forwarded-ID-token attributes
+	metricAttrIssuer   = "issuer"
+	metricAttrAudience = "audience"
+
 	// Audit attributes
 	metricAttrEventType = "event_type"
 )
@@ -60,6 +64,7 @@ type Metrics struct {
 	TokenReuseDetected          metric.Int64Counter
 	RedirectURISecurityRejected metric.Int64Counter // Redirect URI validation failures by category
 	LegacyRefreshTokenRejected  metric.Int64Counter // Legacy refresh tokens rejected (missing client binding)
+	ForwardedIDTokenAccepted    metric.Int64Counter // Forwarded ID token acceptance attempts (labels: issuer, audience, result)
 
 	// Storage Metrics
 	StorageOperationTotal    metric.Int64Counter
@@ -191,6 +196,7 @@ func newMetrics(inst *Instrumentation) (*Metrics, error) {
 	m.TokenReuseDetected = b.counter(securityMeter, "oauth.token.reuse_detected", "Number of token reuse attempts detected", "{attempt}")
 	m.RedirectURISecurityRejected = b.counter(securityMeter, "oauth.redirect_uri.security_rejected", "Number of redirect URI validation failures (SSRF/XSS protection)", "{rejection}")
 	m.LegacyRefreshTokenRejected = b.counter(securityMeter, "oauth.refresh_token.legacy_rejected", "Number of legacy refresh tokens rejected due to missing client binding (OAuth 2.1 compliance)", "{token}")
+	m.ForwardedIDTokenAccepted = b.counter(securityMeter, "oauth.forwarded_id_token.accepted_total", "Number of forwarded ID token acceptance attempts (labels: issuer, audience, result — result is a bounded enum: ok|aud_mismatch|iss_mismatch|sig_invalid|expired|no_jwks|parse_error)", "{attempt}")
 
 	// Storage Metrics
 	m.StorageOperationTotal = b.counter(storageMeter, "storage.operation.total", "Total number of storage operations", "{operation}")
@@ -333,6 +339,31 @@ func (m *Metrics) RecordTokenReuseDetected(ctx context.Context) {
 // This metric tracks rejected tokens for observability and security monitoring.
 func (m *Metrics) RecordLegacyRefreshTokenRejected(ctx context.Context) {
 	m.LegacyRefreshTokenRejected.Add(ctx, 1)
+}
+
+// Forwarded-ID-token result enum. Keep this bounded; never pass raw error strings
+// into RecordForwardedIDTokenAccepted as the `result` — label cardinality matters.
+const (
+	ForwardedIDTokenResultOK            = "ok"
+	ForwardedIDTokenResultAudMismatch   = "aud_mismatch"
+	ForwardedIDTokenResultIssMismatch   = "iss_mismatch"
+	ForwardedIDTokenResultSigInvalid    = "sig_invalid"
+	ForwardedIDTokenResultExpired       = "expired"
+	ForwardedIDTokenResultNoJWKS        = "no_jwks"
+	ForwardedIDTokenResultParseError    = "parse_error"
+)
+
+// RecordForwardedIDTokenAccepted records a forwarded ID token acceptance attempt.
+// The `result` argument MUST be one of the ForwardedIDTokenResult* constants.
+// For the unmatched-audience cases, pass the empty string as `audience` rather
+// than a token-derived value to keep label cardinality bounded.
+func (m *Metrics) RecordForwardedIDTokenAccepted(ctx context.Context, issuer, audience, result string) {
+	attrs := []attribute.KeyValue{
+		attribute.String(metricAttrIssuer, issuer),
+		attribute.String(metricAttrAudience, audience),
+		attribute.String(metricAttrResult, result),
+	}
+	m.ForwardedIDTokenAccepted.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // RecordRedirectURISecurityRejected records a redirect URI security validation failure.

--- a/providers/issuer.go
+++ b/providers/issuer.go
@@ -1,0 +1,18 @@
+package providers
+
+// IssuerOf returns the upstream OIDC issuer URL for a provider that implements
+// JWKSProvider, or "" otherwise.
+//
+// Not every Provider is an OIDC provider. GitHub's provider is OAuth 2.0 only —
+// it has no OIDC issuer and no JWKS — so IssuerOf returns "" for it, which is
+// the correct answer rather than a failure mode.
+//
+// Callers that require an issuer (for example, forwarded-ID-token validation)
+// should check for a non-empty return value and reject the request with a clear
+// error when it is empty.
+func IssuerOf(p Provider) string {
+	if j, ok := p.(JWKSProvider); ok {
+		return j.IssuerURL()
+	}
+	return ""
+}

--- a/providers/issuer_test.go
+++ b/providers/issuer_test.go
@@ -1,0 +1,77 @@
+package providers_test
+
+import (
+	"context"
+	"testing"
+
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/providers"
+)
+
+// jwksProviderStub satisfies both Provider and JWKSProvider, with a fixed
+// issuer URL used to assert IssuerOf's happy path.
+type jwksProviderStub struct {
+	issuer string
+}
+
+func (p *jwksProviderStub) Name() string            { return "stub-jwks" }
+func (p *jwksProviderStub) DefaultScopes() []string { return nil }
+func (p *jwksProviderStub) AuthorizationURL(string, string, string, []string, *providers.AuthorizationURLOptions) string {
+	return ""
+}
+func (p *jwksProviderStub) ExchangeCode(context.Context, string, string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (p *jwksProviderStub) ValidateToken(context.Context, string) (*providers.UserInfo, error) {
+	return nil, nil
+}
+func (p *jwksProviderStub) RefreshToken(context.Context, string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (p *jwksProviderStub) RevokeToken(context.Context, string) error { return nil }
+func (p *jwksProviderStub) HealthCheck(context.Context) error         { return nil }
+func (p *jwksProviderStub) JWKSURI(context.Context) (string, error)   { return "https://jwks.example/keys", nil }
+func (p *jwksProviderStub) IssuerURL() string                         { return p.issuer }
+
+// oauthOnlyStub is a Provider that deliberately does NOT implement
+// JWKSProvider — the case IssuerOf must return "" for (e.g. the in-tree
+// GitHub provider, which is OAuth 2.0 only).
+type oauthOnlyStub struct{}
+
+func (p *oauthOnlyStub) Name() string            { return "stub-oauth-only" }
+func (p *oauthOnlyStub) DefaultScopes() []string { return nil }
+func (p *oauthOnlyStub) AuthorizationURL(string, string, string, []string, *providers.AuthorizationURLOptions) string {
+	return ""
+}
+func (p *oauthOnlyStub) ExchangeCode(context.Context, string, string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (p *oauthOnlyStub) ValidateToken(context.Context, string) (*providers.UserInfo, error) {
+	return nil, nil
+}
+func (p *oauthOnlyStub) RefreshToken(context.Context, string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (p *oauthOnlyStub) RevokeToken(context.Context, string) error { return nil }
+func (p *oauthOnlyStub) HealthCheck(context.Context) error         { return nil }
+
+func TestIssuerOf(t *testing.T) {
+	cases := []struct {
+		name string
+		p    providers.Provider
+		want string
+	}{
+		{"nil provider", nil, ""},
+		{"jwks-capable", &jwksProviderStub{issuer: "https://auth.example"}, "https://auth.example"},
+		{"jwks-capable-empty-issuer", &jwksProviderStub{issuer: ""}, ""},
+		{"oauth-only", &oauthOnlyStub{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := providers.IssuerOf(tc.p); got != tc.want {
+				t.Errorf("IssuerOf = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -571,13 +572,20 @@ func createKeyFunc(jwks *JWKS) jwt.Keyfunc {
 	}
 }
 
+// ErrIssuerMismatch is returned (wrapped) when a JWT's iss claim does not match
+// the expected issuer. Callers that need to distinguish issuer mismatch from
+// other validation failures (for audit classification, metric labeling, etc.)
+// should use errors.Is against this sentinel rather than string-matching the
+// message.
+var ErrIssuerMismatch = errors.New("issuer mismatch")
+
 // validateIssuer checks the token issuer matches the expected issuer.
 func validateIssuer(claims *IDTokenClaims, expectedIssuer string) error {
 	if expectedIssuer == "" {
 		return nil
 	}
 	if claims.Issuer != expectedIssuer {
-		return fmt.Errorf("issuer mismatch: got %q, expected %q", claims.Issuer, expectedIssuer)
+		return fmt.Errorf("%w: got %q, expected %q", ErrIssuerMismatch, claims.Issuer, expectedIssuer)
 	}
 	return nil
 }

--- a/server.go
+++ b/server.go
@@ -20,6 +20,16 @@ type ServerConfig = server.Config
 // Use server.InstrumentationConfig for new code.
 type InstrumentationConfig = server.InstrumentationConfig
 
+// ForwardedIDTokenAcceptance is re-exported from the server package for
+// consumers that want to call Server.AcceptForwardedIDToken via the top-level
+// alias without importing the server package directly.
+type ForwardedIDTokenAcceptance = server.ForwardedIDTokenAcceptance
+
+// ErrTrustedAudienceMismatch is re-exported from the server package for the
+// same reason — callers typically compare with errors.Is to decide whether
+// to respond 401.
+var ErrTrustedAudienceMismatch = server.ErrTrustedAudienceMismatch
+
 // NewServer creates a new OAuth server.
 // This is a convenience wrapper for server.New() to maintain backward compatibility.
 func NewServer(

--- a/server/config.go
+++ b/server/config.go
@@ -618,11 +618,16 @@ type Config struct {
 	// SessionIDHMACKey optionally replaces the default SHA-256 session-ID derivation
 	// in Server.AcceptForwardedIDToken with HMAC-SHA-256 keyed by this value.
 	//
-	// Default (nil/empty): session ID is "ext-" + hex(sha256(token))[:16]. Deterministic
-	// across deployments receiving the same token, which gives cross-hop audit-log
-	// correlation when an aggregator (e.g. muster) fans a single forwarded token out to
-	// multiple downstream MCP servers. This is the intended behavior for single-tenant
-	// deployments.
+	// Session IDs have the form "ext-<16 hex chars>". The digest input is
+	// domain-separated with a versioned label so the key is safely reusable for
+	// other keyed derivations without cross-purpose collision risk; see the
+	// Server.AcceptForwardedIDToken godoc for the exact construction.
+	//
+	// Default (nil/empty): unkeyed SHA-256 over the domain-separated input.
+	// Deterministic across deployments receiving the same token — this gives
+	// cross-hop audit-log correlation when an aggregator (e.g. muster) fans a
+	// single forwarded token out to multiple downstream MCP servers. Intended
+	// for single-tenant deployments.
 	//
 	// Trade-off: anyone with audit-log access across two servers can link a user's
 	// sessions across them via the token hash. For multi-tenant isolation, set this key
@@ -633,6 +638,9 @@ type Config struct {
 	// the same key or all leave it empty. A single mismatched key silently breaks
 	// correlation with no runtime error — the tokens still validate, the sessions just
 	// no longer line up across hops. The library cannot detect the mismatch.
+	//
+	// Recommended: 32 random bytes from crypto/rand, loaded from a secret
+	// manager or mounted file (not from an environment variable).
 	SessionIDHMACKey []byte
 
 	// EnableClientIDMetadataDocuments enables URL-based client_id support per MCP 2025-11-25

--- a/server/config.go
+++ b/server/config.go
@@ -615,6 +615,26 @@ type Config struct {
 	// Default: nil (only tokens for this server's ResourceIdentifier are accepted)
 	TrustedAudiences []string
 
+	// SessionIDHMACKey optionally replaces the default SHA-256 session-ID derivation
+	// in Server.AcceptForwardedIDToken with HMAC-SHA-256 keyed by this value.
+	//
+	// Default (nil/empty): session ID is "ext-" + hex(sha256(token))[:16]. Deterministic
+	// across deployments receiving the same token, which gives cross-hop audit-log
+	// correlation when an aggregator (e.g. muster) fans a single forwarded token out to
+	// multiple downstream MCP servers. This is the intended behavior for single-tenant
+	// deployments.
+	//
+	// Trade-off: anyone with audit-log access across two servers can link a user's
+	// sessions across them via the token hash. For multi-tenant isolation, set this key
+	// to a per-deployment secret — cross-hop correlation then holds only among servers
+	// sharing the same key.
+	//
+	// Operator caveat: every MCP server in a correlation set must either all configure
+	// the same key or all leave it empty. A single mismatched key silently breaks
+	// correlation with no runtime error — the tokens still validate, the sessions just
+	// no longer line up across hops. The library cannot detect the mismatch.
+	SessionIDHMACKey []byte
+
 	// EnableClientIDMetadataDocuments enables URL-based client_id support per MCP 2025-11-25
 	// When enabled, clients can use HTTPS URLs as client identifiers, and the authorization
 	// server will fetch client metadata from that URL following draft-ietf-oauth-client-id-metadata-document-00

--- a/server/flows_forwarded.go
+++ b/server/flows_forwarded.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -22,14 +21,41 @@ import (
 // Callers should typically respond with 401.
 var ErrTrustedAudienceMismatch = errors.New("forwarded ID token audience does not match TrustedAudiences")
 
+// errForwardedTokenParseFailed wraps the underlying parser error so
+// [classifyForwardedTokenError] can distinguish "not a JWT" from later
+// validation failures without a second parse.
+var errForwardedTokenParseFailed = errors.New("forwarded ID token parse failed")
+
+// Session-ID derivation: the library publishes a stable format for
+// ForwardedIDTokenAcceptance.SessionID so downstream servers receiving the
+// same token derive the same ID (cross-hop audit correlation). To keep the
+// key reusable for other purposes later, the input is domain-separated with
+// a versioned label.
+const (
+	// forwardedSessionIDLabel is the domain-separation label written BEFORE
+	// the bearer token bytes into both the SHA-256 and HMAC-SHA-256
+	// derivations. Versioned so a future format change can be distinguished.
+	forwardedSessionIDLabel = "mcp-oauth/v1/forwarded-session-id"
+
+	// sessionIDDigestBytes is the truncation length of the digest output
+	// (64 bits → 16 hex chars). Chosen for audit-log correlation, not as a
+	// security boundary: birthday collision is ~1-in-a-million at ~6.5k
+	// concurrent distinct tokens, which is comfortable for per-server active
+	// sessions. If a deployment needs stronger collision resistance, it
+	// should raise this and coordinate the change across all servers sharing
+	// SessionIDHMACKey.
+	sessionIDDigestBytes = 8
+)
+
 // ForwardedIDTokenAcceptance is the verified result of accepting a JWT forwarded
 // from a trusted upstream identity provider. It is returned by
 // [Server.AcceptForwardedIDToken] and is safe to use for downstream routing, session
 // keying, and audit-log correlation.
 type ForwardedIDTokenAcceptance struct {
-	// SessionID is a deterministic identifier derived from the bearer token:
-	//   default: "ext-" + hex(sha256(token))[:16]
-	//   with Config.SessionIDHMACKey set: "ext-" + hex(hmac-sha256(key, token))[:16]
+	// SessionID is a deterministic identifier of the form "ext-<16 hex chars>"
+	// derived from a domain-separated hash of the bearer token:
+	//   default: first sessionIDDigestBytes of sha256(forwardedSessionIDLabel || 0x00 || token)
+	//   with Config.SessionIDHMACKey set: same input, HMAC-SHA-256 with the key
 	//
 	// Two MCP servers receiving the same token compute the same SessionID, which
 	// gives cross-hop audit-log correlation when an aggregator fans a single
@@ -45,10 +71,14 @@ type ForwardedIDTokenAcceptance struct {
 	// has TokenSource = TokenSourceSSO.
 	UserInfo *providers.UserInfo
 
-	// Issuer is the validated `iss` claim from the JWT.
+	// Issuer is the validated `iss` claim from the JWT. Equals the configured
+	// provider's IssuerURL() — the signature check enforces that equality, so
+	// this field never carries an unverified value.
 	Issuer string
 
-	// Audience is the entry of Config.TrustedAudiences that matched the token's `aud`.
+	// Audience is the entry of Config.TrustedAudiences that matched the token's
+	// `aud` claim (not the raw aud claim itself, which may contain multiple
+	// values). Suitable for metric labels and audit records.
 	Audience string
 
 	// ExpiresAt is the JWT `exp` claim, for caller-side session-cache TTLs. The
@@ -96,38 +126,40 @@ type ForwardedIDTokenAcceptance struct {
 //
 // Returns [ErrTrustedAudienceMismatch] when the token's `aud` does not match any
 // entry in Config.TrustedAudiences. Other errors (signature invalid, issuer
-// mismatch, JWT expired, provider has no JWKS, parse error) are returned wrapped.
+// mismatch, JWT expired, JWT not yet valid, provider has no JWKS, parse error)
+// are returned wrapped.
 func (s *Server) AcceptForwardedIDToken(ctx context.Context, bearerToken string) (*ForwardedIDTokenAcceptance, error) {
-	// Early parse-shape check to distinguish parse_error from later failure modes
-	// in the metric. validateAndParseForwardedIDToken handles the real parse too.
-	if _, err := oidc.ParseUnverifiedClaims(bearerToken); err != nil {
-		s.recordForwardedIDTokenAccepted("", "", instrumentation.ForwardedIDTokenResultParseError)
-		return nil, fmt.Errorf("parse JWT: %w", err)
+	providerName := s.provider.Name()
+
+	if bearerToken == "" {
+		err := errors.New("forwarded ID token must not be empty")
+		s.recordForwardedIDTokenAccepted(ctx, providerName, "", "", instrumentation.ForwardedIDTokenResultParseError)
+		return nil, err
 	}
 
-	// Check JWKSProvider up front so the no_jwks classification is explicit and
-	// can't be swallowed into a generic sig_invalid downstream.
-	jwksProvider, ok := s.provider.(providers.JWKSProvider)
-	if !ok {
-		s.recordForwardedIDTokenAccepted("", "", instrumentation.ForwardedIDTokenResultNoJWKS)
-		return nil, fmt.Errorf("provider %s does not support JWKS validation (required for forwarded ID token acceptance)", s.provider.Name())
+	// Fail fast when the provider cannot verify JWTs. Using providers.IssuerOf
+	// both matches the sibling fast-path's intent and exercises the in-tree
+	// helper (instead of re-doing a type assertion here).
+	expectedIssuer := providers.IssuerOf(s.provider)
+	if expectedIssuer == "" {
+		s.recordForwardedIDTokenAccepted(ctx, providerName, "", "", instrumentation.ForwardedIDTokenResultNoJWKS)
+		return nil, fmt.Errorf("provider %s does not support JWKS validation (required for forwarded ID token acceptance)", providerName)
 	}
 
 	claims, matchedAudience, err := s.validateAndParseForwardedIDToken(ctx, bearerToken)
 	if err != nil {
-		s.recordForwardedIDTokenAccepted(jwksProvider.IssuerURL(), "", classifyValidationError(err))
+		s.recordForwardedIDTokenAccepted(ctx, providerName, expectedIssuer, "", classifyForwardedTokenError(err))
 		return nil, err
 	}
 	if claims == nil {
 		// No trusted audience matched — the caller asked us to accept a forwarded
 		// token, so an audience mismatch is a hard error here (unlike the
 		// ValidateToken fast-path which falls back to userinfo).
-		s.recordForwardedIDTokenAccepted(jwksProvider.IssuerURL(), "", instrumentation.ForwardedIDTokenResultAudMismatch)
+		s.recordForwardedIDTokenAccepted(ctx, providerName, expectedIssuer, "", instrumentation.ForwardedIDTokenResultAudMismatch)
 		return nil, ErrTrustedAudienceMismatch
 	}
 
 	userInfo := s.idTokenClaimsToUserInfo(claims)
-	issuer := claims.Issuer
 
 	var expiresAt time.Time
 	if claims.ExpiresAt != nil {
@@ -138,61 +170,69 @@ func (s *Server) AcceptForwardedIDToken(ctx context.Context, bearerToken string)
 		SessionID: s.deriveForwardedSessionID(bearerToken),
 		Subject:   claims.Subject,
 		UserInfo:  userInfo,
-		Issuer:    issuer,
+		Issuer:    claims.Issuer,
 		Audience:  matchedAudience,
 		ExpiresAt: expiresAt,
 	}
 
-	s.logForwardedIDTokenAccepted(bearerToken, matchedAudience, jwksProvider.IssuerURL(), userInfo)
-	s.recordForwardedIDTokenAccepted(issuer, matchedAudience, instrumentation.ForwardedIDTokenResultOK)
+	s.logForwardedIDTokenAccepted(bearerToken, matchedAudience, expectedIssuer, userInfo)
+	s.recordForwardedIDTokenAccepted(ctx, providerName, claims.Issuer, matchedAudience, instrumentation.ForwardedIDTokenResultOK)
 
 	return acceptance, nil
 }
 
-// deriveForwardedSessionID produces the deterministic "ext-<hex16>" session identifier.
-// Uses HMAC-SHA-256 when Config.SessionIDHMACKey is set, otherwise plain SHA-256.
-// See the Config.SessionIDHMACKey godoc and docs/security.md for the correlation
-// property and operator caveat.
+// deriveForwardedSessionID produces the deterministic "ext-<hex>" session
+// identifier. See the SessionID field godoc and docs/security.md for the
+// correlation property and the SessionIDHMACKey operator caveat.
+//
+// The input is domain-separated so Config.SessionIDHMACKey can be safely reused
+// for other keyed derivations without risking cross-purpose collisions.
+// hash.Hash.Write never returns an error — the doc on hash.Hash guarantees it —
+// so the results are ignored.
 func (s *Server) deriveForwardedSessionID(bearerToken string) string {
 	var digest []byte
 	if len(s.Config.SessionIDHMACKey) > 0 {
 		mac := hmac.New(sha256.New, s.Config.SessionIDHMACKey)
+		_, _ = mac.Write([]byte(forwardedSessionIDLabel))
+		_, _ = mac.Write([]byte{0x00})
 		_, _ = mac.Write([]byte(bearerToken))
 		digest = mac.Sum(nil)
 	} else {
-		sum := sha256.Sum256([]byte(bearerToken))
-		digest = sum[:]
+		h := sha256.New()
+		_, _ = h.Write([]byte(forwardedSessionIDLabel))
+		_, _ = h.Write([]byte{0x00})
+		_, _ = h.Write([]byte(bearerToken))
+		digest = h.Sum(nil)
 	}
-	return "ext-" + hex.EncodeToString(digest[:8])
+	return "ext-" + hex.EncodeToString(digest[:sessionIDDigestBytes])
 }
 
 // recordForwardedIDTokenAccepted emits the forwarded-ID-token metric. Safe when
-// Instrumentation is unconfigured. `result` MUST be one of the
-// instrumentation.ForwardedIDTokenResult* constants.
-func (s *Server) recordForwardedIDTokenAccepted(issuer, audience, result string) {
+// Instrumentation is unconfigured. Threads ctx through so OTel trace correlation
+// survives on the metric.
+func (s *Server) recordForwardedIDTokenAccepted(ctx context.Context, provider, issuer, audience string, result instrumentation.ForwardedIDTokenResult) {
 	if s.Instrumentation == nil {
 		return
 	}
-	s.Instrumentation.Metrics().RecordForwardedIDTokenAccepted(context.Background(), issuer, audience, result)
+	s.Instrumentation.Metrics().RecordForwardedIDTokenAccepted(ctx, provider, issuer, audience, result)
 }
 
-// classifyValidationError maps an error from validateAndParseForwardedIDToken to
-// one of the bounded result-enum values. Never returns raw error strings — label
-// cardinality matters.
-func classifyValidationError(err error) string {
-	if err == nil {
+// classifyForwardedTokenError maps an error from the validator to one of the
+// bounded result-enum values. Uses errors.Is sentinels throughout — no string
+// matching — so the mapping survives upstream message tweaks.
+func classifyForwardedTokenError(err error) instrumentation.ForwardedIDTokenResult {
+	switch {
+	case err == nil:
 		return instrumentation.ForwardedIDTokenResultOK
-	}
-	if errors.Is(err, jwt.ErrTokenExpired) {
+	case errors.Is(err, errForwardedTokenParseFailed):
+		return instrumentation.ForwardedIDTokenResultParseError
+	case errors.Is(err, oidc.ErrIssuerMismatch):
+		return instrumentation.ForwardedIDTokenResultIssMismatch
+	case errors.Is(err, jwt.ErrTokenExpired):
 		return instrumentation.ForwardedIDTokenResultExpired
-	}
-	if errors.Is(err, jwt.ErrTokenNotValidYet) {
+	case errors.Is(err, jwt.ErrTokenNotValidYet):
+		return instrumentation.ForwardedIDTokenResultNotYetValid
+	default:
 		return instrumentation.ForwardedIDTokenResultSigInvalid
 	}
-	// validateIssuer in providers/oidc/jwt.go:575 returns a formatted error without
-	// a sentinel; a substring match keeps this classification deterministic.
-	if msg := err.Error(); strings.Contains(msg, "issuer mismatch") {
-		return instrumentation.ForwardedIDTokenResultIssMismatch
-	}
-	return instrumentation.ForwardedIDTokenResultSigInvalid
 }

--- a/server/flows_forwarded.go
+++ b/server/flows_forwarded.go
@@ -61,6 +61,14 @@ type ForwardedIDTokenAcceptance struct {
 	// gives cross-hop audit-log correlation when an aggregator fans a single
 	// forwarded token out to multiple downstream servers. See Config.SessionIDHMACKey
 	// for the isolation escape hatch and the operator caveat around key agreement.
+	//
+	// Scope: this is a correlation identifier for logs, metrics, and session
+	// caches — not a security boundary. The 64-bit truncation is sized for
+	// audit correlation, not collision resistance under adversarial input.
+	// Do not use SessionID as an authorization key, capability handle, or any
+	// identifier whose uniqueness a security decision depends on; the Subject
+	// field (or a store keyed on verified claims) is the correct source for
+	// authorization decisions.
 	SessionID string
 
 	// Subject is the validated `sub` claim from the JWT. It equals UserInfo.ID and
@@ -215,6 +223,31 @@ func (s *Server) recordForwardedIDTokenAccepted(ctx context.Context, provider, i
 		return
 	}
 	s.Instrumentation.Metrics().RecordForwardedIDTokenAccepted(ctx, provider, issuer, audience, result)
+}
+
+// logForwardedSessionIDKeyFingerprint emits a one-shot startup log line when
+// Config.SessionIDHMACKey is configured, carrying a non-reversible fingerprint
+// of the key (SHA-256 of the key, truncated to 16 hex chars) plus the raw key
+// length.
+//
+// Motivation: a mismatched SessionIDHMACKey across a correlation set silently
+// breaks cross-hop session-ID correlation with no runtime error — the library
+// cannot detect the mismatch. Logging a fingerprint lets operators verify key
+// agreement across deployments by grepping logs, without ever exposing the key
+// itself. The fingerprint uses the full SHA-256 (not HMAC over the key with
+// itself, and not the key directly) truncated to 16 hex chars — sufficient
+// to catch accidental mismatches, one-way so the key cannot be recovered.
+//
+// Safe to call when SessionIDHMACKey is empty (it becomes a no-op).
+func (s *Server) logForwardedSessionIDKeyFingerprint() {
+	if len(s.Config.SessionIDHMACKey) == 0 {
+		return
+	}
+	sum := sha256.Sum256(s.Config.SessionIDHMACKey)
+	s.Logger.Info("Forwarded-ID-token session correlation: SessionIDHMACKey is configured",
+		"key_fingerprint", hex.EncodeToString(sum[:8]),
+		"key_bytes", len(s.Config.SessionIDHMACKey),
+		"purpose", "All MCP servers in a correlation set must report the same key_fingerprint; a mismatch silently breaks cross-hop session-ID correlation")
 }
 
 // classifyForwardedTokenError maps an error from the validator to one of the

--- a/server/flows_forwarded.go
+++ b/server/flows_forwarded.go
@@ -1,0 +1,198 @@
+package server
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/giantswarm/mcp-oauth/instrumentation"
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+)
+
+// ErrTrustedAudienceMismatch is returned by [Server.AcceptForwardedIDToken] when the
+// bearer token's `aud` claim does not match any entry in Config.TrustedAudiences.
+// Callers should typically respond with 401.
+var ErrTrustedAudienceMismatch = errors.New("forwarded ID token audience does not match TrustedAudiences")
+
+// ForwardedIDTokenAcceptance is the verified result of accepting a JWT forwarded
+// from a trusted upstream identity provider. It is returned by
+// [Server.AcceptForwardedIDToken] and is safe to use for downstream routing, session
+// keying, and audit-log correlation.
+type ForwardedIDTokenAcceptance struct {
+	// SessionID is a deterministic identifier derived from the bearer token:
+	//   default: "ext-" + hex(sha256(token))[:16]
+	//   with Config.SessionIDHMACKey set: "ext-" + hex(hmac-sha256(key, token))[:16]
+	//
+	// Two MCP servers receiving the same token compute the same SessionID, which
+	// gives cross-hop audit-log correlation when an aggregator fans a single
+	// forwarded token out to multiple downstream servers. See Config.SessionIDHMACKey
+	// for the isolation escape hatch and the operator caveat around key agreement.
+	SessionID string
+
+	// Subject is the validated `sub` claim from the JWT. It equals UserInfo.ID and
+	// is surfaced as a top-level field for callers that only need the subject.
+	Subject string
+
+	// UserInfo carries the other validated claims (email, name, groups, etc.) and
+	// has TokenSource = TokenSourceSSO.
+	UserInfo *providers.UserInfo
+
+	// Issuer is the validated `iss` claim from the JWT.
+	Issuer string
+
+	// Audience is the entry of Config.TrustedAudiences that matched the token's `aud`.
+	Audience string
+
+	// ExpiresAt is the JWT `exp` claim, for caller-side session-cache TTLs. The
+	// library does not refresh forwarded tokens — when a token expires, the caller
+	// must propagate 401 so the MCP client re-authenticates.
+	ExpiresAt time.Time
+}
+
+// AcceptForwardedIDToken validates a JWT forwarded from a trusted upstream identity
+// provider and returns its verified claims plus a deterministic session identifier.
+// It is the companion of the ValidateToken fast-path (server/flows.go:265) for the
+// direct "accept this forwarded token" use case exposed to aggregators and bridges
+// (e.g., Bedrock AgentCore → muster).
+//
+// Preconditions (documented here because operators configuring a new bridge look at
+// this godoc first):
+//
+//  1. The configured provider implements [providers.JWKSProvider]. GitHub's provider
+//     does not qualify (it is OAuth 2.0 only). Validation returns a "no JWKS" error
+//     when invoked against an OAuth-only provider.
+//  2. Config.TrustedAudiences contains the audience the upstream IdP minted the
+//     token for.
+//  3. The provider's IssuerURL() matches the JWT's `iss` claim. The signature check
+//     requires this anyway.
+//
+// Scope (deliberate — pure function, no side effects):
+//
+//   - Does NOT fire SessionCreationHandler. That handler is gated on the
+//     RefreshTokenFamilyStore interface and the authorization-code family lifecycle,
+//     neither of which applies to forwarded tokens. Callers that want a first-seen
+//     hook for a given SessionID should build that on top using their own
+//     seen-set keyed on acceptance.SessionID with TTL bounded by acceptance.ExpiresAt.
+//
+//   - Does NOT mirror the token into TokenStore. TokenStore is keyed by userID and
+//     is owned by the authorization-code flow. Aggregators that need to retrieve
+//     the forwarded token later (e.g., to attach it to downstream MCP calls) must
+//     store it in a structure they own, keyed however they like.
+//
+// Idempotency: the function is pure. Repeat calls with the same token return the
+// same SessionID and emit the same audit event. Any "first call vs repeat"
+// semantics live with the caller.
+//
+// Token expiry: the library does not refresh forwarded tokens. When the JWT
+// expires, this function returns an error and the caller must propagate 401.
+//
+// Returns [ErrTrustedAudienceMismatch] when the token's `aud` does not match any
+// entry in Config.TrustedAudiences. Other errors (signature invalid, issuer
+// mismatch, JWT expired, provider has no JWKS, parse error) are returned wrapped.
+func (s *Server) AcceptForwardedIDToken(ctx context.Context, bearerToken string) (*ForwardedIDTokenAcceptance, error) {
+	// Early parse-shape check to distinguish parse_error from later failure modes
+	// in the metric. validateAndParseForwardedIDToken handles the real parse too.
+	if _, err := oidc.ParseUnverifiedClaims(bearerToken); err != nil {
+		s.recordForwardedIDTokenAccepted("", "", instrumentation.ForwardedIDTokenResultParseError)
+		return nil, fmt.Errorf("parse JWT: %w", err)
+	}
+
+	// Check JWKSProvider up front so the no_jwks classification is explicit and
+	// can't be swallowed into a generic sig_invalid downstream.
+	jwksProvider, ok := s.provider.(providers.JWKSProvider)
+	if !ok {
+		s.recordForwardedIDTokenAccepted("", "", instrumentation.ForwardedIDTokenResultNoJWKS)
+		return nil, fmt.Errorf("provider %s does not support JWKS validation (required for forwarded ID token acceptance)", s.provider.Name())
+	}
+
+	claims, matchedAudience, err := s.validateAndParseForwardedIDToken(ctx, bearerToken)
+	if err != nil {
+		s.recordForwardedIDTokenAccepted(jwksProvider.IssuerURL(), "", classifyValidationError(err))
+		return nil, err
+	}
+	if claims == nil {
+		// No trusted audience matched — the caller asked us to accept a forwarded
+		// token, so an audience mismatch is a hard error here (unlike the
+		// ValidateToken fast-path which falls back to userinfo).
+		s.recordForwardedIDTokenAccepted(jwksProvider.IssuerURL(), "", instrumentation.ForwardedIDTokenResultAudMismatch)
+		return nil, ErrTrustedAudienceMismatch
+	}
+
+	userInfo := s.idTokenClaimsToUserInfo(claims)
+	issuer := claims.Issuer
+
+	var expiresAt time.Time
+	if claims.ExpiresAt != nil {
+		expiresAt = claims.ExpiresAt.Time
+	}
+
+	acceptance := &ForwardedIDTokenAcceptance{
+		SessionID: s.deriveForwardedSessionID(bearerToken),
+		Subject:   claims.Subject,
+		UserInfo:  userInfo,
+		Issuer:    issuer,
+		Audience:  matchedAudience,
+		ExpiresAt: expiresAt,
+	}
+
+	s.logForwardedIDTokenAccepted(bearerToken, matchedAudience, jwksProvider.IssuerURL(), userInfo)
+	s.recordForwardedIDTokenAccepted(issuer, matchedAudience, instrumentation.ForwardedIDTokenResultOK)
+
+	return acceptance, nil
+}
+
+// deriveForwardedSessionID produces the deterministic "ext-<hex16>" session identifier.
+// Uses HMAC-SHA-256 when Config.SessionIDHMACKey is set, otherwise plain SHA-256.
+// See the Config.SessionIDHMACKey godoc and docs/security.md for the correlation
+// property and operator caveat.
+func (s *Server) deriveForwardedSessionID(bearerToken string) string {
+	var digest []byte
+	if len(s.Config.SessionIDHMACKey) > 0 {
+		mac := hmac.New(sha256.New, s.Config.SessionIDHMACKey)
+		_, _ = mac.Write([]byte(bearerToken))
+		digest = mac.Sum(nil)
+	} else {
+		sum := sha256.Sum256([]byte(bearerToken))
+		digest = sum[:]
+	}
+	return "ext-" + hex.EncodeToString(digest[:8])
+}
+
+// recordForwardedIDTokenAccepted emits the forwarded-ID-token metric. Safe when
+// Instrumentation is unconfigured. `result` MUST be one of the
+// instrumentation.ForwardedIDTokenResult* constants.
+func (s *Server) recordForwardedIDTokenAccepted(issuer, audience, result string) {
+	if s.Instrumentation == nil {
+		return
+	}
+	s.Instrumentation.Metrics().RecordForwardedIDTokenAccepted(context.Background(), issuer, audience, result)
+}
+
+// classifyValidationError maps an error from validateAndParseForwardedIDToken to
+// one of the bounded result-enum values. Never returns raw error strings — label
+// cardinality matters.
+func classifyValidationError(err error) string {
+	if err == nil {
+		return instrumentation.ForwardedIDTokenResultOK
+	}
+	if errors.Is(err, jwt.ErrTokenExpired) {
+		return instrumentation.ForwardedIDTokenResultExpired
+	}
+	if errors.Is(err, jwt.ErrTokenNotValidYet) {
+		return instrumentation.ForwardedIDTokenResultSigInvalid
+	}
+	// validateIssuer in providers/oidc/jwt.go:575 returns a formatted error without
+	// a sentinel; a substring match keeps this classification deterministic.
+	if msg := err.Error(); strings.Contains(msg, "issuer mismatch") {
+		return instrumentation.ForwardedIDTokenResultIssMismatch
+	}
+	return instrumentation.ForwardedIDTokenResultSigInvalid
+}

--- a/server/flows_forwarded_test.go
+++ b/server/flows_forwarded_test.go
@@ -225,8 +225,8 @@ func TestAcceptForwardedIDToken_IssuerMismatch(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for issuer mismatch, got nil")
 	}
-	if !strings.Contains(err.Error(), "issuer mismatch") {
-		t.Errorf("err = %v, want issuer-mismatch message", err)
+	if !errors.Is(err, oidc.ErrIssuerMismatch) {
+		t.Errorf("err = %v, want wrapped oidc.ErrIssuerMismatch", err)
 	}
 }
 

--- a/server/flows_forwarded_test.go
+++ b/server/flows_forwarded_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"math/big"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 
+	"github.com/giantswarm/mcp-oauth/instrumentation"
 	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/giantswarm/mcp-oauth/providers/mock"
 	"github.com/giantswarm/mcp-oauth/providers/oidc"
@@ -269,6 +271,9 @@ func TestAcceptForwardedIDToken_ExpiredJWT(t *testing.T) {
 func TestAcceptForwardedIDToken_NoJWKSProvider(t *testing.T) {
 	h := newForwardedTokenHarness(t)
 	// Replace the JWKSProvider-capable mock with a bare Provider implementation.
+	// Safe because the no-JWKS precondition runs BEFORE validateAndParseForwardedIDToken
+	// (which would dereference the JWKS client) — see AcceptForwardedIDToken for the
+	// check order.
 	h.srv.provider = &oauthOnlyProvider{name: "oauth-only"}
 
 	tok := h.signToken(t, h.validClaims())
@@ -281,33 +286,104 @@ func TestAcceptForwardedIDToken_NoJWKSProvider(t *testing.T) {
 	}
 }
 
+// TestAcceptForwardedIDToken_HMACKeyChangesSessionID feeds the SAME bearer token
+// to two servers — one unkeyed, one with SessionIDHMACKey set — and asserts the
+// derived session IDs differ. Earlier iteration of this test signed two
+// different tokens (one per harness) and compared their session IDs, which
+// trivially differed because the bearer-token bytes differed; it would have
+// passed even if the HMAC branch were deleted. Sharing the same provider
+// keypair across both servers isolates the HMAC key as the only variable.
 func TestAcceptForwardedIDToken_HMACKeyChangesSessionID(t *testing.T) {
-	tok := "" // set below once harness is built
-	h1 := newForwardedTokenHarness(t)
-	tok = h1.signToken(t, h1.validClaims())
+	h := newForwardedTokenHarness(t)
+	tok := h.signToken(t, h.validClaims())
 
-	a1, err := h1.srv.AcceptForwardedIDToken(context.Background(), tok)
+	// a1: unkeyed SHA-256 derivation.
+	a1, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
 	if err != nil {
-		t.Fatalf("default-key: %v", err)
+		t.Fatalf("unkeyed: %v", err)
 	}
 
-	// Second server with an HMAC key set; reuse the same provider/JWKS so the
-	// validation succeeds, just with a different session-ID derivation.
-	h2 := newForwardedTokenHarness(t, func(c *Config) {
-		c.SessionIDHMACKey = []byte("per-deployment-secret-key")
-	})
-	// Re-sign under h2's key so the signature validates against h2's JWKS.
-	tok2 := h2.signToken(t, h2.validClaims())
-	a2, err := h2.srv.AcceptForwardedIDToken(context.Background(), tok2)
+	// Build a second Server sharing the SAME provider/JWKS and validator
+	// state, differing ONLY in Config.SessionIDHMACKey. This exercises the
+	// HMAC branch of deriveForwardedSessionID. Can't shallow-copy *h.srv
+	// because the Server embeds sync primitives (singleflight.Group) that
+	// copylocks would flag; construct a sibling and wire only the fields
+	// AcceptForwardedIDToken reads.
+	cfg2 := *h.srv.Config
+	cfg2.SessionIDHMACKey = []byte("per-deployment-secret-key-32-byte")
+	srv2 := &Server{
+		Config:     &cfg2,
+		Logger:     h.srv.Logger,
+		provider:   h.srv.provider,
+		tokenStore: h.srv.tokenStore,
+		jwksClient: h.srv.jwksClient,
+	}
+	srv2.jwksClientOnce.Do(func() {}) // prevent re-init of jwksClient
+
+	a2, err := srv2.AcceptForwardedIDToken(context.Background(), tok)
 	if err != nil {
-		t.Fatalf("hmac-key: %v", err)
+		t.Fatalf("hmac-keyed: %v", err)
 	}
 
 	if a1.SessionID == a2.SessionID {
-		t.Errorf("SessionID should differ when HMAC key set: both = %q", a1.SessionID)
+		t.Errorf("SessionID should differ when HMAC key set (same token, only key changed): both = %q", a1.SessionID)
 	}
-	if !strings.HasPrefix(a2.SessionID, "ext-") {
-		t.Errorf("HMAC-derived SessionID missing ext- prefix: %q", a2.SessionID)
+	if !strings.HasPrefix(a1.SessionID, "ext-") || len(a1.SessionID) != len("ext-")+16 {
+		t.Errorf("unkeyed SessionID shape unexpected: %q", a1.SessionID)
+	}
+	if !strings.HasPrefix(a2.SessionID, "ext-") || len(a2.SessionID) != len("ext-")+16 {
+		t.Errorf("HMAC-derived SessionID shape unexpected: %q", a2.SessionID)
+	}
+
+	// Second call with the SAME key and SAME token must be deterministic.
+	a2Again, err := srv2.AcceptForwardedIDToken(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("hmac-keyed second call: %v", err)
+	}
+	if a2.SessionID != a2Again.SessionID {
+		t.Errorf("HMAC-keyed SessionID not deterministic across calls: %q vs %q", a2.SessionID, a2Again.SessionID)
+	}
+}
+
+// TestAcceptForwardedIDToken_EmptyBearer guards the explicit empty-token check
+// so callers get a clear error instead of a noisy parse_error metric on every
+// unauthenticated request.
+func TestAcceptForwardedIDToken_EmptyBearer(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	_, err := h.srv.AcceptForwardedIDToken(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty bearer token")
+	}
+	if !strings.Contains(err.Error(), "must not be empty") {
+		t.Errorf("err = %v, want 'must not be empty' message", err)
+	}
+}
+
+func TestClassifyForwardedTokenError(t *testing.T) {
+	// Wrap errForwardedTokenParseFailed the same way validateAndParseForwardedIDToken does.
+	parseWrapped := fmt.Errorf("%w: junk", errForwardedTokenParseFailed)
+	issuerWrapped := fmt.Errorf("ID token signature validation failed: %w: got \"x\", expected \"y\"", oidc.ErrIssuerMismatch)
+	expiredWrapped := fmt.Errorf("ID token signature validation failed: %w", jwt.ErrTokenExpired)
+	nbfWrapped := fmt.Errorf("ID token signature validation failed: %w", jwt.ErrTokenNotValidYet)
+
+	cases := []struct {
+		name string
+		err  error
+		want instrumentation.ForwardedIDTokenResult
+	}{
+		{"nil", nil, instrumentation.ForwardedIDTokenResultOK},
+		{"parse", parseWrapped, instrumentation.ForwardedIDTokenResultParseError},
+		{"issuer", issuerWrapped, instrumentation.ForwardedIDTokenResultIssMismatch},
+		{"expired", expiredWrapped, instrumentation.ForwardedIDTokenResultExpired},
+		{"nbf", nbfWrapped, instrumentation.ForwardedIDTokenResultNotYetValid},
+		{"default", errors.New("some other failure"), instrumentation.ForwardedIDTokenResultSigInvalid},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifyForwardedTokenError(tc.err); got != tc.want {
+				t.Errorf("classifyForwardedTokenError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/server/flows_forwarded_test.go
+++ b/server/flows_forwarded_test.go
@@ -1,0 +1,359 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+// forwardedTokenHarness is the fixture shared by the AcceptForwardedIDToken tests.
+// It spins up a TLS JWKS server, constructs a mock JWKSProvider pointing at it,
+// and returns a Server wired to issue signed ID tokens that validate against it.
+type forwardedTokenHarness struct {
+	srv        *Server
+	privateKey *rsa.PrivateKey
+	keyID      string
+	jwksServer *httptest.Server
+	issuer     string
+	audience   string
+	provider   *mock.Provider
+}
+
+func newForwardedTokenHarness(t *testing.T, opts ...func(*Config)) *forwardedTokenHarness {
+	t.Helper()
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+
+	const keyID = "test-key-1"
+	jwks := oidc.JWKS{
+		Keys: []oidc.JWK{{
+			Kty: "RSA",
+			Use: "sig",
+			Kid: keyID,
+			Alg: "RS256",
+			N:   base64.RawURLEncoding.EncodeToString(privateKey.N.Bytes()),
+			E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privateKey.E)).Bytes()),
+		}},
+	}
+
+	jwksServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(jwksServer.Close)
+
+	const (
+		issuer   = "https://auth.test.example"
+		audience = "forwarded-audience"
+	)
+
+	mockProvider := mock.NewProvider()
+	mockProvider.JWKSURIFunc = func(ctx context.Context) (string, error) {
+		return jwksServer.URL, nil
+	}
+	mockProvider.IssuerURLFunc = func() string {
+		return issuer
+	}
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	cfg := &Config{
+		Issuer:             issuer,
+		TrustedAudiences:   []string{audience},
+		AllowPrivateIPJWKS: true,
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	srv := &Server{
+		Config:     cfg,
+		Logger:     slog.Default(),
+		provider:   mockProvider,
+		tokenStore: store,
+	}
+
+	// Inject a JWKS client that trusts the test TLS server and permits loopback
+	// addresses. srv.getJWKSClient() uses sync.Once, so populate it first and
+	// consume the Once to prevent a real construction from replacing ours.
+	srv.jwksClient = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+		HTTPClient:     jwksServer.Client(),
+		AllowPrivateIP: true,
+		Logger:         slog.Default(),
+	})
+	srv.jwksClientOnce.Do(func() {})
+
+	return &forwardedTokenHarness{
+		srv:        srv,
+		privateKey: privateKey,
+		keyID:      keyID,
+		jwksServer: jwksServer,
+		issuer:     issuer,
+		audience:   audience,
+		provider:   mockProvider,
+	}
+}
+
+// signToken creates a valid RS256-signed JWT with the given registered claims.
+func (h *forwardedTokenHarness) signToken(t *testing.T, claims jwt.RegisteredClaims) string {
+	t.Helper()
+	idClaims := &oidc.IDTokenClaims{
+		RegisteredClaims: claims,
+		Email:            "user@test.example",
+		Name:             "Test User",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, idClaims)
+	token.Header["kid"] = h.keyID
+	signed, err := token.SignedString(h.privateKey)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+// validClaims returns a claims set that should pass all checks.
+func (h *forwardedTokenHarness) validClaims() jwt.RegisteredClaims {
+	now := time.Now()
+	return jwt.RegisteredClaims{
+		Subject:   "user-subject-123",
+		Issuer:    h.issuer,
+		Audience:  []string{h.audience},
+		IssuedAt:  jwt.NewNumericDate(now),
+		ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+	}
+}
+
+// ---- tests ------------------------------------------------------------------
+
+func TestAcceptForwardedIDToken_HappyPath(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	tok := h.signToken(t, h.validClaims())
+
+	acc, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("AcceptForwardedIDToken: %v", err)
+	}
+	if acc == nil {
+		t.Fatal("nil acceptance")
+	}
+	if acc.Subject != "user-subject-123" {
+		t.Errorf("Subject = %q, want user-subject-123", acc.Subject)
+	}
+	if acc.UserInfo == nil || acc.UserInfo.ID != "user-subject-123" {
+		t.Errorf("UserInfo.ID unexpected: %+v", acc.UserInfo)
+	}
+	if acc.UserInfo.TokenSource != providers.TokenSourceSSO {
+		t.Errorf("UserInfo.TokenSource = %q, want sso", acc.UserInfo.TokenSource)
+	}
+	if acc.Issuer != h.issuer {
+		t.Errorf("Issuer = %q, want %q", acc.Issuer, h.issuer)
+	}
+	if acc.Audience != h.audience {
+		t.Errorf("Audience = %q, want %q", acc.Audience, h.audience)
+	}
+	if !strings.HasPrefix(acc.SessionID, "ext-") || len(acc.SessionID) != len("ext-")+16 {
+		t.Errorf("SessionID = %q, want ext-<16 hex>", acc.SessionID)
+	}
+	if acc.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt should be populated from JWT exp")
+	}
+}
+
+func TestAcceptForwardedIDToken_Determinism(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	tok := h.signToken(t, h.validClaims())
+
+	ctx := context.Background()
+	a1, err := h.srv.AcceptForwardedIDToken(ctx, tok)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+	a2, err := h.srv.AcceptForwardedIDToken(ctx, tok)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if a1.SessionID != a2.SessionID {
+		t.Errorf("SessionID not deterministic: %q vs %q", a1.SessionID, a2.SessionID)
+	}
+}
+
+func TestAcceptForwardedIDToken_AudienceMismatch(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	claims := h.validClaims()
+	claims.Audience = []string{"some-other-audience"}
+	tok := h.signToken(t, claims)
+
+	_, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if !errors.Is(err, ErrTrustedAudienceMismatch) {
+		t.Fatalf("err = %v, want ErrTrustedAudienceMismatch", err)
+	}
+}
+
+func TestAcceptForwardedIDToken_IssuerMismatch(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	claims := h.validClaims()
+	claims.Issuer = "https://wrong.issuer.example"
+	tok := h.signToken(t, claims)
+
+	_, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if err == nil {
+		t.Fatal("expected error for issuer mismatch, got nil")
+	}
+	if !strings.Contains(err.Error(), "issuer mismatch") {
+		t.Errorf("err = %v, want issuer-mismatch message", err)
+	}
+}
+
+func TestAcceptForwardedIDToken_InvalidSignature(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	// Sign with a completely different key so the signature fails verification.
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	idClaims := &oidc.IDTokenClaims{RegisteredClaims: h.validClaims()}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, idClaims)
+	token.Header["kid"] = h.keyID
+	bad, err := token.SignedString(otherKey)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	_, err = h.srv.AcceptForwardedIDToken(context.Background(), bad)
+	if err == nil {
+		t.Fatal("expected signature error")
+	}
+	if errors.Is(err, ErrTrustedAudienceMismatch) {
+		t.Errorf("got audience-mismatch sentinel for signature failure: %v", err)
+	}
+}
+
+func TestAcceptForwardedIDToken_ExpiredJWT(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	claims := h.validClaims()
+	past := time.Now().Add(-2 * time.Hour)
+	claims.IssuedAt = jwt.NewNumericDate(past)
+	claims.ExpiresAt = jwt.NewNumericDate(past.Add(time.Minute))
+	tok := h.signToken(t, claims)
+
+	_, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if err == nil {
+		t.Fatal("expected error for expired JWT")
+	}
+}
+
+func TestAcceptForwardedIDToken_NoJWKSProvider(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	// Replace the JWKSProvider-capable mock with a bare Provider implementation.
+	h.srv.provider = &oauthOnlyProvider{name: "oauth-only"}
+
+	tok := h.signToken(t, h.validClaims())
+	_, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if err == nil {
+		t.Fatal("expected error for non-JWKS provider")
+	}
+	if !strings.Contains(err.Error(), "does not support JWKS") {
+		t.Errorf("err = %v, want 'does not support JWKS' message", err)
+	}
+}
+
+func TestAcceptForwardedIDToken_HMACKeyChangesSessionID(t *testing.T) {
+	tok := "" // set below once harness is built
+	h1 := newForwardedTokenHarness(t)
+	tok = h1.signToken(t, h1.validClaims())
+
+	a1, err := h1.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("default-key: %v", err)
+	}
+
+	// Second server with an HMAC key set; reuse the same provider/JWKS so the
+	// validation succeeds, just with a different session-ID derivation.
+	h2 := newForwardedTokenHarness(t, func(c *Config) {
+		c.SessionIDHMACKey = []byte("per-deployment-secret-key")
+	})
+	// Re-sign under h2's key so the signature validates against h2's JWKS.
+	tok2 := h2.signToken(t, h2.validClaims())
+	a2, err := h2.srv.AcceptForwardedIDToken(context.Background(), tok2)
+	if err != nil {
+		t.Fatalf("hmac-key: %v", err)
+	}
+
+	if a1.SessionID == a2.SessionID {
+		t.Errorf("SessionID should differ when HMAC key set: both = %q", a1.SessionID)
+	}
+	if !strings.HasPrefix(a2.SessionID, "ext-") {
+		t.Errorf("HMAC-derived SessionID missing ext- prefix: %q", a2.SessionID)
+	}
+}
+
+func TestAcceptForwardedIDToken_ExpiresAtMatchesExp(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	claims := h.validClaims()
+	exp := time.Now().Add(23 * time.Minute).Truncate(time.Second)
+	claims.ExpiresAt = jwt.NewNumericDate(exp)
+	tok := h.signToken(t, claims)
+
+	acc, err := h.srv.AcceptForwardedIDToken(context.Background(), tok)
+	if err != nil {
+		t.Fatalf("AcceptForwardedIDToken: %v", err)
+	}
+	if !acc.ExpiresAt.Equal(exp) {
+		t.Errorf("ExpiresAt = %v, want %v", acc.ExpiresAt, exp)
+	}
+}
+
+func TestAcceptForwardedIDToken_ParseError(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	_, err := h.srv.AcceptForwardedIDToken(context.Background(), "not.a.jwt.at.all")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+// oauthOnlyProvider is a minimal Provider implementation that deliberately does
+// not satisfy JWKSProvider, used to exercise the no-JWKS precondition.
+type oauthOnlyProvider struct {
+	name string
+}
+
+func (p *oauthOnlyProvider) Name() string            { return p.name }
+func (p *oauthOnlyProvider) DefaultScopes() []string { return nil }
+func (p *oauthOnlyProvider) AuthorizationURL(state, cc, ccm string, scopes []string, opts *providers.AuthorizationURLOptions) string {
+	return ""
+}
+func (p *oauthOnlyProvider) ExchangeCode(ctx context.Context, code, verifier string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (p *oauthOnlyProvider) ValidateToken(ctx context.Context, tok string) (*providers.UserInfo, error) {
+	return nil, nil
+}
+func (p *oauthOnlyProvider) RefreshToken(ctx context.Context, rt string) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (p *oauthOnlyProvider) RevokeToken(ctx context.Context, tok string) error { return nil }
+func (p *oauthOnlyProvider) HealthCheck(ctx context.Context) error             { return nil }

--- a/server/flows_sso.go
+++ b/server/flows_sso.go
@@ -41,7 +41,10 @@ import (
 func (s *Server) validateAndParseForwardedIDToken(ctx context.Context, tokenString string) (*oidc.IDTokenClaims, string, error) {
 	claims, err := oidc.ParseUnverifiedClaims(tokenString)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to parse JWT claims: %w", err)
+		// Wrap with errForwardedTokenParseFailed so AcceptForwardedIDToken's
+		// classifier can distinguish parse errors from later validation
+		// failures via errors.Is, without a second parse pass.
+		return nil, "", fmt.Errorf("%w: %w", errForwardedTokenParseFailed, err)
 	}
 
 	tokenAudiences := oidc.GetAudienceFromClaims(claims)

--- a/server/flows_sso.go
+++ b/server/flows_sso.go
@@ -23,54 +23,49 @@ import (
 // 4. Extract user info from validated claims
 // 5. Fall back to userinfo endpoint if JWT validation fails
 
-// validateForwardedIDToken validates a JWT ID token from a trusted upstream service.
-// This enables SSO token forwarding where an upstream MCP server forwards its ID token
-// to downstream services for authentication.
+// validateAndParseForwardedIDToken validates a JWT ID token from a trusted upstream
+// service and returns its verified claims. This is the shared core used by both the
+// fallback-style validateForwardedIDToken (ValidateToken fast-path) and the direct
+// AcceptForwardedIDToken entry point.
 //
 // Validation steps:
 // 1. Parse the JWT claims without verification to check audience
 // 2. Check if any audience matches TrustedAudiences
 // 3. If matched, validate the JWT signature using the provider's JWKS
-// 4. Extract user info from the validated claims
+// 4. Return the verified claims
 //
-// Returns (nil, nil) if the token doesn't match any trusted audience (fallback to normal flow)
-// Returns (nil, error) if the token matches but validation fails
-// Returns (userInfo, nil) if validation succeeds
-func (s *Server) validateForwardedIDToken(ctx context.Context, tokenString string) (*providers.UserInfo, error) {
-	// Parse claims without verification to check audience
+// Returns (nil, "", nil) if the token doesn't match any trusted audience — callers
+// that want fallback semantics (the ValidateToken fast-path) treat this as "not for us."
+// Returns (nil, "", error) if the token matches but validation fails.
+// Returns (claims, matchedAudience, nil) if validation succeeds.
+func (s *Server) validateAndParseForwardedIDToken(ctx context.Context, tokenString string) (*oidc.IDTokenClaims, string, error) {
 	claims, err := oidc.ParseUnverifiedClaims(tokenString)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse JWT claims: %w", err)
+		return nil, "", fmt.Errorf("failed to parse JWT claims: %w", err)
 	}
 
-	// Check if any audience matches our trusted audiences
 	tokenAudiences := oidc.GetAudienceFromClaims(claims)
 	matchedAudience := s.findMatchingTrustedAudience(tokenAudiences)
 	if matchedAudience == "" {
-		// No match - this token is not for us, return nil to trigger fallback
-		return nil, nil
+		return nil, "", nil
 	}
 
 	s.Logger.Debug("JWT audience matches TrustedAudiences, validating via JWKS",
 		"matched_audience", matchedAudience,
 		"token_suffix", helpers.TokenSuffix(tokenString, 8))
 
-	// Check if provider supports JWKS validation
 	jwksProvider, ok := s.provider.(providers.JWKSProvider)
 	if !ok {
 		s.Logger.Warn("Provider does not support JWKS validation, cannot validate forwarded ID token",
 			"provider", s.provider.Name())
-		return nil, fmt.Errorf("provider %s does not support JWKS validation", s.provider.Name())
+		return nil, "", fmt.Errorf("provider %s does not support JWKS validation", s.provider.Name())
 	}
 
-	// Get JWKS URI from provider
 	jwksURI, err := jwksProvider.JWKSURI(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get JWKS URI: %w", err)
+		return nil, "", fmt.Errorf("failed to get JWKS URI: %w", err)
 	}
 
-	// Get issuer URL from provider for additional validation
-	// This adds defense-in-depth by ensuring the token was issued by the expected provider
 	expectedIssuer := jwksProvider.IssuerURL()
 	if expectedIssuer != "" {
 		s.Logger.Debug("Validating JWT issuer against provider",
@@ -78,30 +73,44 @@ func (s *Server) validateForwardedIDToken(ctx context.Context, tokenString strin
 			"token_suffix", helpers.TokenSuffix(tokenString, 8))
 	}
 
-	// Validate the JWT signature using JWKS
 	idTokenClaims, err := oidc.ValidateIDToken(
 		ctx,
 		tokenString,
 		s.getJWKSClient(),
 		jwksURI,
-		expectedIssuer, // Validate issuer if provider specifies one
+		expectedIssuer,
 		s.Config.TrustedAudiences,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("ID token signature validation failed: %w", err)
+		return nil, "", fmt.Errorf("ID token signature validation failed: %w", err)
 	}
 
-	// Defensive nil check - ValidateIDToken should never return (nil, nil)
-	// but this guards against future changes
 	if idTokenClaims == nil {
-		return nil, fmt.Errorf("ID token validation returned nil claims")
+		return nil, "", fmt.Errorf("ID token validation returned nil claims")
 	}
 
-	// Extract user info from validated claims
-	userInfo := s.idTokenClaimsToUserInfo(idTokenClaims)
+	return idTokenClaims, matchedAudience, nil
+}
 
-	// Log the successful SSO token acceptance with issuer information
-	s.logForwardedIDTokenAccepted(tokenString, matchedAudience, expectedIssuer, userInfo)
+// validateForwardedIDToken is the fallback-style wrapper used by the ValidateToken
+// fast-path. It returns (nil, nil) when the token doesn't carry a trusted audience
+// so the caller falls back to the normal userinfo flow.
+func (s *Server) validateForwardedIDToken(ctx context.Context, tokenString string) (*providers.UserInfo, error) {
+	claims, matchedAudience, err := s.validateAndParseForwardedIDToken(ctx, tokenString)
+	if err != nil {
+		return nil, err
+	}
+	if claims == nil {
+		return nil, nil
+	}
+
+	userInfo := s.idTokenClaimsToUserInfo(claims)
+
+	var validatedIssuer string
+	if jwksProvider, ok := s.provider.(providers.JWKSProvider); ok {
+		validatedIssuer = jwksProvider.IssuerURL()
+	}
+	s.logForwardedIDTokenAccepted(tokenString, matchedAudience, validatedIssuer, userInfo)
 
 	return userInfo, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -140,6 +140,7 @@ func New(
 	srv.initializeInstrumentation(tokenStore, clientStore, flowStore)
 	srv.initializeMetadataSupport()
 	srv.validateProviderDefaultScopes(logger)
+	srv.logForwardedSessionIDKeyFingerprint()
 
 	return srv, nil
 }


### PR DESCRIPTION
## Summary

Adds `Server.AcceptForwardedIDToken` — a library entry point for accepting a JWT forwarded from a trusted upstream identity provider. Centralizes the validation + synthetic-session-ID derivation every aggregator reinvents, so downstream MCP servers receiving the same forwarded token derive the same session identifier.

Driven by giantswarm/giantswarm#36340 (Muster behind Amazon Bedrock), though the underlying `TrustedAudiences` + `validateForwardedIDToken` path already exists on `main` — this PR is a DX improvement and standardization of the synthetic-session-ID format, not a hard blocker.

## Design highlights

- **Pure function, no side effects** beyond the existing `EventForwardedIDTokenAccepted` audit event and a new counter. Does **not** fire `SessionCreationHandler` (that handler is gated on `RefreshTokenFamilyStore` and the auth-code family lifecycle; forwarded tokens bypass both). Does **not** mirror the token into `TokenStore` (`TokenStore.SaveToken` is userID-keyed; aggregators that need retrieval-by-session must own that mapping).
- **Domain-separated session ID** `"ext-" + hex(sha256(label || 0x00 || token))[:16]`, with HMAC-SHA-256 variant when `Config.SessionIDHMACKey` is set. Two MCP servers receiving the same token derive the same ID — free cross-hop audit correlation.
- **`Config.SessionIDHMACKey`** opt-in for multi-tenant isolation; docs/security.md spells out the operator caveat (all correlated servers must share the same key or all leave it empty — library cannot detect a mismatch).
- **Bounded typed result enum** (`ForwardedIDTokenResult`: `ok|aud_mismatch|iss_mismatch|sig_invalid|expired|not_yet_valid|no_jwks|parse_error`). Compiler enforces the closed set; no raw error strings.
- **Sentinel `providers/oidc.ErrIssuerMismatch`** instead of `strings.Contains(msg, "issuer mismatch")` — classifier survives upstream message tweaks.
- **`providers.IssuerOf`** free helper (type-asserts to `JWKSProvider`, returns `""` for OAuth-only providers like GitHub). Used at the call site; no breaking change to the `Provider` interface.
- Re-exports `ForwardedIDTokenAcceptance` and `ErrTrustedAudienceMismatch` at the top-level `oauth` package.

## Migration impact (honest estimate)

Muster PR #566's `injectExternalIDToken` is 93 lines. This function replaces the 40-50 lines of JWT-parse / sub-extraction / issuer-resolution / session-ID-derivation boilerplate. The remaining 40-50 lines (muster's own storage mirroring, session-creation callbacks, request-context injection) stay in muster where the keying and lifecycle policy live.

Realistic landing point for muster: **~30-40 lines, not 10**. The win isn't line count — it's that the synthetic-session-ID format becomes library-owned, so two MCP servers receiving the same forwarded token produce the same session ID, which muster's private `ext-<sha8>` format cannot guarantee across different consumer implementations.

## Related

- Refs: giantswarm/giantswarm#36340
- Unblocks: giantswarm/muster#566