### PR TITLE
feat(oauthconfig): NewEncryptorFromEnv accepts base64 OR hex encryption keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **oauthconfig.NewEncryptorFromEnv accepts hex-encoded keys**
+  - `OAUTH_ENCRYPTION_KEY` is now decoded as base64 first (canonical, `openssl rand -base64 32`); on any failure the value is retried as hex (`openssl rand -hex 32`). Reinstates hex support that was dropped in an earlier refactor and broke operators with hex-generated keys.
+  - Additive: existing base64 deployments are unaffected.
+
 ### Fixed
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**

--- a/oauthconfig/doc.go
+++ b/oauthconfig/doc.go
@@ -13,7 +13,7 @@
 //   - OAUTH_ALLOW_INSECURE_HTTP               (default false) — permit http:// issuer
 //   - OAUTH_ALLOW_PUBLIC_CLIENT_REGISTRATION  (default false)
 //   - OAUTH_REGISTRATION_ACCESS_TOKEN         — registration bearer; see _FILE note below
-//   - OAUTH_ENCRYPTION_KEY                    — base64 32-byte AES-GCM key
+//   - OAUTH_ENCRYPTION_KEY                    — 32-byte AES-GCM key, base64 (preferred) or hex
 //   - OAUTH_SESSION_ID_HMAC_KEY               — base64 32-byte HMAC key
 //     (see server.Config.SessionIDHMACKey for the operator caveat)
 //   - OAUTH_ACCESS_TOKEN_TTL                  — Go duration (e.g. "1h")

--- a/oauthconfig/env.go
+++ b/oauthconfig/env.go
@@ -148,9 +148,14 @@ func loadSessionIDHMACKey(prefix string, cfg *server.Config) error {
 }
 
 // NewEncryptorFromEnv reads OAUTH_ENCRYPTION_KEY (or OAUTH_ENCRYPTION_KEY_FILE)
-// as a base64-encoded 32-byte AES-GCM key and returns a *security.Encryptor
-// ready to pass to server.SetEncryptor. Returns (nil, nil) when no key is
-// configured — callers can decide whether to require encryption.
+// as a 32-byte AES-GCM key and returns a *security.Encryptor ready to pass to
+// server.SetEncryptor. Returns (nil, nil) when no key is configured — callers
+// can decide whether to require encryption.
+//
+// The key may be encoded as either base64 (canonical, produced by
+// `openssl rand -base64 32`) or hex (`openssl rand -hex 32`). Base64 is tried
+// first; on any failure (decode error or wrong length) the value is retried as
+// hex. base64 is the recommended form.
 //
 // Separate from [FromEnv] because token-at-rest encryption is wired via
 // server.SetEncryptor after server construction, not through *server.Config.
@@ -161,18 +166,39 @@ func NewEncryptorFromEnv() (*security.Encryptor, error) {
 // NewEncryptorFromEnvWithPrefix is [NewEncryptorFromEnv] with a caller-supplied
 // prefix. See [FromEnvWithPrefix] for the convention.
 func NewEncryptorFromEnvWithPrefix(prefix string) (*security.Encryptor, error) {
-	encB64, err := optionalSecret(prefix + "ENCRYPTION_KEY")
+	raw, err := optionalSecret(prefix + "ENCRYPTION_KEY")
 	if err != nil {
 		return nil, err
 	}
-	if encB64 == "" {
+	if raw == "" {
 		return nil, nil
 	}
-	key, err := security.KeyFromBase64(encB64)
+	key, err := decodeSymmetricKey(raw)
 	if err != nil {
 		return nil, fmt.Errorf("%sENCRYPTION_KEY: %w", prefix, err)
 	}
 	return security.NewEncryptor(key)
+}
+
+// decodeSymmetricKey decodes a 32-byte symmetric key from either base64 (the
+// canonical form produced by `openssl rand -base64 32`) or hex
+// (`openssl rand -hex 32`). Base64 is attempted first; on any failure — bad
+// charset OR a decoded length other than 32 — the value is retried as hex.
+//
+// The fallback exists because the previous loader accepted only base64, and
+// dropping hex support broke operators who had generated keys with
+// `openssl rand -hex 32`. The two encodings have disjoint shapes when the
+// underlying key really is 32 bytes (base64 → 44 chars with `=` padding;
+// hex → 64 chars [0-9a-f]), so the order is unambiguous in practice.
+func decodeSymmetricKey(s string) ([]byte, error) {
+	if key, err := security.KeyFromBase64(s); err == nil {
+		return key, nil
+	}
+	key, err := security.KeyFromHex(s)
+	if err != nil {
+		return nil, fmt.Errorf("expected base64 or hex 32-byte key: %w", err)
+	}
+	return key, nil
 }
 
 // requireString returns os.Getenv(name) or an error if empty.

--- a/oauthconfig/env_test.go
+++ b/oauthconfig/env_test.go
@@ -2,6 +2,7 @@ package oauthconfig_test
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -15,6 +16,10 @@ import (
 // security.KeyFromBase64 requires for both ENCRYPTION_KEY and
 // SESSION_ID_HMAC_KEY.
 var validKeyB64 = base64.StdEncoding.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
+
+// validKeyHex is the same 32-byte key encoded as hex — the form produced by
+// `openssl rand -hex 32`. NewEncryptorFromEnv accepts both encodings.
+var validKeyHex = hex.EncodeToString([]byte("0123456789abcdef0123456789abcdef"))
 
 // writeSecretFile writes v to a temp file and returns its path. The file is
 // cleaned up automatically at test end via t.TempDir.
@@ -320,14 +325,64 @@ func TestNewEncryptorFromEnv(t *testing.T) {
 		}
 	})
 
-	t.Run("bad-base64", func(t *testing.T) {
+	t.Run("bad-encoding", func(t *testing.T) {
 		setRequired(t, "")
 		t.Setenv("OAUTH_ENCRYPTION_KEY", "not-base64-!!")
 		_, err := oauthconfig.NewEncryptorFromEnv()
 		if err == nil || !strings.Contains(err.Error(), "ENCRYPTION_KEY") {
-			t.Fatalf("expected base64 error, got %v", err)
+			t.Fatalf("expected ENCRYPTION_KEY decode error, got %v", err)
 		}
 	})
+}
+
+// TestNewEncryptorFromEnv_KeyEncodings exercises the base64/hex acceptance
+// matrix introduced when hex support was reinstated. Operators historically
+// generated keys with `openssl rand -hex 32`; dropping hex broke those
+// deployments. Base64 stays canonical (and is tried first), hex is the
+// documented fallback.
+func TestNewEncryptorFromEnv_KeyEncodings(t *testing.T) {
+	tooShortB64 := base64.StdEncoding.EncodeToString([]byte("too-short"))
+	tooShortHex := hex.EncodeToString([]byte("too-short"))
+
+	cases := []struct {
+		name    string
+		envKey  string
+		fileKey string
+		wantErr bool
+		wantEnc bool
+	}{
+		{name: "base64", envKey: validKeyB64, wantEnc: true},
+		{name: "hex", envKey: validKeyHex, wantEnc: true},
+		{name: "base64 via _FILE", fileKey: validKeyB64 + "\n", wantEnc: true},
+		{name: "hex via _FILE", fileKey: validKeyHex + "\n", wantEnc: true},
+		{name: "neither base64 nor hex rejected", envKey: "definitely-neither-!!", wantErr: true},
+		{name: "wrong-length base64 rejected", envKey: tooShortB64, wantErr: true},
+		{name: "wrong-length hex rejected", envKey: tooShortHex, wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setRequired(t, "")
+			if tc.envKey != "" {
+				t.Setenv("OAUTH_ENCRYPTION_KEY", tc.envKey)
+			}
+			if tc.fileKey != "" {
+				t.Setenv("OAUTH_ENCRYPTION_KEY_FILE", writeSecretFile(t, tc.fileKey))
+			}
+			enc, err := oauthconfig.NewEncryptorFromEnv()
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "ENCRYPTION_KEY") {
+					t.Fatalf("expected ENCRYPTION_KEY error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewEncryptorFromEnv: %v", err)
+			}
+			if tc.wantEnc && enc == nil {
+				t.Fatal("expected non-nil Encryptor")
+			}
+		})
+	}
 }
 
 func TestFromEnv_EmptyTrustedAudiencesOmitted(t *testing.T) {

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 )
 
+// githubProviderName is providers.Provider.Name() for the GitHub provider.
+// Constant exists to satisfy goconst (the literal "github" appears in several
+// Setenv / Name() assertions across tests in this file).
+const githubProviderName = "github"
+
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
 func clearProviderEnv(t *testing.T) {
@@ -167,8 +172,8 @@ func TestGitHubFromEnv_Happy(t *testing.T) {
 	if p == nil {
 		t.Fatal("nil provider")
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 	// GitHub is OAuth-only — IssuerOf must return "".
 	if got := providers.IssuerOf(p); got != "" {
@@ -238,7 +243,7 @@ func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
 
 func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_PROVIDER", githubProviderName)
 	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -247,8 +252,8 @@ func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 
@@ -266,7 +271,7 @@ func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
 
 func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_PROVIDER", githubProviderName)
 	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -275,8 +280,8 @@ func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes gap #3 of the v0.2.109 → v0.2.110 consumer-friction list.

`OAUTH_ENCRYPTION_KEY` (and its `_FILE` variant) now accepts either base64 or hex-encoded 32-byte keys:

- Base64 is tried first (existing behavior, recommended). `openssl rand -base64 32` produces this form.
- On any failure (charset OR length), the value is retried as hex. `openssl rand -hex 32` produces this form.
- If both fail, the error wraps the hex error for a concrete user-facing message.

Reinstates hex support that was dropped in an earlier refactor; some operators had generated keys with `openssl rand -hex 32` and saw startup failures after the migration. Fully additive — existing base64 deployments are unaffected.

`security.KeyFromHex` was already exported, so this is purely a loader-side change.

## Consumer migration

Nothing required if you're already using base64. Operators with hex keys can stop pre-decoding/re-encoding before exporting `OAUTH_ENCRYPTION_KEY`.

## Out of scope

`OAUTH_SESSION_ID_HMAC_KEY` still goes through `security.KeyFromBase64` only. Extending the same fallback there is a sensible follow-up — flagged but not bundled here so the change matches the scoped gap.

## Test plan

- [x] `go test ./oauthconfig/...` — table-driven `TestNewEncryptorFromEnv_KeyEncodings` covers base64+hex env, base64+hex `_FILE`, malformed input, wrong-length base64, wrong-length hex.
- [x] `go vet ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)