### PR TITLE
feat(handler): RFC 9207 iss parameter in authorization response

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -959,6 +959,9 @@ func (h *Handler) buildAuthServerMetadata() map[string]any {
 		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"code_challenge_methods_supported":      []string{PKCEMethodS256},
 		"token_endpoint_auth_methods_supported": SupportedTokenAuthMethods,
+		// RFC 9207: advertise that authorization responses include the `iss` parameter
+		// so clients can verify the response came from the expected authorization server.
+		"authorization_response_iss_parameter_supported": true,
 	}
 
 	h.addOptionalMetadata(metadata)
@@ -1169,8 +1172,18 @@ func (h *Handler) ServeCallback(w http.ResponseWriter, r *http.Request) {
 	instrumentation.SetSpanSuccess(span)
 
 	// CRITICAL SECURITY: Redirect back to client with their original state parameter
-	// This allows the client to verify the callback is for their original request (CSRF protection)
-	redirectURL := fmt.Sprintf("%s?code=%s&state=%s", authCode.RedirectURI, authCode.Code, clientState)
+	// This allows the client to verify the callback is for their original request (CSRF protection).
+	//
+	// RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification): include the `iss`
+	// parameter so clients talking to multiple authorization servers can detect mix-up
+	// attacks (authorization response injected from a different AS than the client sent
+	// the request to). The issuer MUST be URL-encoded since it is an https:// URL.
+	redirectURL := fmt.Sprintf("%s?code=%s&state=%s&iss=%s",
+		authCode.RedirectURI,
+		authCode.Code,
+		clientState,
+		url.QueryEscape(h.server.Config.Issuer),
+	)
 
 	// RFC 8252 Section 7.1: Custom URL schemes require special handling
 	// Browsers may fail silently on 302 redirects to custom schemes (cursor://, vscode://, etc.)

--- a/handler_test.go
+++ b/handler_test.go
@@ -1075,6 +1075,12 @@ func TestHandler_ServeAuthorizationServerMetadata(t *testing.T) {
 	if len(meta.CodeChallengeMethodsSupported) > 0 && meta.CodeChallengeMethodsSupported[0] != "S256" {
 		t.Errorf("CodeChallengeMethodsSupported[0] = %q, want %q", meta.CodeChallengeMethodsSupported[0], "S256")
 	}
+
+	// RFC 9207: servers that include the `iss` parameter in authorization responses
+	// MUST advertise the capability so clients can enable the corresponding check.
+	if !meta.AuthorizationResponseIssParameterSupported {
+		t.Error("AuthorizationResponseIssParameterSupported should be true (RFC 9207)")
+	}
 }
 
 func TestHandler_ServeAuthorizationServerMetadata_NoRegistration(t *testing.T) {
@@ -2461,6 +2467,11 @@ func TestHandler_ServeCallback(t *testing.T) {
 	}
 	if !strings.Contains(location, "state="+clientState) {
 		t.Error("Location should contain original client state")
+	}
+	// RFC 9207: Location MUST carry the URL-encoded `iss` parameter so the client
+	// can confirm the response came from the expected authorization server.
+	if !strings.Contains(location, "iss="+url.QueryEscape(testIssuer)) {
+		t.Errorf("Location should contain URL-encoded iss=%s; got %q", testIssuer, location)
 	}
 }
 
@@ -5210,6 +5221,12 @@ func TestHandler_ServeCallback_CustomURLScheme(t *testing.T) {
 	}
 	if !strings.Contains(body, "state="+clientState) {
 		t.Error("Response should contain original client state")
+	}
+	// RFC 9207: the embedded redirect URL in the interstitial must include `iss`
+	// so the client app sees the same authorization-response parameters it would
+	// have received via a direct 302.
+	if !strings.Contains(body, "iss="+url.QueryEscape(testIssuer)) {
+		t.Errorf("Interstitial should contain URL-encoded iss=%s in the embedded redirect", testIssuer)
 	}
 
 	// Should contain manual button

--- a/types.go
+++ b/types.go
@@ -69,6 +69,12 @@ type AuthorizationServerMetadata struct {
 
 	// ClientIDMetadataDocumentSupported indicates support for Client ID Metadata Documents (MCP 2025-11-25)
 	ClientIDMetadataDocumentSupported bool `json:"client_id_metadata_document_supported,omitempty"`
+
+	// AuthorizationResponseIssParameterSupported indicates that this authorization
+	// server includes the `iss` parameter in authorization responses (RFC 9207),
+	// allowing clients talking to multiple authorization servers to detect mix-up
+	// attacks.
+	AuthorizationResponseIssParameterSupported bool `json:"authorization_response_iss_parameter_supported,omitempty"`
 }
 
 // ==================== Dynamic Client Registration (RFC 7591) Types ====================


### PR DESCRIPTION
## Summary

Emits the `iss` parameter in authorization-code redirects per RFC 9207, closing the only MCP 2025-11-25 / OAuth 2.1 spec gap identified in the library audit. Without it, clients talking to multiple authorization servers cannot detect mix-up attacks where an authorization response is injected from a different AS than the client sent the request to.

## Changes

- `handler.go`: append `&iss=<url-encoded Config.Issuer>` to the authorization response redirect (covers both the direct 302 path and the custom-URL-scheme interstitial, since the interstitial embeds the same URL).
- `handler.go`: advertise `authorization_response_iss_parameter_supported: true` in RFC 8414 metadata so clients know to check it.
- `types.go`: expose `AuthorizationResponseIssParameterSupported` on the top-level `AuthorizationServerMetadata` struct so consumers (and our own tests) can decode the capability.
- `handler_test.go`: extend `TestHandler_ServeCallback`, `TestHandler_ServeCallback_CustomURLScheme`, and `TestHandler_ServeAuthorizationServerMetadata` with the new assertions.

## Migration impact

Zero. Clients that ignore `iss` keep working unchanged; clients that check it now pass the RFC 9207 validation.