### PR TITLE
feat(handler): RegisterOAuthRoutes bundle helper

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -718,6 +718,80 @@ func (h *Handler) buildProtectedResourceMetadata(resourcePath string, pathConfig
 	return metadata
 }
 
+// OAuthRoutesOptions controls the bundle registered by [Handler.RegisterOAuthRoutes].
+type OAuthRoutesOptions struct {
+	// MCPPath is forwarded to RegisterProtectedResourceMetadataRoutes for
+	// backward compatibility with single-path consumers. Kept because a few
+	// examples still pass it, but prefer configuring
+	// [Config.ResourceMetadataByPath] instead — when that map is non-empty,
+	// MCPPath is ignored (with a single warn log at registration time so the
+	// conflict is visible).
+	MCPPath string
+
+	// IncludeMetadata controls whether the two discovery bundles
+	// (Protected Resource Metadata per RFC 9728 and Authorization Server
+	// Metadata per RFC 8414) are registered alongside the OAuth flow
+	// endpoints. Default true — this is what every consumer today does by
+	// hand.
+	IncludeMetadata bool
+}
+
+// RegisterOAuthRoutes registers the five OAuth flow endpoints on mux and,
+// when opts.IncludeMetadata is true (the default), also registers the
+// Protected Resource Metadata and Authorization Server Metadata routes
+// via the two existing Register*Routes helpers.
+//
+// The endpoints registered are fixed at their standard paths
+// (authorize/callback/token/revoke/register under /oauth) because
+// [Config.AuthorizationEndpoint], [Config.TokenEndpoint] and the other
+// metadata builders hardcode those paths. A customizable prefix was
+// considered and rejected — it would make the routes register at one URL
+// while metadata advertised a different one. Consumers needing a custom
+// prefix must wire the individual Serve* methods by hand, at which point
+// they also need to override metadata advertisement.
+//
+// Replaces the five-line `mux.HandleFunc("/oauth/...", handler.Serve...)`
+// block every consumer writes today:
+//
+//	handler.RegisterOAuthRoutes(mux, oauth.OAuthRoutesOptions{
+//	    MCPPath:         "/mcp",
+//	    IncludeMetadata: true,
+//	})
+func (h *Handler) RegisterOAuthRoutes(mux *http.ServeMux, opts OAuthRoutesOptions) {
+	// OAuth flow endpoints — fixed paths (see method godoc for rationale).
+	mux.HandleFunc(server.EndpointPathAuthorize, h.ServeAuthorization)
+	mux.HandleFunc(oauthCallbackPath, h.ServeCallback)
+	mux.HandleFunc(server.EndpointPathToken, h.ServeToken)
+	mux.HandleFunc(server.EndpointPathRevoke, h.ServeTokenRevocation)
+	mux.HandleFunc(server.EndpointPathRegister, h.ServeClientRegistration)
+
+	if !opts.IncludeMetadata {
+		return
+	}
+
+	// ResourceMetadataByPath is the configuration-driven replacement for the
+	// single MCPPath argument. If both are set, the configuration wins —
+	// RegisterProtectedResourceMetadataRoutes already registers all the
+	// configured paths, so a different MCPPath value would be registered
+	// but never preferred over the config entries. Log once so consumers
+	// notice the inconsistency instead of silently ignoring the MCPPath.
+	if opts.MCPPath != "" && len(h.server.Config.ResourceMetadataByPath) > 0 {
+		h.logger.Warn("RegisterOAuthRoutes: MCPPath is set alongside non-empty Config.ResourceMetadataByPath; the configuration map is preferred and MCPPath adds only a back-compat alias route",
+			"mcp_path", opts.MCPPath,
+			"configured_paths", len(h.server.Config.ResourceMetadataByPath),
+		)
+	}
+
+	h.RegisterProtectedResourceMetadataRoutes(mux, opts.MCPPath)
+	h.RegisterAuthorizationServerMetadataRoutes(mux)
+}
+
+// oauthCallbackPath is the provider-callback path. The server's own
+// AuthorizationEndpoint / TokenEndpoint / RegistrationEndpoint / RevocationEndpoint
+// methods all live under /oauth (see server/config.go); callback follows the
+// same convention.
+const oauthCallbackPath = "/oauth/callback"
+
 // RegisterProtectedResourceMetadataRoutes registers all Protected Resource Metadata discovery routes.
 // It registers the root endpoint and optional sub-path endpoints based on configuration.
 //

--- a/handler.go
+++ b/handler.go
@@ -736,19 +736,28 @@ type OAuthRoutesOptions struct {
 	IncludeMetadata bool
 }
 
-// RegisterOAuthRoutes registers the five OAuth flow endpoints on mux and,
-// when opts.IncludeMetadata is true (the default), also registers the
-// Protected Resource Metadata and Authorization Server Metadata routes
-// via the two existing Register*Routes helpers.
+// RegisterOAuthRoutes registers the OAuth flow endpoints on mux and, when
+// opts.IncludeMetadata is true (the default), also registers the Protected
+// Resource Metadata and Authorization Server Metadata routes via the two
+// existing Register*Routes helpers.
 //
-// The endpoints registered are fixed at their standard paths
-// (authorize/callback/token/revoke/register under /oauth) because
-// [Config.AuthorizationEndpoint], [Config.TokenEndpoint] and the other
-// metadata builders hardcode those paths. A customizable prefix was
-// considered and rejected — it would make the routes register at one URL
-// while metadata advertised a different one. Consumers needing a custom
-// prefix must wire the individual Serve* methods by hand, at which point
-// they also need to override metadata advertisement.
+// Routes registered (all under /oauth, paths fixed by the Config endpoint
+// builders):
+//
+//   - /oauth/authorize, /oauth/callback, /oauth/token,
+//     /oauth/revoke, /oauth/register — always registered.
+//   - /oauth/introspect — only when Config.EnableIntrospectionEndpoint is
+//     true. ServeTokenIntrospection does not self-gate on that flag, so
+//     registering it unconditionally would expose an endpoint the operator
+//     disabled in config.
+//
+// A customizable prefix was considered and rejected — [Config.AuthorizationEndpoint],
+// [Config.TokenEndpoint], and the other metadata builders hardcode the /oauth
+// prefix when constructing the issuer-scoped URLs that appear in metadata.
+// A custom prefix would make the routes register at one URL while metadata
+// advertised a different one. Consumers needing a custom prefix must wire
+// the individual Serve* methods by hand, at which point they also need to
+// override metadata advertisement.
 //
 // Replaces the five-line `mux.HandleFunc("/oauth/...", handler.Serve...)`
 // block every consumer writes today:
@@ -764,6 +773,14 @@ func (h *Handler) RegisterOAuthRoutes(mux *http.ServeMux, opts OAuthRoutesOption
 	mux.HandleFunc(server.EndpointPathToken, h.ServeToken)
 	mux.HandleFunc(server.EndpointPathRevoke, h.ServeTokenRevocation)
 	mux.HandleFunc(server.EndpointPathRegister, h.ServeClientRegistration)
+
+	// Token introspection (RFC 7662) is opt-in. ServeTokenIntrospection does
+	// not self-gate on Config.EnableIntrospectionEndpoint — registering it
+	// unconditionally would expose an endpoint the operator disabled in
+	// config. Only wire the route when the flag is on.
+	if h.server.Config.EnableIntrospectionEndpoint {
+		mux.HandleFunc(server.EndpointPathIntrospect, h.ServeTokenIntrospection)
+	}
 
 	if !opts.IncludeMetadata {
 		return

--- a/handler_register_routes_test.go
+++ b/handler_register_routes_test.go
@@ -146,6 +146,29 @@ func TestHandler_RegisterOAuthRoutes_MCPPathWithResourceMetadataByPath_WarnsOnce
 	}
 }
 
+func TestHandler_RegisterOAuthRoutes_IntrospectGatedOnEnableFlag(t *testing.T) {
+	t.Run("disabled-by-default", func(t *testing.T) {
+		handler, _, _ := newRegisterRoutesHandler(t, nil)
+		mux := http.NewServeMux()
+		handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{IncludeMetadata: true})
+		// ServeTokenIntrospection does not self-gate on
+		// Config.EnableIntrospectionEndpoint, so the bundle must not register
+		// the route unless explicitly enabled.
+		assertMuxUnregistered(t, mux, "/oauth/introspect")
+	})
+
+	t.Run("enabled-via-config", func(t *testing.T) {
+		cfg := &server.Config{
+			Issuer:                      testIssuer,
+			EnableIntrospectionEndpoint: true,
+		}
+		handler, _, _ := newRegisterRoutesHandler(t, cfg)
+		mux := http.NewServeMux()
+		handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{IncludeMetadata: true})
+		assertMuxResolves(t, mux, "/oauth/introspect", "/oauth/introspect")
+	})
+}
+
 func TestHandler_RegisterOAuthRoutes_NoWarnWithoutConflict(t *testing.T) {
 	handler, _, buf := newRegisterRoutesHandler(t, nil)
 	mux := http.NewServeMux()

--- a/handler_register_routes_test.go
+++ b/handler_register_routes_test.go
@@ -1,0 +1,161 @@
+package oauth
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/server"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// newRegisterRoutesHandler builds a minimal Handler + capturing logger for
+// RegisterOAuthRoutes tests. A capturing logger lets us assert the "MCPPath
+// alongside ResourceMetadataByPath" warn log without otherwise changing
+// test-time defaults.
+func newRegisterRoutesHandler(t *testing.T, cfg *server.Config) (*Handler, *memory.Store, *bytes.Buffer) {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	provider := mock.NewProvider()
+	if cfg == nil {
+		cfg = &server.Config{Issuer: testIssuer}
+	}
+	srv, err := server.New(provider, store, store, store, cfg, nil)
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	return NewHandler(srv, logger), store, &buf
+}
+
+// assertMuxResolves checks that mux resolves path to a handler registered at
+// exactly the expected pattern. http.ServeMux.Handler returns the registered
+// pattern for a matched route, or "" for the implicit NotFoundHandler.
+func assertMuxResolves(t *testing.T, mux *http.ServeMux, path, wantPattern string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	_, gotPattern := mux.Handler(req)
+	if gotPattern != wantPattern {
+		t.Errorf("mux.Handler(%q) pattern = %q, want %q", path, gotPattern, wantPattern)
+	}
+}
+
+// assertMuxUnregistered verifies that path is not registered on mux (the
+// returned pattern is empty — http.ServeMux's sentinel for NotFoundHandler).
+func assertMuxUnregistered(t *testing.T, mux *http.ServeMux, path string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	_, gotPattern := mux.Handler(req)
+	if gotPattern != "" {
+		t.Errorf("mux.Handler(%q) unexpectedly resolved to pattern %q", path, gotPattern)
+	}
+}
+
+func TestHandler_RegisterOAuthRoutes_FlowEndpoints(t *testing.T) {
+	handler, _, _ := newRegisterRoutesHandler(t, nil)
+	mux := http.NewServeMux()
+	handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{})
+
+	for _, tc := range []struct {
+		name, path string
+	}{
+		{"authorize", "/oauth/authorize"},
+		{"callback", "/oauth/callback"},
+		{"token", "/oauth/token"},
+		{"revoke", "/oauth/revoke"},
+		{"register", "/oauth/register"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assertMuxResolves(t, mux, tc.path, tc.path)
+		})
+	}
+}
+
+func TestHandler_RegisterOAuthRoutes_IncludeMetadataFalse(t *testing.T) {
+	handler, _, _ := newRegisterRoutesHandler(t, nil)
+	mux := http.NewServeMux()
+	handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{IncludeMetadata: false})
+
+	// Flow endpoints still registered.
+	assertMuxResolves(t, mux, "/oauth/authorize", "/oauth/authorize")
+	// Metadata endpoints not registered.
+	assertMuxUnregistered(t, mux, "/.well-known/oauth-protected-resource")
+	assertMuxUnregistered(t, mux, "/.well-known/oauth-authorization-server")
+	assertMuxUnregistered(t, mux, "/.well-known/openid-configuration")
+}
+
+func TestHandler_RegisterOAuthRoutes_IncludeMetadataTrue(t *testing.T) {
+	handler, _, _ := newRegisterRoutesHandler(t, nil)
+	mux := http.NewServeMux()
+	handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{IncludeMetadata: true})
+
+	assertMuxResolves(t, mux, "/.well-known/oauth-protected-resource", "/.well-known/oauth-protected-resource")
+	assertMuxResolves(t, mux, "/.well-known/oauth-authorization-server", "/.well-known/oauth-authorization-server")
+	assertMuxResolves(t, mux, "/.well-known/openid-configuration", "/.well-known/openid-configuration")
+}
+
+func TestHandler_RegisterOAuthRoutes_MCPPathBackCompat(t *testing.T) {
+	handler, _, _ := newRegisterRoutesHandler(t, nil)
+	mux := http.NewServeMux()
+	handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{
+		MCPPath:         "/mcp",
+		IncludeMetadata: true,
+	})
+
+	assertMuxResolves(t, mux, "/.well-known/oauth-protected-resource/mcp", "/.well-known/oauth-protected-resource/mcp")
+}
+
+func TestHandler_RegisterOAuthRoutes_MCPPathWithResourceMetadataByPath_WarnsOnce(t *testing.T) {
+	cfg := &server.Config{
+		Issuer: testIssuer,
+		ResourceMetadataByPath: map[string]server.ProtectedResourceConfig{
+			"/mcp/files": {ScopesSupported: []string{"files:read"}},
+		},
+	}
+	handler, _, buf := newRegisterRoutesHandler(t, cfg)
+	mux := http.NewServeMux()
+	handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{
+		MCPPath:         "/mcp",
+		IncludeMetadata: true,
+	})
+
+	got := buf.String()
+	if !strings.Contains(got, "MCPPath is set alongside non-empty Config.ResourceMetadataByPath") {
+		t.Errorf("expected warn log about MCPPath + ResourceMetadataByPath conflict, got: %q", got)
+	}
+
+	// Both configured and legacy paths resolve — the warn is just a visibility
+	// aid, it does not suppress the MCPPath route.
+	assertMuxResolves(t, mux, "/.well-known/oauth-protected-resource/mcp", "/.well-known/oauth-protected-resource/mcp")
+	assertMuxResolves(t, mux, "/.well-known/oauth-protected-resource/mcp/files", "/.well-known/oauth-protected-resource/mcp/files")
+
+	// Emit the warn at most once per registration (no more than one occurrence
+	// in the log buffer).
+	if c := strings.Count(got, "MCPPath is set alongside"); c != 1 {
+		t.Errorf("expected exactly one warn log, got %d:\n%s", c, got)
+	}
+}
+
+func TestHandler_RegisterOAuthRoutes_NoWarnWithoutConflict(t *testing.T) {
+	handler, _, buf := newRegisterRoutesHandler(t, nil)
+	mux := http.NewServeMux()
+	handler.RegisterOAuthRoutes(mux, OAuthRoutesOptions{
+		MCPPath:         "/mcp",
+		IncludeMetadata: true,
+	})
+
+	got := buf.String()
+	if strings.Contains(got, "MCPPath is set alongside") {
+		t.Errorf("did not expect MCPPath-conflict warn when ResourceMetadataByPath is empty; got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Collapses the five-line `mux.HandleFunc(\"/oauth/...\", handler.Serve...)` block every consumer (muster, mcp-prometheus, mcp-observability-platform, plus the examples) writes today into a single `Handler` method that also optionally calls the two existing `Register*Routes` helpers for RFC 9728 Protected Resource Metadata and RFC 8414 Authorization Server Metadata.

## API

```go
type OAuthRoutesOptions struct {
    MCPPath         string // forwarded to RegisterProtectedResourceMetadataRoutes
    IncludeMetadata bool   // default true
}

func (h *Handler) RegisterOAuthRoutes(mux *http.ServeMux, opts OAuthRoutesOptions)
```

## MCPPath + ResourceMetadataByPath conflict

When both are set, the helper emits a single `slog.Warn` at registration time and still registers the MCPPath route (as a back-compat alias). Silent-ignore would be confusing; one log line surfaces the inconsistency without breaking working setups.

## Migration impact

- mcp-observability-platform / mcp-prometheus / muster each drop ~5 lines of hand-registered routes in their future cleanup PRs.
- Zero source-breaking change: existing `Register*Routes` helpers and individual `Serve*` methods stay.