### PR TITLE
feat(storage/mock): CombinedStore + NewCombined

### DIFF
--- a/storage/mock/mock_combined.go
+++ b/storage/mock/mock_combined.go
@@ -1,0 +1,46 @@
+package mock
+
+import "github.com/giantswarm/mcp-oauth/storage"
+
+// CombinedStore bundles the three per-interface mocks into a single type that
+// satisfies [storage.Combined]. It lets tests construct a Server via
+// [server.NewWithCombined] with one argument instead of three:
+//
+//	store := mock.NewCombined()
+//	srv, _ := server.NewWithCombined(provider, store, cfg, logger)
+//
+// The individual mock fields remain accessible when a test wants to install
+// custom behavior or inspect CallCounts — e.g. store.TokenStore.SaveTokenFunc
+// or store.ClientStore.CallCounts. The embedded ResetCallCounts methods are
+// ambiguous at the CombinedStore level by design (Go won't promote a method
+// name shared by three embedded types); use the individual pointers or the
+// [CombinedStore.ResetAllCallCounts] helper below.
+type CombinedStore struct {
+	*TokenStore
+	*ClientStore
+	*FlowStore
+}
+
+// NewCombined returns a CombinedStore with freshly constructed
+// TokenStore/ClientStore/FlowStore mocks (each via their existing constructors).
+func NewCombined() *CombinedStore {
+	return &CombinedStore{
+		TokenStore:  NewTokenStore(),
+		ClientStore: NewClientStore(),
+		FlowStore:   NewFlowStore(),
+	}
+}
+
+// ResetAllCallCounts forwards to each embedded mock's ResetCallCounts. Exists
+// because the bare ResetCallCounts method is ambiguous on *CombinedStore — all
+// three embedded types expose one.
+func (c *CombinedStore) ResetAllCallCounts() {
+	c.TokenStore.ResetCallCounts()
+	c.ClientStore.ResetCallCounts()
+	c.FlowStore.ResetCallCounts()
+}
+
+// Compile-time assertion: CombinedStore satisfies the public union interface.
+// If this breaks, the embedded mocks' method sets have drifted from the real
+// storage interfaces — fix the mock rather than relax this assertion.
+var _ storage.Combined = (*CombinedStore)(nil)

--- a/storage/mock/mock_combined_test.go
+++ b/storage/mock/mock_combined_test.go
@@ -1,0 +1,108 @@
+package mock_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+	"github.com/giantswarm/mcp-oauth/storage/mock"
+)
+
+// TestCombinedStore_RoundTrip exercises one method from each of the three
+// embedded interfaces against a single CombinedStore value, proving the
+// interface is satisfied by the embedded mocks and that the underlying state
+// is per-mock (not shared).
+func TestCombinedStore_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	store := mock.NewCombined()
+
+	// TokenStore leg.
+	if err := store.SaveToken(ctx, "user-1", &oauth2.Token{AccessToken: "at-1"}); err != nil {
+		t.Fatalf("SaveToken: %v", err)
+	}
+	if tok, err := store.GetToken(ctx, "user-1"); err != nil {
+		t.Fatalf("GetToken: %v", err)
+	} else if tok.AccessToken != "at-1" {
+		t.Errorf("GetToken.AccessToken = %q, want at-1", tok.AccessToken)
+	}
+
+	// ClientStore leg.
+	client := &storage.Client{
+		ClientID:   "client-1",
+		ClientType: "public",
+		CreatedAt:  time.Now(),
+	}
+	if err := store.SaveClient(ctx, client); err != nil {
+		t.Fatalf("SaveClient: %v", err)
+	}
+	if c, err := store.GetClient(ctx, "client-1"); err != nil {
+		t.Fatalf("GetClient: %v", err)
+	} else if c.ClientID != "client-1" {
+		t.Errorf("GetClient.ClientID = %q, want client-1", c.ClientID)
+	}
+
+	// FlowStore leg.
+	if err := store.SaveAuthorizationState(ctx, &storage.AuthorizationState{
+		StateID:       "state-1",
+		ProviderState: "provider-state-1",
+		ClientID:      "client-1",
+		ExpiresAt:     time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("SaveAuthorizationState: %v", err)
+	}
+	if s, err := store.GetAuthorizationState(ctx, "state-1"); err != nil {
+		t.Fatalf("GetAuthorizationState: %v", err)
+	} else if s.StateID != "state-1" {
+		t.Errorf("GetAuthorizationState.StateID = %q, want state-1", s.StateID)
+	}
+}
+
+// TestCombinedStore_ResetAllCallCounts verifies the disambiguation helper
+// calls through to each embedded mock. The bare ResetCallCounts method is
+// ambiguous by design on CombinedStore because all three embedded types
+// expose one; the helper exists so callers don't need to remember that.
+func TestCombinedStore_ResetAllCallCounts(t *testing.T) {
+	ctx := context.Background()
+	store := mock.NewCombined()
+
+	_ = store.SaveToken(ctx, "u", &oauth2.Token{AccessToken: "at"})
+	_ = store.SaveClient(ctx, &storage.Client{ClientID: "c", ClientType: "public"})
+	_ = store.SaveAuthorizationState(ctx, &storage.AuthorizationState{
+		StateID:       "s",
+		ProviderState: "ps",
+		ExpiresAt:     time.Now().Add(time.Hour),
+	})
+
+	// Sanity: each mock recorded its call.
+	if store.TokenStore.CallCounts["SaveToken"] != 1 {
+		t.Errorf("TokenStore.CallCounts[SaveToken] = %d, want 1", store.TokenStore.CallCounts["SaveToken"])
+	}
+	if store.ClientStore.CallCounts["SaveClient"] != 1 {
+		t.Errorf("ClientStore.CallCounts[SaveClient] = %d, want 1", store.ClientStore.CallCounts["SaveClient"])
+	}
+	if store.FlowStore.CallCounts["SaveAuthorizationState"] != 1 {
+		t.Errorf("FlowStore.CallCounts[SaveAuthorizationState] = %d, want 1", store.FlowStore.CallCounts["SaveAuthorizationState"])
+	}
+
+	store.ResetAllCallCounts()
+
+	if store.TokenStore.CallCounts["SaveToken"] != 0 {
+		t.Errorf("after Reset: TokenStore.CallCounts[SaveToken] = %d, want 0", store.TokenStore.CallCounts["SaveToken"])
+	}
+	if store.ClientStore.CallCounts["SaveClient"] != 0 {
+		t.Errorf("after Reset: ClientStore.CallCounts[SaveClient] = %d, want 0", store.ClientStore.CallCounts["SaveClient"])
+	}
+	if store.FlowStore.CallCounts["SaveAuthorizationState"] != 0 {
+		t.Errorf("after Reset: FlowStore.CallCounts[SaveAuthorizationState] = %d, want 0", store.FlowStore.CallCounts["SaveAuthorizationState"])
+	}
+}
+
+// TestCombinedStore_SatisfiesInterface is a compile+runtime assertion
+// companion to the package-level var — keeps the contract visible in test
+// output when someone intentionally or accidentally breaks embedding.
+func TestCombinedStore_SatisfiesInterface(t *testing.T) {
+	var _ storage.Combined = mock.NewCombined()
+}

--- a/storage/mock/mock_combined_test.go
+++ b/storage/mock/mock_combined_test.go
@@ -7,6 +7,8 @@ import (
 
 	"golang.org/x/oauth2"
 
+	mockproviders "github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/server"
 	"github.com/giantswarm/mcp-oauth/storage"
 	"github.com/giantswarm/mcp-oauth/storage/mock"
 )
@@ -105,4 +107,52 @@ func TestCombinedStore_ResetAllCallCounts(t *testing.T) {
 // output when someone intentionally or accidentally breaks embedding.
 func TestCombinedStore_SatisfiesInterface(t *testing.T) {
 	var _ storage.Combined = mock.NewCombined()
+}
+
+// TestCombinedStore_WithNewWithCombined is the end-to-end composition test:
+// mock.NewCombined() passed to server.NewWithCombined should produce a
+// functional *Server. Each piece is unit-tested in isolation — PR 5 covers
+// NewWithCombined's pointer-identity, this package covers the mock's
+// interface satisfaction — this test locks down the combination so the two
+// APIs cannot drift apart without failing here.
+//
+// Concrete reason to have it: if someone adds a method to storage.TokenStore
+// without implementing it on mock.TokenStore, the compile-time assertion
+// already catches that. But the actual server-construction path — which
+// uses the embedded interface promotion to satisfy all three separate
+// storage arguments to server.New from a single *CombinedStore — also needs
+// to work, and that's what THIS test proves.
+func TestCombinedStore_WithNewWithCombined(t *testing.T) {
+	store := mock.NewCombined()
+	provider := mockproviders.NewProvider()
+
+	srv, err := server.NewWithCombined(provider, store, &server.Config{
+		Issuer: "https://auth.test.example",
+	}, nil)
+	if err != nil {
+		t.Fatalf("server.NewWithCombined(mock.NewCombined()): %v", err)
+	}
+	if srv == nil {
+		t.Fatal("*Server should not be nil after successful construction")
+	}
+
+	// Exercise one method from each embedded interface through the store to
+	// prove the mocks wired behind the server are live and addressable —
+	// not just a compile-time trick.
+	ctx := context.Background()
+	if err := store.SaveToken(ctx, "u-1", &oauth2.Token{AccessToken: "at"}); err != nil {
+		t.Fatalf("SaveToken via CombinedStore: %v", err)
+	}
+	if err := store.SaveClient(ctx, &storage.Client{ClientID: "c-1", ClientType: "public"}); err != nil {
+		t.Fatalf("SaveClient via CombinedStore: %v", err)
+	}
+
+	// Per-mock CallCounts remain reachable — the point of keeping the
+	// embedded pointers visible rather than flattening them away.
+	if store.TokenStore.CallCounts["SaveToken"] != 1 {
+		t.Errorf("TokenStore.CallCounts[SaveToken] = %d, want 1", store.TokenStore.CallCounts["SaveToken"])
+	}
+	if store.ClientStore.CallCounts["SaveClient"] != 1 {
+		t.Errorf("ClientStore.CallCounts[SaveClient] = %d, want 1", store.ClientStore.CallCounts["SaveClient"])
+	}
 }


### PR DESCRIPTION
## Summary

Companion to #270 (`storage.Combined` + `server.NewWithCombined`). Tests currently wire a Server via three separate mock constructors:

```go
NewServer(p, mock.NewTokenStore(), mock.NewClientStore(), mock.NewFlowStore(), cfg, logger)
```

With `mock.NewCombined()` that becomes:

```go
NewServerWithCombined(p, mock.NewCombined(), cfg, logger)
```

**Stacked on #270.** Rebase target is `feat/storage-combined`; auto-retargets to `main` when the parent merges.

## Implementation

- `CombinedStore` embeds `*TokenStore`, `*ClientStore`, `*FlowStore`. The `storage.Combined` interface methods come from three disjoint interfaces, so embedding promotes the full method set cleanly.
- `NewCombined()` constructs each embedded mock via its existing constructor. No duplication.
- `ResetCallCounts` is ambiguous on `*CombinedStore` by design — all three embedded types expose one. Added `ResetAllCallCounts()` helper for the "reset everything between subtests" case; per-mock reset still works via `store.TokenStore.ResetCallCounts()` etc.
- Compile-time assertion `var _ storage.Combined = (*CombinedStore)(nil)` plus a runtime-visible `TestCombinedStore_SatisfiesInterface` so future interface drift surfaces in both `go build` and test output.

## Migration impact (follow-up, out of scope here)

~40 call sites in `server/*_test.go` and `handler_test.go` pass three separate `mock.New*` values to `NewServer`. A follow-up sweep can collapse them to `mock.NewCombined()` + `NewServerWithCombined`. Kept out of this PR to keep it focused — each `TokenStore`-specific test that installs custom `*Func` fields still works because the embedded `*TokenStore` is reachable as `store.TokenStore`.