### PR TITLE
refactor(oauthconfig): StorageFromEnv switch uses storage.Backend* constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **oauthconfig.StorageFromEnv switch now uses `storage.BackendMemory` / `storage.BackendValkey` instead of string literals**
+  - Internal cleanup so the loader and the storage package share one source of truth for backend names. The constants were already exported from the `storage` package — consumers that branch on backend name (e.g. "refuse memory in production") should reference `storage.Backend*`.
 - **oauthconfig.FromEnv: loopback issuers bypass the http:// gate**
   - `http://localhost`, `http://127.0.0.1`, and `http://[::1]` (with or without ports) are now accepted as `OAUTH_ISSUER` without setting `OAUTH_ALLOW_INSECURE_HTTP`. Per RFC 8252 §7.3 (native-app loopback). Lookalikes like `http://127.0.0.1.evil` are still rejected.
   - Removes the dev-loop footgun where flipping `OAUTH_ALLOW_INSECURE_HTTP=true` for `http://localhost:5556` weakened every other http:// check at the same time.

--- a/oauthconfig/storage.go
+++ b/oauthconfig/storage.go
@@ -45,17 +45,17 @@ func StorageFromEnv(logger *slog.Logger) (storage.Combined, func() error, error)
 func StorageFromEnvWithPrefix(prefix string, logger *slog.Logger) (storage.Combined, func() error, error) {
 	backend := os.Getenv(prefix + "STORAGE_BACKEND")
 	if backend == "" {
-		backend = "memory"
+		backend = storage.BackendMemory
 	}
 
 	switch backend {
-	case "memory":
+	case storage.BackendMemory:
 		store := memory.New()
 		return store, func() error { store.Stop(); return nil }, nil
-	case "valkey":
+	case storage.BackendValkey:
 		return newValkeyFromEnv(prefix, logger)
 	default:
-		return nil, nil, fmt.Errorf("%sSTORAGE_BACKEND: unknown backend %q (want \"memory\" or \"valkey\")", prefix, backend)
+		return nil, nil, fmt.Errorf("%sSTORAGE_BACKEND: unknown backend %q (want %q or %q)", prefix, backend, storage.BackendMemory, storage.BackendValkey)
 	}
 }
 


### PR DESCRIPTION
## Summary

The original gap-list item asked to "export `BackendMemory` / `BackendValkey`". Those constants **already existed** at `storage/storage.go:26-29` — my first commit duplicated them in `oauthconfig`, which @QuentinBisson rightly flagged.

Stripped the PR down to the only useful slice: replace the string literals in `oauthconfig.StorageFromEnv`'s switch + error message with references to the existing `storage.BackendMemory` / `storage.BackendValkey`. One source of truth.

## Diff

```
 CHANGELOG.md           | 2 ++
 oauthconfig/storage.go | 8 ++++----
 2 files changed, 6 insertions(+), 4 deletions(-)
```

No new public API in `oauthconfig`. Consumers that need to branch on backend name should reference `storage.BackendMemory` / `storage.BackendValkey` (always could).

## Test plan

- [x] `go test ./oauthconfig/...`
- [x] `go vet ./...`
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)