### PR TITLE
feat(oauthconfig): per-provider env loaders + ProviderFromEnv dispatcher

### DIFF
--- a/oauthconfig/provider.go
+++ b/oauthconfig/provider.go
@@ -51,6 +51,23 @@ func ProviderFromEnvWithPrefix(prefix string) (providers.Provider, error) {
 //
 // Returned as providers.Provider (not *dex.Provider) so call sites stay
 // provider-agnostic. Callers that need Dex-specific methods cast.
+//
+// Deliberately NOT exposed as env vars (opinionated defaults):
+//
+//   - Scopes — the default Dex-optimized scope set is strictly better than
+//     what an operator would hand-configure; callers needing custom scopes
+//     build dex.Config themselves.
+//   - HTTPClient — overriding the HTTP client is a programmatic concern
+//     (proxies, custom TLS, test doubles); the env surface would force the
+//     loader to invent a serialization for *http.Client.
+//   - RequestTimeout — operators tune this via the upstream IdP's latency
+//     profile, which rarely varies per deployment. Default 30s is sound.
+//   - MaxGroups — enterprise-specific tuning for very large AD group counts;
+//     the library default (oidc.DefaultMaxGroups = 600) covers the common
+//     case, and callers with unusual group counts construct Config manually.
+//
+// Callers needing any of these construct [dex.Config] programmatically and
+// call [dex.NewProvider] directly, bypassing this loader.
 func DexFromEnv() (providers.Provider, error) {
 	return DexFromEnvWithPrefix("OAUTH_")
 }
@@ -91,8 +108,16 @@ func DexFromEnvWithPrefix(prefix string) (providers.Provider, error) {
 //	OAUTH_GOOGLE_REDIRECT_URL          (required)
 //	OAUTH_GOOGLE_FORCE_CONSENT         (optional; defaults to provider default of true)
 //
-// google.Config does not currently expose a hosted-domain setting; consumers
-// that need workspace restriction must construct google.Config programmatically.
+// Deliberately NOT exposed as env vars:
+//
+//   - Scopes — the Google-default set ("openid", "email", "profile") matches
+//     the overwhelmingly common case; custom scopes are a programmatic choice.
+//   - HTTPClient / RequestTimeout — same rationale as [DexFromEnv].
+//
+// google.Config currently has no hosted-domain field (the Google provider
+// doesn't implement Workspace domain restriction). Callers needing workspace
+// restriction must construct [google.Config] programmatically once that field
+// exists on the Config struct.
 func GoogleFromEnv() (providers.Provider, error) {
 	return GoogleFromEnvWithPrefix("OAUTH_")
 }
@@ -138,9 +163,15 @@ func GoogleFromEnvWithPrefix(prefix string) (providers.Provider, error) {
 //	OAUTH_GITHUB_ALLOWED_ORGANIZATIONS     (optional; comma-separated) — restrict login to members
 //	OAUTH_GITHUB_REQUIRE_VERIFIED_EMAIL    (optional; defaults to provider default of true)
 //
-// GitHub is OAuth 2.0 only (no OIDC), so providers.IssuerOf returns "" for
-// the resulting provider. Consumers that rely on AcceptForwardedIDToken must
-// not configure GitHub as the upstream provider.
+// Deliberately NOT exposed as env vars:
+//
+//   - Scopes — the defaults ("user:email", "read:user") suit the vast
+//     majority of MCP deployments; custom scopes are programmatic.
+//   - HTTPClient / RequestTimeout — same rationale as [DexFromEnv].
+//
+// GitHub is OAuth 2.0 only (no OIDC), so [providers.IssuerOf] returns "" for
+// the resulting provider. Consumers that rely on
+// [Server.AcceptForwardedIDToken] must not configure GitHub as the upstream.
 func GitHubFromEnv() (providers.Provider, error) {
 	return GitHubFromEnvWithPrefix("OAUTH_")
 }

--- a/oauthconfig/provider.go
+++ b/oauthconfig/provider.go
@@ -1,0 +1,194 @@
+package oauthconfig
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/dex"
+	"github.com/giantswarm/mcp-oauth/providers/github"
+	"github.com/giantswarm/mcp-oauth/providers/google"
+)
+
+// ProviderFromEnv reads OAUTH_PROVIDER (dex|google|github) and dispatches to
+// the matching per-provider loader (DexFromEnv, GoogleFromEnv, GitHubFromEnv).
+// Use this when the provider should be chosen at deploy time. Consumers that
+// hard-code a single provider can call the specific loader directly.
+//
+// Returns an error when OAUTH_PROVIDER is unset, empty, or not one of the
+// three supported values. Unlike other variables in this package, there is
+// deliberately no default — silently picking a provider would hide
+// misconfiguration.
+func ProviderFromEnv() (providers.Provider, error) {
+	return ProviderFromEnvWithPrefix("OAUTH_")
+}
+
+// ProviderFromEnvWithPrefix is [ProviderFromEnv] with a caller-supplied prefix.
+// See [FromEnvWithPrefix] for the convention.
+func ProviderFromEnvWithPrefix(prefix string) (providers.Provider, error) {
+	name := os.Getenv(prefix + "PROVIDER")
+	switch name {
+	case "":
+		return nil, fmt.Errorf("%sPROVIDER is required (one of: dex, google, github)", prefix)
+	case "dex":
+		return DexFromEnvWithPrefix(prefix)
+	case "google":
+		return GoogleFromEnvWithPrefix(prefix)
+	case "github":
+		return GitHubFromEnvWithPrefix(prefix)
+	default:
+		return nil, fmt.Errorf("%sPROVIDER: unknown provider %q (want dex, google, or github)", prefix, name)
+	}
+}
+
+// DexFromEnv reads OAUTH_DEX_* variables and returns a configured Dex provider.
+//
+//	OAUTH_DEX_ISSUER_URL            (required) — e.g. https://dex.example.com
+//	OAUTH_DEX_CLIENT_ID             (required)
+//	OAUTH_DEX_CLIENT_SECRET[_FILE]  (required)
+//	OAUTH_DEX_REDIRECT_URL          (required)
+//	OAUTH_DEX_CONNECTOR_ID          (optional) — e.g. "github", "ldap"
+//
+// Returned as providers.Provider (not *dex.Provider) so call sites stay
+// provider-agnostic. Callers that need Dex-specific methods cast.
+func DexFromEnv() (providers.Provider, error) {
+	return DexFromEnvWithPrefix("OAUTH_")
+}
+
+// DexFromEnvWithPrefix is [DexFromEnv] with a caller-supplied prefix.
+func DexFromEnvWithPrefix(prefix string) (providers.Provider, error) {
+	issuer, err := requireString(prefix + "DEX_ISSUER_URL")
+	if err != nil {
+		return nil, err
+	}
+	clientID, err := requireString(prefix + "DEX_CLIENT_ID")
+	if err != nil {
+		return nil, err
+	}
+	redirectURL, err := requireString(prefix + "DEX_REDIRECT_URL")
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := requireSecret(prefix + "DEX_CLIENT_SECRET")
+	if err != nil {
+		return nil, err
+	}
+
+	return dex.NewProvider(&dex.Config{
+		IssuerURL:    issuer,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+		ConnectorID:  os.Getenv(prefix + "DEX_CONNECTOR_ID"),
+	})
+}
+
+// GoogleFromEnv reads OAUTH_GOOGLE_* variables and returns a configured Google
+// provider.
+//
+//	OAUTH_GOOGLE_CLIENT_ID             (required)
+//	OAUTH_GOOGLE_CLIENT_SECRET[_FILE]  (required)
+//	OAUTH_GOOGLE_REDIRECT_URL          (required)
+//	OAUTH_GOOGLE_FORCE_CONSENT         (optional; defaults to provider default of true)
+//
+// google.Config does not currently expose a hosted-domain setting; consumers
+// that need workspace restriction must construct google.Config programmatically.
+func GoogleFromEnv() (providers.Provider, error) {
+	return GoogleFromEnvWithPrefix("OAUTH_")
+}
+
+// GoogleFromEnvWithPrefix is [GoogleFromEnv] with a caller-supplied prefix.
+func GoogleFromEnvWithPrefix(prefix string) (providers.Provider, error) {
+	clientID, err := requireString(prefix + "GOOGLE_CLIENT_ID")
+	if err != nil {
+		return nil, err
+	}
+	redirectURL, err := requireString(prefix + "GOOGLE_REDIRECT_URL")
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := requireSecret(prefix + "GOOGLE_CLIENT_SECRET")
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &google.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  redirectURL,
+	}
+
+	if v := os.Getenv(prefix + "GOOGLE_FORCE_CONSENT"); v != "" {
+		fc, err := optionalBool(prefix+"GOOGLE_FORCE_CONSENT", true)
+		if err != nil {
+			return nil, err
+		}
+		cfg.ForceConsent = &fc
+	}
+
+	return google.NewProvider(cfg)
+}
+
+// GitHubFromEnv reads OAUTH_GITHUB_* variables and returns a configured GitHub
+// provider.
+//
+//	OAUTH_GITHUB_CLIENT_ID                 (required)
+//	OAUTH_GITHUB_CLIENT_SECRET[_FILE]      (required)
+//	OAUTH_GITHUB_REDIRECT_URL              (required)
+//	OAUTH_GITHUB_ALLOWED_ORGANIZATIONS     (optional; comma-separated) — restrict login to members
+//	OAUTH_GITHUB_REQUIRE_VERIFIED_EMAIL    (optional; defaults to provider default of true)
+//
+// GitHub is OAuth 2.0 only (no OIDC), so providers.IssuerOf returns "" for
+// the resulting provider. Consumers that rely on AcceptForwardedIDToken must
+// not configure GitHub as the upstream provider.
+func GitHubFromEnv() (providers.Provider, error) {
+	return GitHubFromEnvWithPrefix("OAUTH_")
+}
+
+// GitHubFromEnvWithPrefix is [GitHubFromEnv] with a caller-supplied prefix.
+func GitHubFromEnvWithPrefix(prefix string) (providers.Provider, error) {
+	clientID, err := requireString(prefix + "GITHUB_CLIENT_ID")
+	if err != nil {
+		return nil, err
+	}
+	redirectURL, err := requireString(prefix + "GITHUB_REDIRECT_URL")
+	if err != nil {
+		return nil, err
+	}
+	clientSecret, err := requireSecret(prefix + "GITHUB_CLIENT_SECRET")
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := &github.Config{
+		ClientID:             clientID,
+		ClientSecret:         clientSecret,
+		RedirectURL:          redirectURL,
+		AllowedOrganizations: splitAndTrim(os.Getenv(prefix+"GITHUB_ALLOWED_ORGANIZATIONS"), ","),
+	}
+
+	if v := os.Getenv(prefix + "GITHUB_REQUIRE_VERIFIED_EMAIL"); v != "" {
+		rv, err := optionalBool(prefix+"GITHUB_REQUIRE_VERIFIED_EMAIL", true)
+		if err != nil {
+			return nil, err
+		}
+		cfg.RequireVerifiedEmail = &rv
+	}
+
+	return github.NewProvider(cfg)
+}
+
+// requireSecret is requireString that also understands the _FILE convention
+// used by [optionalSecret] — necessary because client secrets are mandatory
+// but may arrive via either channel. Returns a clear error if neither the
+// plain var nor the _FILE variant has a non-empty value.
+func requireSecret(name string) (string, error) {
+	v, err := optionalSecret(name)
+	if err != nil {
+		return "", err
+	}
+	if v == "" {
+		return "", fmt.Errorf("required environment variable %s (or %s_FILE) is not set", name, name)
+	}
+	return v, nil
+}

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -1,0 +1,282 @@
+package oauthconfig_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/mcp-oauth/oauthconfig"
+	"github.com/giantswarm/mcp-oauth/providers"
+)
+
+// clearProviderEnv zeroes every provider-related var this package reads.
+// Per-test t.Setenv calls then re-populate what each test actually exercises.
+func clearProviderEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"OAUTH_PROVIDER",
+		"OAUTH_DEX_ISSUER_URL",
+		"OAUTH_DEX_CLIENT_ID",
+		"OAUTH_DEX_CLIENT_SECRET",
+		"OAUTH_DEX_CLIENT_SECRET_FILE",
+		"OAUTH_DEX_REDIRECT_URL",
+		"OAUTH_DEX_CONNECTOR_ID",
+		"OAUTH_GOOGLE_CLIENT_ID",
+		"OAUTH_GOOGLE_CLIENT_SECRET",
+		"OAUTH_GOOGLE_CLIENT_SECRET_FILE",
+		"OAUTH_GOOGLE_REDIRECT_URL",
+		"OAUTH_GOOGLE_FORCE_CONSENT",
+		"OAUTH_GITHUB_CLIENT_ID",
+		"OAUTH_GITHUB_CLIENT_SECRET",
+		"OAUTH_GITHUB_CLIENT_SECRET_FILE",
+		"OAUTH_GITHUB_REDIRECT_URL",
+		"OAUTH_GITHUB_ALLOWED_ORGANIZATIONS",
+		"OAUTH_GITHUB_REQUIRE_VERIFIED_EMAIL",
+	} {
+		t.Setenv(v, "")
+	}
+}
+
+// Dex -----------------------------------------------------------------------
+
+func TestDexFromEnv_MissingIssuer(t *testing.T) {
+	clearProviderEnv(t)
+	_, err := oauthconfig.DexFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_DEX_ISSUER_URL") {
+		t.Fatalf("expected OAUTH_DEX_ISSUER_URL error, got %v", err)
+	}
+}
+
+func TestDexFromEnv_MissingClientID(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_DEX_ISSUER_URL", "https://dex.example")
+	_, err := oauthconfig.DexFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_DEX_CLIENT_ID") {
+		t.Fatalf("expected OAUTH_DEX_CLIENT_ID error, got %v", err)
+	}
+}
+
+func TestDexFromEnv_MissingRedirectURL(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_DEX_ISSUER_URL", "https://dex.example")
+	t.Setenv("OAUTH_DEX_CLIENT_ID", "cid")
+	_, err := oauthconfig.DexFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_DEX_REDIRECT_URL") {
+		t.Fatalf("expected OAUTH_DEX_REDIRECT_URL error, got %v", err)
+	}
+}
+
+func TestDexFromEnv_MissingClientSecret(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_DEX_ISSUER_URL", "https://dex.example")
+	t.Setenv("OAUTH_DEX_CLIENT_ID", "cid")
+	t.Setenv("OAUTH_DEX_REDIRECT_URL", "https://app.example/callback")
+	_, err := oauthconfig.DexFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_DEX_CLIENT_SECRET") {
+		t.Fatalf("expected OAUTH_DEX_CLIENT_SECRET error, got %v", err)
+	}
+}
+
+// TestDexFromEnv_SecretFilePrecedence verifies the _FILE variant is honored
+// by the loader. We can't easily assert the specific secret ended up on the
+// provider struct (fields are unexported), but we can verify the loader
+// passes secret-reading and advances to the Dex discovery network call,
+// which will fail with a discovery error — not a secret error.
+func TestDexFromEnv_SecretFilePrecedence(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_DEX_ISSUER_URL", "https://unreachable.invalid.example")
+	t.Setenv("OAUTH_DEX_CLIENT_ID", "cid")
+	t.Setenv("OAUTH_DEX_REDIRECT_URL", "https://app.example/callback")
+	t.Setenv("OAUTH_DEX_CLIENT_SECRET_FILE", writeSecretFile(t, "from-file\n"))
+
+	_, err := oauthconfig.DexFromEnv()
+	if err == nil {
+		t.Fatal("expected Dex discovery failure against unreachable host")
+	}
+	if strings.Contains(err.Error(), "CLIENT_SECRET") {
+		t.Errorf("secret stage should not have errored; got %v", err)
+	}
+}
+
+// Google --------------------------------------------------------------------
+
+func TestGoogleFromEnv_Happy(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_GOOGLE_CLIENT_ID", "gid")
+	t.Setenv("OAUTH_GOOGLE_CLIENT_SECRET", "gsecret")
+	t.Setenv("OAUTH_GOOGLE_REDIRECT_URL", "https://app.example/callback")
+
+	p, err := oauthconfig.GoogleFromEnv()
+	if err != nil {
+		t.Fatalf("GoogleFromEnv: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+	if p.Name() != "google" {
+		t.Errorf("Name() = %q, want google", p.Name())
+	}
+}
+
+func TestGoogleFromEnv_MissingClientID(t *testing.T) {
+	clearProviderEnv(t)
+	_, err := oauthconfig.GoogleFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_GOOGLE_CLIENT_ID") {
+		t.Fatalf("expected OAUTH_GOOGLE_CLIENT_ID error, got %v", err)
+	}
+}
+
+func TestGoogleFromEnv_SecretFile(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_GOOGLE_CLIENT_ID", "gid")
+	t.Setenv("OAUTH_GOOGLE_CLIENT_SECRET_FILE", writeSecretFile(t, "file-secret\n"))
+	t.Setenv("OAUTH_GOOGLE_REDIRECT_URL", "https://app.example/callback")
+
+	p, err := oauthconfig.GoogleFromEnv()
+	if err != nil {
+		t.Fatalf("GoogleFromEnv: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+}
+
+func TestGoogleFromEnv_ForceConsentOptional(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_GOOGLE_CLIENT_ID", "gid")
+	t.Setenv("OAUTH_GOOGLE_CLIENT_SECRET", "gsecret")
+	t.Setenv("OAUTH_GOOGLE_REDIRECT_URL", "https://app.example/callback")
+	t.Setenv("OAUTH_GOOGLE_FORCE_CONSENT", "false")
+
+	if _, err := oauthconfig.GoogleFromEnv(); err != nil {
+		t.Fatalf("GoogleFromEnv with FORCE_CONSENT=false: %v", err)
+	}
+}
+
+// GitHub --------------------------------------------------------------------
+
+func TestGitHubFromEnv_Happy(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
+	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
+	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
+
+	p, err := oauthconfig.GitHubFromEnv()
+	if err != nil {
+		t.Fatalf("GitHubFromEnv: %v", err)
+	}
+	if p == nil {
+		t.Fatal("nil provider")
+	}
+	if p.Name() != "github" {
+		t.Errorf("Name() = %q, want github", p.Name())
+	}
+	// GitHub is OAuth-only — IssuerOf must return "".
+	if got := providers.IssuerOf(p); got != "" {
+		t.Errorf("IssuerOf(github) = %q, want \"\"", got)
+	}
+}
+
+func TestGitHubFromEnv_AllowedOrganizations(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
+	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
+	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
+	t.Setenv("OAUTH_GITHUB_ALLOWED_ORGANIZATIONS", "org-a, org-b ,")
+
+	if _, err := oauthconfig.GitHubFromEnv(); err != nil {
+		t.Fatalf("GitHubFromEnv with ALLOWED_ORGANIZATIONS: %v", err)
+	}
+}
+
+func TestGitHubFromEnv_BadRequireVerifiedEmail(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
+	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
+	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
+	t.Setenv("OAUTH_GITHUB_REQUIRE_VERIFIED_EMAIL", "maybe")
+
+	_, err := oauthconfig.GitHubFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "REQUIRE_VERIFIED_EMAIL") {
+		t.Fatalf("expected bool parse error, got %v", err)
+	}
+}
+
+// ProviderFromEnv dispatcher ------------------------------------------------
+
+func TestProviderFromEnv_MissingProvider(t *testing.T) {
+	clearProviderEnv(t)
+	_, err := oauthconfig.ProviderFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_PROVIDER") {
+		t.Fatalf("expected OAUTH_PROVIDER required error, got %v", err)
+	}
+}
+
+func TestProviderFromEnv_UnknownProvider(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_PROVIDER", "okta")
+	_, err := oauthconfig.ProviderFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "unknown provider") {
+		t.Fatalf("expected unknown-provider error, got %v", err)
+	}
+}
+
+func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_PROVIDER", "google")
+	t.Setenv("OAUTH_GOOGLE_CLIENT_ID", "gid")
+	t.Setenv("OAUTH_GOOGLE_CLIENT_SECRET", "gsecret")
+	t.Setenv("OAUTH_GOOGLE_REDIRECT_URL", "https://app.example/callback")
+
+	p, err := oauthconfig.ProviderFromEnv()
+	if err != nil {
+		t.Fatalf("ProviderFromEnv: %v", err)
+	}
+	if p.Name() != "google" {
+		t.Errorf("Name() = %q, want google", p.Name())
+	}
+}
+
+func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
+	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
+	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
+
+	p, err := oauthconfig.ProviderFromEnv()
+	if err != nil {
+		t.Fatalf("ProviderFromEnv: %v", err)
+	}
+	if p.Name() != "github" {
+		t.Errorf("Name() = %q, want github", p.Name())
+	}
+}
+
+func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
+	// Dex's NewProvider performs OIDC discovery, which would network-fail here.
+	// Verify ProviderFromEnv routed to DexFromEnv by leaving a required Dex
+	// var unset and asserting the Dex-specific error surfaces.
+	clearProviderEnv(t)
+	t.Setenv("OAUTH_PROVIDER", "dex")
+	_, err := oauthconfig.ProviderFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "OAUTH_DEX_ISSUER_URL") {
+		t.Fatalf("expected DexFromEnv missing-issuer error, got %v", err)
+	}
+}
+
+func TestProviderFromEnv_WithPrefix(t *testing.T) {
+	clearProviderEnv(t)
+	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
+	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
+	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
+
+	p, err := oauthconfig.ProviderFromEnvWithPrefix("MUSTER_")
+	if err != nil {
+		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
+	}
+	if p.Name() != "github" {
+		t.Errorf("Name() = %q, want github", p.Name())
+	}
+}
+

--- a/oauthconfig/turnkey_test.go
+++ b/oauthconfig/turnkey_test.go
@@ -1,0 +1,133 @@
+package oauthconfig_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/giantswarm/mcp-oauth/oauthconfig"
+	"github.com/giantswarm/mcp-oauth/server"
+)
+
+// TestTurnkeyWiring proves the full oauthconfig loader surface composes into
+// a working server: FromEnv + NewEncryptorFromEnv + StorageFromEnv +
+// ProviderFromEnv → server.NewWithCombined. This is the complete end-to-end
+// path a typical consumer writes, and each piece is unit-tested in isolation
+// elsewhere — this test locks down the composition.
+//
+// Intentionally uses:
+//   - GitHub provider (synchronous construction, no network)
+//   - memory storage (default; no external dependency)
+//   - encryption key set via env
+//
+// Dex would need a live OIDC discovery server; Google and GitHub don't hit
+// the network during construction, so GitHub is the safe choice here.
+func TestTurnkeyWiring(t *testing.T) {
+	// Start from a clean env so stray CI vars can't skew the result.
+	clearRequired(t)
+	clearStorageEnv(t)
+	clearProviderEnv(t)
+
+	// Base server config.
+	t.Setenv("OAUTH_ISSUER", "https://auth.turnkey.test")
+	t.Setenv("OAUTH_ACCESS_TOKEN_TTL", "1h")
+	t.Setenv("OAUTH_ENCRYPTION_KEY", validKeyB64)
+	t.Setenv("OAUTH_SESSION_ID_HMAC_KEY", validKeyB64)
+
+	// Storage: memory (explicit, to prove the env var is honored through the
+	// composition, not just "default fall-through").
+	t.Setenv("STORAGE_BACKEND", "memory")
+
+	// Provider: GitHub. Synchronous construction, no network.
+	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "gh-client")
+	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "gh-secret")
+	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.turnkey.test/callback")
+
+	// ---- The composition the library's README will promise. ----
+	cfg, err := oauthconfig.FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+
+	encryptor, err := oauthconfig.NewEncryptorFromEnv()
+	if err != nil {
+		t.Fatalf("NewEncryptorFromEnv: %v", err)
+	}
+	if encryptor == nil {
+		t.Fatal("NewEncryptorFromEnv returned nil despite ENCRYPTION_KEY set")
+	}
+
+	store, closeFn, err := oauthconfig.StorageFromEnv(slog.Default())
+	if err != nil {
+		t.Fatalf("StorageFromEnv: %v", err)
+	}
+	t.Cleanup(func() { _ = closeFn() })
+
+	provider, err := oauthconfig.ProviderFromEnv()
+	if err != nil {
+		t.Fatalf("ProviderFromEnv: %v", err)
+	}
+
+	srv, err := server.NewWithCombined(provider, store, cfg, slog.Default())
+	if err != nil {
+		t.Fatalf("server.NewWithCombined: %v", err)
+	}
+
+	// Attaching the encryptor is the documented post-construction step; prove
+	// it wires through without a panic, since the whole point of
+	// NewEncryptorFromEnv is to be composable with SetEncryptor.
+	srv.SetEncryptor(encryptor)
+
+	// Minimal behavioral spot-check: the constructed server should accept a
+	// healthy provider check. Not asking for a round-trip OAuth flow — that
+	// is covered by the package's own integration tests — just that the
+	// composed pieces produce a functional *Server whose wired provider
+	// answers its contract.
+	if err := provider.HealthCheck(context.Background()); err != nil {
+		// GitHub HealthCheck hits api.github.com. Skipping is honest — we
+		// don't want a CI flake when GitHub is down. The point of this test
+		// is the composition step, not the provider's health.
+		t.Logf("provider HealthCheck returned %v (non-fatal; test is about composition)", err)
+	}
+
+	// Final sanity: each loader returned the shape the constructor expects.
+	if srv == nil {
+		t.Fatal("*Server should not be nil after successful NewWithCombined")
+	}
+	if cfg.Issuer != "https://auth.turnkey.test" {
+		t.Errorf("Issuer = %q, want https://auth.turnkey.test", cfg.Issuer)
+	}
+	if len(cfg.SessionIDHMACKey) != 32 {
+		t.Errorf("SessionIDHMACKey length = %d, want 32 (base64-decoded from validKeyB64)", len(cfg.SessionIDHMACKey))
+	}
+	if provider.Name() != "github" {
+		t.Errorf("provider.Name() = %q, want github", provider.Name())
+	}
+}
+
+// clearRequired is a superset of the helpers in env_test.go / storage_test.go
+// / provider_test.go that zeros everything the turnkey path reads. Keeping a
+// local copy (rather than exporting the package-internal clear helpers) keeps
+// the test surface minimal.
+func clearRequired(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{
+		"OAUTH_ISSUER",
+		"OAUTH_ALLOW_INSECURE_HTTP",
+		"OAUTH_ALLOW_PUBLIC_CLIENT_REGISTRATION",
+		"OAUTH_TRUST_PROXY",
+		"OAUTH_ACCESS_TOKEN_TTL",
+		"OAUTH_REFRESH_TOKEN_TTL",
+		"OAUTH_MAX_CLIENTS_PER_IP",
+		"OAUTH_REGISTRATION_ACCESS_TOKEN",
+		"OAUTH_REGISTRATION_ACCESS_TOKEN_FILE",
+		"OAUTH_ENCRYPTION_KEY",
+		"OAUTH_ENCRYPTION_KEY_FILE",
+		"OAUTH_SESSION_ID_HMAC_KEY",
+		"OAUTH_SESSION_ID_HMAC_KEY_FILE",
+		"OAUTH_TRUSTED_AUDIENCES",
+	} {
+		t.Setenv(v, "")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `DexFromEnv`, `GoogleFromEnv`, `GitHubFromEnv` and a `ProviderFromEnv` dispatcher. Replaces the ~10-line `dex.NewProvider(&dex.Config{...})` block every Giant Swarm consumer hardcodes, and gives external adopters a turn-key path for the other in-tree providers without forcing a custom wrapper.

**Stacked on #270.** Rebase target is `feat/storage-combined`; auto-retargets to `main` once the parent merges.

## API

```go
// Per-provider (hardcoded consumers):
oauthconfig.DexFromEnv()    (providers.Provider, error)
oauthconfig.GoogleFromEnv() (providers.Provider, error)
oauthconfig.GitHubFromEnv() (providers.Provider, error)

// Dispatcher (choose at deploy time via OAUTH_PROVIDER):
oauthconfig.ProviderFromEnv() (providers.Provider, error)
oauthconfig.ProviderFromEnvWithPrefix(prefix string) (providers.Provider, error)
```

Full variable list in the per-loader godocs; secret vars honor the `_FILE` convention established in #269.

## Deliberately unexposed fields (across all three loaders)

The loaders expose the required + commonly-tuned fields only. Each per-loader godoc now lists the fields the loader does NOT expose as env vars, with rationale:

- **`Scopes`** — provider defaults cover the common case; custom scopes are a programmatic choice.
- **`HTTPClient`** — not serializable as an env var (proxies, custom TLS, test doubles).
- **`RequestTimeout`** — default 30s is sound; operators rarely tune per deployment.
- **`MaxGroups`** (Dex) — enterprise-specific tuning; default 600 covers the common case.
- **`HostedDomain`** (Google) — `google.Config` does not currently expose workspace-domain restriction. Once that field exists on the Config struct, a follow-up can add the env var.

Callers needing any of these construct the provider's `Config` programmatically and call `NewProvider` directly, bypassing this loader.

## Migration impact

Once the stack (#266, #269, #270) merges, consumer cleanup:

- muster, mcp-prometheus, mcp-observability-platform each replace their ~10-line `dex.NewProvider(...)` block with a single `oauthconfig.DexFromEnv()` call (or `ProviderFromEnvWithPrefix("MUSTER_OAUTH_")` in muster's case for its custom prefix).