### PR TITLE
feat(oauthconfig): LogStartupWarnings centralizes AllowInsecureHTTP / AllowPublicClientRegistration warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **oauthconfig.LogStartupWarnings helper for AllowInsecureHTTP / AllowPublicClientRegistration**
+  - Centralizes the two `logger.Warn` calls every consumer was rolling after building `*server.Config`. Each warning fires at most once per call and includes the env var name so operators can grep their logs back to the source. Nil-safe for cfg and logger.
+
 ### Fixed
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**

--- a/oauthconfig/doc.go
+++ b/oauthconfig/doc.go
@@ -56,4 +56,11 @@
 // with a caller-supplied prefix (for consumers that scope env vars to their
 // product, e.g. "MUSTER_OAUTH_"). The prefix is applied verbatim — include the
 // trailing underscore if you want one.
+//
+// # Startup warnings
+//
+// [LogStartupWarnings] emits operator-facing slog.Warn calls for
+// security-sensitive flags (AllowInsecureHTTP, AllowPublicClientRegistration)
+// that consumers were previously logging in their own startup code. Call once
+// after FromEnv and before serving requests.
 package oauthconfig

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 )
 
+// githubProviderName is providers.Provider.Name() for the GitHub provider.
+// Constant exists to satisfy goconst (the literal "github" appears in several
+// Setenv / Name() assertions across tests in this file).
+const githubProviderName = "github"
+
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
 func clearProviderEnv(t *testing.T) {
@@ -167,8 +172,8 @@ func TestGitHubFromEnv_Happy(t *testing.T) {
 	if p == nil {
 		t.Fatal("nil provider")
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 	// GitHub is OAuth-only — IssuerOf must return "".
 	if got := providers.IssuerOf(p); got != "" {
@@ -238,7 +243,7 @@ func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
 
 func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_PROVIDER", githubProviderName)
 	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -247,8 +252,8 @@ func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 
@@ -266,7 +271,7 @@ func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
 
 func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_PROVIDER", githubProviderName)
 	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -275,8 +280,8 @@ func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 

--- a/oauthconfig/warnings.go
+++ b/oauthconfig/warnings.go
@@ -1,0 +1,41 @@
+package oauthconfig
+
+import (
+	"log/slog"
+
+	"github.com/giantswarm/mcp-oauth/server"
+)
+
+// LogStartupWarnings emits operator-facing warnings for security-sensitive
+// *server.Config flags that are easy to leave enabled by mistake:
+//
+//   - AllowInsecureHTTP — the OAuth issuer is running over plain HTTP.
+//   - AllowPublicClientRegistration — anyone on the network can register a
+//     client without a registration token.
+//
+// Call once after building the config and before starting request handling.
+// Each warning fires at most once per call (the helper is not request-scoped).
+//
+// Consumers (mcp-observability-platform, muster, mcp-prometheus) previously
+// rolled the same two slog.Warn calls in their own startup code; centralizing
+// the wording here keeps the operator message consistent across mcp-oauth
+// deployments.
+//
+// nil cfg or nil logger returns silently — convenient for callers that want
+// to defer the helper unconditionally.
+func LogStartupWarnings(cfg *server.Config, logger *slog.Logger) {
+	if cfg == nil || logger == nil {
+		return
+	}
+	if cfg.AllowInsecureHTTP {
+		logger.Warn(
+			"OAUTH_ALLOW_INSECURE_HTTP=true: OAuth server is running over plain HTTP. Disable in production by removing the env var or setting it to false.",
+			"issuer", cfg.Issuer,
+		)
+	}
+	if cfg.AllowPublicClientRegistration {
+		logger.Warn(
+			"OAUTH_ALLOW_PUBLIC_CLIENT_REGISTRATION=true: any client on the network can register without a registration token. Disable in production and configure OAUTH_REGISTRATION_ACCESS_TOKEN instead.",
+		)
+	}
+}

--- a/oauthconfig/warnings_test.go
+++ b/oauthconfig/warnings_test.go
@@ -1,0 +1,87 @@
+package oauthconfig_test
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/mcp-oauth/oauthconfig"
+	"github.com/giantswarm/mcp-oauth/server"
+)
+
+// insecureWarnNeedle and pubRegWarnNeedle are stable substrings of the warning
+// messages emitted by LogStartupWarnings. They include the env var name so an
+// operator grepping their logs can find the matching config knob.
+const (
+	insecureWarnNeedle = "OAUTH_ALLOW_INSECURE_HTTP=true"
+	pubRegWarnNeedle   = "OAUTH_ALLOW_PUBLIC_CLIENT_REGISTRATION=true"
+)
+
+func TestLogStartupWarnings(t *testing.T) {
+	cases := []struct {
+		name             string
+		allowInsecure    bool
+		allowPubReg      bool
+		wantInsecureHits int
+		wantPubRegHits   int
+	}{
+		{name: "no flags, no warnings"},
+		{name: "insecure http only", allowInsecure: true, wantInsecureHits: 1},
+		{name: "public registration only", allowPubReg: true, wantPubRegHits: 1},
+		{name: "both flags, both warnings", allowInsecure: true, allowPubReg: true, wantInsecureHits: 1, wantPubRegHits: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+			cfg := &server.Config{
+				Issuer:                        "https://auth.example",
+				AllowInsecureHTTP:             tc.allowInsecure,
+				AllowPublicClientRegistration: tc.allowPubReg,
+			}
+
+			oauthconfig.LogStartupWarnings(cfg, logger)
+
+			out := buf.String()
+			if got := strings.Count(out, insecureWarnNeedle); got != tc.wantInsecureHits {
+				t.Errorf("insecure-HTTP warning hits = %d, want %d; log = %q", got, tc.wantInsecureHits, out)
+			}
+			if got := strings.Count(out, pubRegWarnNeedle); got != tc.wantPubRegHits {
+				t.Errorf("public-registration warning hits = %d, want %d; log = %q", got, tc.wantPubRegHits, out)
+			}
+		})
+	}
+}
+
+// TestLogStartupWarnings_FiresOncePerCall guards against an accidental
+// per-request emission pattern: if the helper is mistakenly wired into a
+// middleware, this test would flag the regression by failing on a hit count
+// >1 after a single invocation.
+func TestLogStartupWarnings_FiresOncePerCall(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	cfg := &server.Config{
+		Issuer:                        "http://auth.example",
+		AllowInsecureHTTP:             true,
+		AllowPublicClientRegistration: true,
+	}
+
+	oauthconfig.LogStartupWarnings(cfg, logger)
+
+	out := buf.String()
+	if got := strings.Count(out, insecureWarnNeedle); got != 1 {
+		t.Errorf("insecure warning fired %d times, want 1", got)
+	}
+	if got := strings.Count(out, pubRegWarnNeedle); got != 1 {
+		t.Errorf("public-registration warning fired %d times, want 1", got)
+	}
+}
+
+// TestLogStartupWarnings_NilSafe documents the nil-cfg / nil-logger contract
+// so callers can defer the helper unconditionally.
+func TestLogStartupWarnings_NilSafe(t *testing.T) {
+	oauthconfig.LogStartupWarnings(nil, slog.Default())
+	oauthconfig.LogStartupWarnings(&server.Config{AllowInsecureHTTP: true}, nil)
+	oauthconfig.LogStartupWarnings(nil, nil)
+}


### PR DESCRIPTION
## Summary

Closes gap #5. New `oauthconfig.LogStartupWarnings(cfg, logger)` emits the two operator-facing warnings every downstream consumer was rolling in its own startup code:

- `OAUTH_ALLOW_INSECURE_HTTP=true` — OAuth running over plain HTTP
- `OAUTH_ALLOW_PUBLIC_CLIENT_REGISTRATION=true` — anyone can register a client without a token

Each warning fires at most once per call (test guards against an accidental per-request emission). Nil-safe for cfg/logger so callers can defer it unconditionally.

Includes the goconst const-extract from #279 so this PR's CI is green standalone.

## Consumer migration

```go
// before
srvCfg, _ := oauthconfig.FromEnv()
if srvCfg.AllowInsecureHTTP {
    logger.Warn("OAuth running over insecure HTTP …")
}
if srvCfg.AllowPublicClientRegistration {
    logger.Warn("public client registration enabled …")
}

// after
srvCfg, _ := oauthconfig.FromEnv()
oauthconfig.LogStartupWarnings(srvCfg, logger)
```

## Test plan

- [x] `go test ./oauthconfig/...` — table-driven `TestLogStartupWarnings` (4 flag matrices), `TestLogStartupWarnings_FiresOncePerCall`, `TestLogStartupWarnings_NilSafe`. JSON slog handler with a `*bytes.Buffer` so we can grep on stable substrings.
- [x] `go vet ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)