### PR TITLE
feat(oauthconfig)!: validate OAUTH_TRUSTED_AUDIENCES via dex.ValidateAudiences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **oauthconfig.FromEnv validates `OAUTH_TRUSTED_AUDIENCES` at startup**
+  - Each entry is now passed through `dex.ValidateAudiences`. Allowed charset is `[a-zA-Z0-9_-]` (per-entry max 256 chars, list max 50). Malformed values fail loudly at startup instead of silently failing token-acceptance later.
+  - **Behaviour change**: URL-shaped audiences (e.g. `https://api.example.com`) are rejected. The package documented RFC 8707 URI audiences previously; in practice all in-tree consumers use Dex client-id-shaped audiences. Operators with URL-shaped audiences must populate `oauth.Config.TrustedAudiences` programmatically rather than via env.
+
 ### Fixed
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**

--- a/oauthconfig/doc.go
+++ b/oauthconfig/doc.go
@@ -42,13 +42,19 @@
 // identifiers are not secrets. The asymmetry is intentional; the list lives in
 // deployment configuration (Helm values / ConfigMap) rather than in a Secret.
 //
-// # OAUTH_TRUSTED_AUDIENCES limitation
+// # OAUTH_TRUSTED_AUDIENCES charset and limits
 //
-// The value is split on literal commas. RFC 8707 audiences are URIs and URIs
-// should not contain literal commas, so this is safe in practice. Callers with
-// audiences containing commas for some other reason must populate
-// oauth.Config.TrustedAudiences programmatically instead of relying on this
-// loader.
+// The value is split on literal commas, then each non-empty entry is validated
+// through dex.ValidateAudiences. Allowed characters are [a-zA-Z0-9_-]; the
+// per-entry length cap is 256 characters and the total list cap is 50.
+// FromEnv returns an error at startup if any entry violates these rules.
+//
+// This charset matches the Dex cross-client audience scope namespace
+// (`audience:server:client_id:<id>`), which is the only context in which
+// TrustedAudiences is currently consumed in production. Operators with
+// URL-shaped audiences (RFC 8707) or other non-conforming values must
+// populate oauth.Config.TrustedAudiences programmatically instead of relying
+// on this loader.
 //
 // # FromEnv vs FromEnvWithPrefix
 //

--- a/oauthconfig/env.go
+++ b/oauthconfig/env.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/giantswarm/mcp-oauth/providers/dex"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/server"
 )
@@ -87,6 +88,9 @@ func FromEnvWithPrefix(prefix string) (*server.Config, error) {
 
 	if raw := os.Getenv(prefix + "TRUSTED_AUDIENCES"); raw != "" {
 		cfg.TrustedAudiences = splitAndTrim(raw, ",")
+		if err := dex.ValidateAudiences(cfg.TrustedAudiences); err != nil {
+			return nil, fmt.Errorf("%sTRUSTED_AUDIENCES: %w", prefix, err)
+		}
 	}
 
 	return cfg, nil

--- a/oauthconfig/env_test.go
+++ b/oauthconfig/env_test.go
@@ -342,3 +342,40 @@ func TestFromEnv_EmptyTrustedAudiencesOmitted(t *testing.T) {
 		t.Errorf("TrustedAudiences = %v, want empty (whitespace-only entries dropped)", cfg.TrustedAudiences)
 	}
 }
+
+// TestFromEnv_TrustedAudiencesCharset locks down the dex.ValidateAudiences
+// gate added to FromEnv: client-id-shaped entries pass; entries with spaces,
+// scheme separators, or path slashes (i.e. URL-shaped audiences) are
+// rejected at startup so operators don't get a silent SSO break later.
+func TestFromEnv_TrustedAudiencesCharset(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+	}{
+		{name: "single client-id", raw: "muster-client"},
+		{name: "multiple client-ids", raw: "muster-client, second-aud,a_b-c"},
+		{name: "trailing comma", raw: "muster-client,"},
+		{name: "url-shaped audience rejected", raw: "https://api.example.com", wantErr: true},
+		{name: "audience with space rejected", raw: "muster client", wantErr: true},
+		{name: "audience with colon rejected", raw: "muster:client", wantErr: true},
+		{name: "audience with slash rejected", raw: "muster/client", wantErr: true},
+		{name: "mix of valid and invalid rejects whole list", raw: "muster-client,bad audience", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setRequired(t, "https://auth.example")
+			t.Setenv("OAUTH_TRUSTED_AUDIENCES", tc.raw)
+			_, err := oauthconfig.FromEnv()
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "TRUSTED_AUDIENCES") {
+					t.Fatalf("expected TRUSTED_AUDIENCES error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+		})
+	}
+}

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 )
 
+// githubProviderName is providers.Provider.Name() for the GitHub provider.
+// Constant exists to satisfy goconst (the literal "github" appears in several
+// Setenv / Name() assertions across tests in this file).
+const githubProviderName = "github"
+
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
 func clearProviderEnv(t *testing.T) {
@@ -167,8 +172,8 @@ func TestGitHubFromEnv_Happy(t *testing.T) {
 	if p == nil {
 		t.Fatal("nil provider")
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 	// GitHub is OAuth-only — IssuerOf must return "".
 	if got := providers.IssuerOf(p); got != "" {
@@ -238,7 +243,7 @@ func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
 
 func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_PROVIDER", githubProviderName)
 	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -247,8 +252,8 @@ func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 
@@ -266,7 +271,7 @@ func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
 
 func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_PROVIDER", githubProviderName)
 	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -275,8 +280,8 @@ func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes gap #4 of the v0.2.109 → v0.2.110 consumer-friction list.

`OAUTH_TRUSTED_AUDIENCES` entries are now validated through `dex.ValidateAudiences` after splitting. Charset: `[a-zA-Z0-9_-]`, per-entry max 256 chars, list max 50. Malformed values fail at startup with the env var name in the error rather than silently breaking token-acceptance later.

Today every consumer either remembers (boilerplate) or forgets (silent gap). Folding the validation in fixes both.

⚠ **Breaking** for operators using URL-shaped audiences (e.g. `https://api.example.com`). The `oauthconfig/doc.go` previously mentioned RFC 8707 URI audiences as supported; in practice all in-tree consumers (mcp-observability-platform, muster, mcp-prometheus) use client-id-shaped values. URI users must populate `oauth.Config.TrustedAudiences` programmatically.

Includes the goconst const-extract from #279 so this PR's CI is green standalone — will be a no-op merge once one of the other PRs lands first.

## Consumer migration

Delete the post-`FromEnv()` `dex.ValidateAudiences(srvCfg.TrustedAudiences)` block.

## Test plan

- [x] `go test ./oauthconfig/...` — table-driven `TestFromEnv_TrustedAudiencesCharset`: client-ids accepted, spaces/colons/slashes/URLs rejected, mixed list rejected as a whole, error wraps `TRUSTED_AUDIENCES`.
- [x] `go vet ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)