### PR TITLE
feat(oauthconfig): DexFromEnv defaults DEX_REDIRECT_URL to OAUTH_ISSUER + /oauth/callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **oauthconfig.DexFromEnv defaults `OAUTH_DEX_REDIRECT_URL` to `${OAUTH_ISSUER}/oauth/callback`**
+  - Saves consumers from templating the issuer URL into two env vars (helm value + DEX_REDIRECT_URL). When OAUTH_ISSUER is set and DEX_REDIRECT_URL is unset, the loader derives the canonical provider-callback URL automatically. A trailing slash on the issuer is tolerated.
+  - Additive: explicit OAUTH_DEX_REDIRECT_URL still wins. The "required" error still fires when both vars are unset.
+
 ### Fixed
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**

--- a/oauthconfig/provider.go
+++ b/oauthconfig/provider.go
@@ -3,12 +3,20 @@ package oauthconfig
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/giantswarm/mcp-oauth/providers"
 	"github.com/giantswarm/mcp-oauth/providers/dex"
 	"github.com/giantswarm/mcp-oauth/providers/github"
 	"github.com/giantswarm/mcp-oauth/providers/google"
 )
+
+// dexDefaultCallbackPath is the canonical mcp-oauth provider-callback path;
+// kept in sync with handler.oauthCallbackPath in the root package. Used by
+// DexFromEnvWithPrefix when OAUTH_DEX_REDIRECT_URL is unset and OAUTH_ISSUER
+// is available, so consumers stop having to pre-template
+// ${OAUTH_ISSUER}/oauth/callback in their helm values.
+const dexDefaultCallbackPath = "/oauth/callback"
 
 // ProviderFromEnv reads OAUTH_PROVIDER (dex|google|github) and dispatches to
 // the matching per-provider loader (DexFromEnv, GoogleFromEnv, GitHubFromEnv).
@@ -46,8 +54,13 @@ func ProviderFromEnvWithPrefix(prefix string) (providers.Provider, error) {
 //	OAUTH_DEX_ISSUER_URL            (required) — e.g. https://dex.example.com
 //	OAUTH_DEX_CLIENT_ID             (required)
 //	OAUTH_DEX_CLIENT_SECRET[_FILE]  (required)
-//	OAUTH_DEX_REDIRECT_URL          (required)
+//	OAUTH_DEX_REDIRECT_URL          (optional; defaults to OAUTH_ISSUER + "/oauth/callback")
 //	OAUTH_DEX_CONNECTOR_ID          (optional) — e.g. "github", "ldap"
+//
+// OAUTH_DEX_REDIRECT_URL is required ONLY when OAUTH_ISSUER is also unset.
+// When OAUTH_ISSUER is set (the typical deployment shape), the redirect URL
+// defaults to "${OAUTH_ISSUER}/oauth/callback" — the canonical mcp-oauth
+// provider-callback path. A trailing slash on OAUTH_ISSUER is tolerated.
 //
 // Returned as providers.Provider (not *dex.Provider) so call sites stay
 // provider-agnostic. Callers that need Dex-specific methods cast.
@@ -82,7 +95,7 @@ func DexFromEnvWithPrefix(prefix string) (providers.Provider, error) {
 	if err != nil {
 		return nil, err
 	}
-	redirectURL, err := requireString(prefix + "DEX_REDIRECT_URL")
+	redirectURL, err := dexRedirectURL(prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -207,6 +220,28 @@ func GitHubFromEnvWithPrefix(prefix string) (providers.Provider, error) {
 	}
 
 	return github.NewProvider(cfg)
+}
+
+// dexRedirectURL resolves the OAuth provider-callback URL for the Dex
+// provider. Reads OAUTH_DEX_REDIRECT_URL when set; otherwise falls back to
+// "${OAUTH_ISSUER}<dexDefaultCallbackPath>" so deployments don't have to
+// duplicate the issuer URL across two env vars (one explicit gap that every
+// consumer's helm chart was working around with a value template).
+//
+// If both are unset, returns the existing requireString "required" error
+// for OAUTH_DEX_REDIRECT_URL — preserving the prior failure message and
+// shifting the onus back to the operator to set at least one of the two.
+//
+// strings.TrimRight handles a trailing slash on the issuer so we don't emit
+// "https://auth.example//oauth/callback".
+func dexRedirectURL(prefix string) (string, error) {
+	if v := os.Getenv(prefix + "DEX_REDIRECT_URL"); v != "" {
+		return v, nil
+	}
+	if issuer := os.Getenv(prefix + "ISSUER"); issuer != "" {
+		return strings.TrimRight(issuer, "/") + dexDefaultCallbackPath, nil
+	}
+	return requireString(prefix + "DEX_REDIRECT_URL")
 }
 
 // requireSecret is requireString that also understands the _FILE convention

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -10,10 +10,13 @@ import (
 
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
+// OAUTH_ISSUER is included because DexFromEnv falls back to it for
+// OAUTH_DEX_REDIRECT_URL when the explicit redirect URL is unset.
 func clearProviderEnv(t *testing.T) {
 	t.Helper()
 	for _, v := range []string{
 		"OAUTH_PROVIDER",
+		"OAUTH_ISSUER",
 		"OAUTH_DEX_ISSUER_URL",
 		"OAUTH_DEX_CLIENT_ID",
 		"OAUTH_DEX_CLIENT_SECRET",
@@ -55,13 +58,55 @@ func TestDexFromEnv_MissingClientID(t *testing.T) {
 	}
 }
 
-func TestDexFromEnv_MissingRedirectURL(t *testing.T) {
+// TestDexFromEnv_DefaultRedirectURLFromIssuer locks down the OAUTH_ISSUER
+// fallback for DEX_REDIRECT_URL: when the explicit redirect URL is unset
+// but OAUTH_ISSUER is set, the loader proceeds (no missing-redirect error)
+// and constructs ${OAUTH_ISSUER}/oauth/callback. We can't read RedirectURL
+// off the constructed *dex.Provider (unexported), so instead we drive the
+// loader to the dex.NewProvider discovery step (set DEX_ISSUER_URL to an
+// unreachable host) and assert the failure surfaces from the network step,
+// not from the missing-redirect check we just bypassed.
+func TestDexFromEnv_DefaultRedirectURLFromIssuer(t *testing.T) {
+	cases := []struct {
+		name   string
+		issuer string
+	}{
+		{name: "without trailing slash", issuer: "https://auth.example"},
+		{name: "with trailing slash", issuer: "https://auth.example/"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			clearProviderEnv(t)
+			t.Setenv("OAUTH_ISSUER", tc.issuer)
+			t.Setenv("OAUTH_DEX_ISSUER_URL", "https://unreachable.invalid.example")
+			t.Setenv("OAUTH_DEX_CLIENT_ID", "cid")
+			t.Setenv("OAUTH_DEX_CLIENT_SECRET", "secret")
+			// DEX_REDIRECT_URL deliberately unset.
+
+			_, err := oauthconfig.DexFromEnv()
+			if err == nil {
+				t.Fatal("expected dex.NewProvider discovery failure against unreachable host")
+			}
+			if strings.Contains(err.Error(), "DEX_REDIRECT_URL") {
+				t.Errorf("expected fallback to OAUTH_ISSUER, got missing-redirect error: %v", err)
+			}
+		})
+	}
+}
+
+// TestDexFromEnv_MissingRedirectURLAndIssuer verifies the existing "required"
+// error still fires when BOTH OAUTH_DEX_REDIRECT_URL and OAUTH_ISSUER are
+// unset, so unset deployments still fail fast rather than silently building a
+// "/oauth/callback" path that goes nowhere.
+func TestDexFromEnv_MissingRedirectURLAndIssuer(t *testing.T) {
 	clearProviderEnv(t)
 	t.Setenv("OAUTH_DEX_ISSUER_URL", "https://dex.example")
 	t.Setenv("OAUTH_DEX_CLIENT_ID", "cid")
+	// Neither DEX_REDIRECT_URL nor OAUTH_ISSUER set.
+
 	_, err := oauthconfig.DexFromEnv()
 	if err == nil || !strings.Contains(err.Error(), "OAUTH_DEX_REDIRECT_URL") {
-		t.Fatalf("expected OAUTH_DEX_REDIRECT_URL error, got %v", err)
+		t.Fatalf("expected OAUTH_DEX_REDIRECT_URL required error, got %v", err)
 	}
 }
 

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 )
 
+// githubProviderName is providers.Provider.Name() for the GitHub provider.
+// Constant exists to satisfy goconst (the literal "github" appears in several
+// Setenv / Name() assertions across tests in this file).
+const githubProviderName = "github"
+
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
 // OAUTH_ISSUER is included because DexFromEnv falls back to it for
@@ -212,8 +217,8 @@ func TestGitHubFromEnv_Happy(t *testing.T) {
 	if p == nil {
 		t.Fatal("nil provider")
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 	// GitHub is OAuth-only — IssuerOf must return "".
 	if got := providers.IssuerOf(p); got != "" {
@@ -283,7 +288,7 @@ func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
 
 func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_PROVIDER", githubProviderName)
 	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -292,8 +297,8 @@ func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 
@@ -311,7 +316,7 @@ func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
 
 func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_PROVIDER", githubProviderName)
 	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -320,8 +325,8 @@ func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes gap #6. When `OAUTH_DEX_REDIRECT_URL` is unset and `OAUTH_ISSUER` is set (the typical deployment shape), `DexFromEnv` now derives the redirect URL as `${OAUTH_ISSUER}/oauth/callback` — the canonical mcp-oauth provider-callback path. Trailing slash on the issuer is tolerated.

This deletes one line + a value-template from every consumer's helm chart. Explicit `OAUTH_DEX_REDIRECT_URL` still wins; the existing "required" error still fires when both vars are unset.

The path constant (`dexDefaultCallbackPath = "/oauth/callback"`) cross-references `handler.oauthCallbackPath` in the root package — kept local rather than importing the root package to avoid pulling its compile graph into the loader package.

`clearProviderEnv` now also clears `OAUTH_ISSUER` so the dex tests don't accidentally pick up a leaked value when exercising the no-fallback path.

Includes the goconst const-extract from #279 so this PR's CI is green standalone.

## Consumer migration

Helm values:

```diff
- OAUTH_DEX_REDIRECT_URL: "{{ .Values.issuer }}/oauth/callback"
+ # OAUTH_DEX_REDIRECT_URL omitted; derived from OAUTH_ISSUER
```

## Test plan

- [x] `go test ./oauthconfig/...` — table-driven `TestDexFromEnv_DefaultRedirectURLFromIssuer` (with/without trailing slash drives loader to `dex.NewProvider` discovery; missing-redirect error must NOT fire) + `TestDexFromEnv_MissingRedirectURLAndIssuer` (existing "required" error still fires when both vars unset).
- [x] `go vet ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)