### PR TITLE
feat(oauthconfig): FromEnv reads OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS + OAUTH_TRUSTED_REDIRECT_SCHEMES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **oauthconfig.FromEnv: cover `AllowLocalhostRedirectURIs` and `TrustedPublicRegistrationSchemes`**
+  - New `OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS` (bool) and `OAUTH_TRUSTED_REDIRECT_SCHEMES` (comma-separated) env vars are now read by `FromEnv` / `FromEnvWithPrefix`. `OAUTH_TRUSTED_REDIRECT_SCHEMES` populates `server.Config.TrustedPublicRegistrationSchemes`.
+  - Removes the need for downstream consumers (mcp-observability-platform, muster, mcp-prometheus) to set `srvCfg.AllowLocalhostRedirectURIs = true` and `srvCfg.TrustedPublicRegistrationSchemes = []string{...}` manually after `FromEnv()`.
+
 ### Fixed
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**

--- a/oauthconfig/doc.go
+++ b/oauthconfig/doc.go
@@ -21,6 +21,9 @@
 //   - OAUTH_MAX_CLIENTS_PER_IP                — positive integer
 //   - OAUTH_TRUST_PROXY                       (default false)
 //   - OAUTH_TRUSTED_AUDIENCES                 — comma-separated audience list
+//   - OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS     (default false) — RFC 8252 native-app loopback support
+//   - OAUTH_TRUSTED_REDIRECT_SCHEMES          — comma-separated URI schemes (e.g. "cursor,vscode")
+//     populates server.Config.TrustedPublicRegistrationSchemes
 //
 // Defaults are not applied in this package. [FromEnv] only populates the
 // fields it reads; server.New runs applyDefaults afterwards and is the single

--- a/oauthconfig/env.go
+++ b/oauthconfig/env.go
@@ -89,6 +89,15 @@ func FromEnvWithPrefix(prefix string) (*server.Config, error) {
 		cfg.TrustedAudiences = splitAndTrim(raw, ",")
 	}
 
+	cfg.AllowLocalhostRedirectURIs, err = optionalBool(prefix+"ALLOW_LOCALHOST_REDIRECT_URIS", false)
+	if err != nil {
+		return nil, err
+	}
+
+	if raw := os.Getenv(prefix + "TRUSTED_REDIRECT_SCHEMES"); raw != "" {
+		cfg.TrustedPublicRegistrationSchemes = splitAndTrim(raw, ",")
+	}
+
 	return cfg, nil
 }
 

--- a/oauthconfig/env_test.go
+++ b/oauthconfig/env_test.go
@@ -48,6 +48,8 @@ func setRequired(t *testing.T, issuer string) {
 		"OAUTH_SESSION_ID_HMAC_KEY",
 		"OAUTH_SESSION_ID_HMAC_KEY_FILE",
 		"OAUTH_TRUSTED_AUDIENCES",
+		"OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS",
+		"OAUTH_TRUSTED_REDIRECT_SCHEMES",
 	} {
 		t.Setenv(v, "")
 	}
@@ -67,6 +69,8 @@ func TestFromEnv_HappyPath(t *testing.T) {
 	t.Setenv("OAUTH_ENCRYPTION_KEY", validKeyB64)
 	t.Setenv("OAUTH_SESSION_ID_HMAC_KEY", validKeyB64)
 	t.Setenv("OAUTH_TRUSTED_AUDIENCES", "muster-client, second-aud ,")
+	t.Setenv("OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS", "true")
+	t.Setenv("OAUTH_TRUSTED_REDIRECT_SCHEMES", "cursor, vscode ,, vscode-insiders")
 
 	cfg, err := oauthconfig.FromEnv()
 	if err != nil {
@@ -99,6 +103,13 @@ func TestFromEnv_HappyPath(t *testing.T) {
 	want := []string{"muster-client", "second-aud"}
 	if !reflect.DeepEqual(cfg.TrustedAudiences, want) {
 		t.Errorf("TrustedAudiences = %v, want %v", cfg.TrustedAudiences, want)
+	}
+	if !cfg.AllowLocalhostRedirectURIs {
+		t.Errorf("AllowLocalhostRedirectURIs = false")
+	}
+	wantSchemes := []string{"cursor", "vscode", "vscode-insiders"}
+	if !reflect.DeepEqual(cfg.TrustedPublicRegistrationSchemes, wantSchemes) {
+		t.Errorf("TrustedPublicRegistrationSchemes = %v, want %v", cfg.TrustedPublicRegistrationSchemes, wantSchemes)
 	}
 }
 
@@ -271,6 +282,8 @@ func TestFromEnvWithPrefix(t *testing.T) {
 	setRequired(t, "")
 	t.Setenv("MUSTER_OAUTH_ISSUER", "https://muster.example")
 	t.Setenv("MUSTER_OAUTH_TRUSTED_AUDIENCES", "agentcore-runtime")
+	t.Setenv("MUSTER_OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS", "true")
+	t.Setenv("MUSTER_OAUTH_TRUSTED_REDIRECT_SCHEMES", "cursor")
 
 	cfg, err := oauthconfig.FromEnvWithPrefix("MUSTER_OAUTH_")
 	if err != nil {
@@ -281,6 +294,12 @@ func TestFromEnvWithPrefix(t *testing.T) {
 	}
 	if want := []string{"agentcore-runtime"}; !reflect.DeepEqual(cfg.TrustedAudiences, want) {
 		t.Errorf("TrustedAudiences = %v, want %v", cfg.TrustedAudiences, want)
+	}
+	if !cfg.AllowLocalhostRedirectURIs {
+		t.Errorf("AllowLocalhostRedirectURIs = false")
+	}
+	if want := []string{"cursor"}; !reflect.DeepEqual(cfg.TrustedPublicRegistrationSchemes, want) {
+		t.Errorf("TrustedPublicRegistrationSchemes = %v, want %v", cfg.TrustedPublicRegistrationSchemes, want)
 	}
 }
 
@@ -340,5 +359,27 @@ func TestFromEnv_EmptyTrustedAudiencesOmitted(t *testing.T) {
 	}
 	if len(cfg.TrustedAudiences) != 0 {
 		t.Errorf("TrustedAudiences = %v, want empty (whitespace-only entries dropped)", cfg.TrustedAudiences)
+	}
+}
+
+func TestFromEnv_BadAllowLocalhostRedirectURIs(t *testing.T) {
+	setRequired(t, "https://auth.example")
+	t.Setenv("OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS", "maybe")
+	_, err := oauthconfig.FromEnv()
+	if err == nil || !strings.Contains(err.Error(), "ALLOW_LOCALHOST_REDIRECT_URIS") {
+		t.Fatalf("expected bool parse error on ALLOW_LOCALHOST_REDIRECT_URIS, got %v", err)
+	}
+}
+
+func TestFromEnv_EmptyTrustedRedirectSchemesOmitted(t *testing.T) {
+	setRequired(t, "https://auth.example")
+	t.Setenv("OAUTH_TRUSTED_REDIRECT_SCHEMES", "  , , ")
+
+	cfg, err := oauthconfig.FromEnv()
+	if err != nil {
+		t.Fatalf("FromEnv: %v", err)
+	}
+	if len(cfg.TrustedPublicRegistrationSchemes) != 0 {
+		t.Errorf("TrustedPublicRegistrationSchemes = %v, want empty (whitespace-only entries dropped)", cfg.TrustedPublicRegistrationSchemes)
 	}
 }

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 )
 
+// githubProviderName is providers.Provider.Name() for the GitHub provider.
+// Constant exists to satisfy goconst (the literal "github" appears in several
+// Setenv / Name() assertions across tests in this file).
+const githubProviderName = "github"
+
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
 func clearProviderEnv(t *testing.T) {
@@ -167,8 +172,8 @@ func TestGitHubFromEnv_Happy(t *testing.T) {
 	if p == nil {
 		t.Fatal("nil provider")
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 	// GitHub is OAuth-only — IssuerOf must return "".
 	if got := providers.IssuerOf(p); got != "" {
@@ -238,7 +243,7 @@ func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
 
 func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_PROVIDER", githubProviderName)
 	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -247,8 +252,8 @@ func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 
@@ -266,7 +271,7 @@ func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
 
 func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_PROVIDER", githubProviderName)
 	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -275,8 +280,8 @@ func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes gaps #1 and #2 of the v0.2.109 → v0.2.110 consumer-friction list. Both
tunables are wired post-`FromEnv()` in every downstream consumer
(mcp-observability-platform, muster, mcp-prometheus); folding them into the
loader removes that boilerplate.

- `OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS` — `optionalBool`, default `false`.
  RFC 8252 native-app loopback support (Claude Code, mcp-inspector).
- `OAUTH_TRUSTED_REDIRECT_SCHEMES` — comma-separated, `splitAndTrim`. Populates
  `server.Config.TrustedPublicRegistrationSchemes` so clients like Cursor /
  VS Code can register without a token. Mirrors `OAUTH_TRUSTED_AUDIENCES`'
  shape and the `splitAndTrim` empty-handling.

Additive: `FromEnv` continues to work unchanged when neither var is set.
Defaults still belong to `server.applyDefaults`; `FromEnv` only populates
what the operator provided.

## Consumer migration

Delete the two manual assignments after `oauthconfig.FromEnv()`:

```go
srvCfg.AllowLocalhostRedirectURIs = true
srvCfg.TrustedPublicRegistrationSchemes = []string{"cursor", "vscode"}
```

Replace with env vars in the deployment (Helm values / ConfigMap):

```
OAUTH_ALLOW_LOCALHOST_REDIRECT_URIS=true
OAUTH_TRUSTED_REDIRECT_SCHEMES=cursor,vscode,vscode-insiders
```

## Test plan

- [x] `go test ./oauthconfig/...` — happy-path, prefix variant, bad-bool error,
      whitespace-only schemes omitted
- [x] `go vet ./...`
- [x] `go build ./...`
- [ ] Downstream verify: bump `mcp-oauth` in mcp-observability-platform's
      `cmd/oauth.go` (branch `chore/simplify-yagni`) and confirm the post-`FromEnv`
      lines disappear without behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)