### PR TITLE
feat(oauthconfig): loopback issuers bypass the http:// gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **oauthconfig.FromEnv: loopback issuers bypass the http:// gate**
+  - `http://localhost`, `http://127.0.0.1`, and `http://[::1]` (with or without ports) are now accepted as `OAUTH_ISSUER` without setting `OAUTH_ALLOW_INSECURE_HTTP`. Per RFC 8252 §7.3 (native-app loopback). Lookalikes like `http://127.0.0.1.evil` are still rejected.
+  - Removes the dev-loop footgun where flipping `OAUTH_ALLOW_INSECURE_HTTP=true` for `http://localhost:5556` weakened every other http:// check at the same time.
+
 ### Fixed
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**

--- a/oauthconfig/doc.go
+++ b/oauthconfig/doc.go
@@ -11,6 +11,9 @@
 //
 //   - OAUTH_ISSUER                            (required) — server issuer URL
 //   - OAUTH_ALLOW_INSECURE_HTTP               (default false) — permit http:// issuer
+//     (loopback issuers — http://localhost, http://127.0.0.1, http://[::1] —
+//     are exempt from this gate per RFC 8252 §7.3, so dev loops don't have to
+//     enable the global insecure flag)
 //   - OAUTH_ALLOW_PUBLIC_CLIENT_REGISTRATION  (default false)
 //   - OAUTH_REGISTRATION_ACCESS_TOKEN         — registration bearer; see _FILE note below
 //   - OAUTH_ENCRYPTION_KEY                    — base64 32-byte AES-GCM key

--- a/oauthconfig/env.go
+++ b/oauthconfig/env.go
@@ -93,8 +93,14 @@ func FromEnvWithPrefix(prefix string) (*server.Config, error) {
 }
 
 // validateIssuerScheme rejects a plain-HTTP issuer unless the operator has
-// explicitly opted in. URL schemes are case-insensitive per RFC 3986 §3.1, so
-// HTTP://example.com must not slip past a gate that catches http://example.com.
+// explicitly opted in OR the issuer points at a loopback host. URL schemes
+// are case-insensitive per RFC 3986 §3.1, so HTTP://example.com must not
+// slip past a gate that catches http://example.com.
+//
+// The loopback exception (RFC 8252 native-app territory) skips the
+// ALLOW_INSECURE_HTTP requirement for "http://localhost", "http://127.0.0.1",
+// and "http://[::1]" so dev loops don't have to flip the global insecure flag
+// — which would weaken every other http:// check at the same time.
 func validateIssuerScheme(issuer string, allowInsecure bool, prefix string) error {
 	if allowInsecure {
 		return nil
@@ -103,10 +109,25 @@ func validateIssuerScheme(issuer string, allowInsecure bool, prefix string) erro
 	if err != nil {
 		return fmt.Errorf("%sISSUER is not a valid URL: %w", prefix, err)
 	}
-	if strings.EqualFold(u.Scheme, "http") {
-		return fmt.Errorf("%sISSUER uses http:// but %sALLOW_INSECURE_HTTP is not set; refusing to run an OAuth server over plain HTTP without an explicit opt-in", prefix, prefix)
+	if !strings.EqualFold(u.Scheme, "http") {
+		return nil
 	}
-	return nil
+	if isLoopbackHost(u.Hostname()) {
+		return nil
+	}
+	return fmt.Errorf("%sISSUER uses http:// but %sALLOW_INSECURE_HTTP is not set; refusing to run an OAuth server over plain HTTP without an explicit opt-in", prefix, prefix)
+}
+
+// isLoopbackHost reports whether host is one of the loopback identifiers
+// used to bypass the http-issuer gate: "localhost", "127.0.0.1", or "::1".
+// Pure string match — no DNS resolution. Comparison is case-insensitive on
+// the textual identifier ("Localhost" matches) per RFC 3986 §3.2.2.
+func isLoopbackHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "localhost", "127.0.0.1", "::1":
+		return true
+	}
+	return false
 }
 
 func loadDurationSecondsIfSet(name string, dst *int64) error {

--- a/oauthconfig/env_test.go
+++ b/oauthconfig/env_test.go
@@ -167,6 +167,44 @@ func TestFromEnv_InsecureHTTPGate(t *testing.T) {
 	})
 }
 
+// TestFromEnv_LoopbackIssuerException locks down the RFC 8252 loopback
+// bypass: http:// is permitted without OAUTH_ALLOW_INSECURE_HTTP when the
+// hostname is localhost / 127.0.0.1 / [::1]. Required for local dev loops
+// (`http://localhost:5556`) that should NOT need to flip the global insecure
+// flag — which would weaken every other http:// check at the same time.
+func TestFromEnv_LoopbackIssuerException(t *testing.T) {
+	cases := []struct {
+		name    string
+		issuer  string
+		wantErr bool
+	}{
+		{name: "localhost with port", issuer: "http://localhost:5556"},
+		{name: "localhost without port", issuer: "http://localhost"},
+		{name: "127.0.0.1 with port", issuer: "http://127.0.0.1:5556"},
+		{name: "ipv6 loopback with port", issuer: "http://[::1]:5556"},
+		{name: "Localhost mixed case", issuer: "http://Localhost:5556"},
+		{name: "https on loopback still fine", issuer: "https://localhost:5556"},
+		{name: "non-loopback http rejected", issuer: "http://auth.example", wantErr: true},
+		{name: "lookalike 127.0.0.1.evil rejected", issuer: "http://127.0.0.1.evil.com", wantErr: true},
+		{name: "lookalike localhost.evil rejected", issuer: "http://localhost.evil.com", wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setRequired(t, tc.issuer)
+			_, err := oauthconfig.FromEnv()
+			if tc.wantErr {
+				if err == nil || !strings.Contains(err.Error(), "ALLOW_INSECURE_HTTP") {
+					t.Fatalf("expected ALLOW_INSECURE_HTTP refusal, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("FromEnv: %v", err)
+			}
+		})
+	}
+}
+
 func TestFromEnv_FilePrecedence(t *testing.T) {
 	setRequired(t, "https://auth.example")
 	t.Setenv("OAUTH_REGISTRATION_ACCESS_TOKEN", "from-env")

--- a/oauthconfig/provider_test.go
+++ b/oauthconfig/provider_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers"
 )
 
+// githubProviderName is providers.Provider.Name() for the GitHub provider.
+// Constant exists to satisfy goconst (the literal "github" appears in several
+// Setenv / Name() assertions across tests in this file).
+const githubProviderName = "github"
+
 // clearProviderEnv zeroes every provider-related var this package reads.
 // Per-test t.Setenv calls then re-populate what each test actually exercises.
 func clearProviderEnv(t *testing.T) {
@@ -167,8 +172,8 @@ func TestGitHubFromEnv_Happy(t *testing.T) {
 	if p == nil {
 		t.Fatal("nil provider")
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 	// GitHub is OAuth-only — IssuerOf must return "".
 	if got := providers.IssuerOf(p); got != "" {
@@ -238,7 +243,7 @@ func TestProviderFromEnv_DispatchesToGoogle(t *testing.T) {
 
 func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("OAUTH_PROVIDER", "github")
+	t.Setenv("OAUTH_PROVIDER", githubProviderName)
 	t.Setenv("OAUTH_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("OAUTH_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("OAUTH_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -247,8 +252,8 @@ func TestProviderFromEnv_DispatchesToGitHub(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 
@@ -266,7 +271,7 @@ func TestProviderFromEnv_DispatchesToDex_ParsesBeforeNetwork(t *testing.T) {
 
 func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	clearProviderEnv(t)
-	t.Setenv("MUSTER_PROVIDER", "github")
+	t.Setenv("MUSTER_PROVIDER", githubProviderName)
 	t.Setenv("MUSTER_GITHUB_CLIENT_ID", "ghid")
 	t.Setenv("MUSTER_GITHUB_CLIENT_SECRET", "ghsecret")
 	t.Setenv("MUSTER_GITHUB_REDIRECT_URL", "https://app.example/callback")
@@ -275,8 +280,8 @@ func TestProviderFromEnv_WithPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ProviderFromEnvWithPrefix: %v", err)
 	}
-	if p.Name() != "github" {
-		t.Errorf("Name() = %q, want github", p.Name())
+	if p.Name() != githubProviderName {
+		t.Errorf("Name() = %q, want %s", p.Name(), githubProviderName)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes gap #8. `validateIssuerScheme` now allows `http://localhost`, `http://127.0.0.1`, and `http://[::1]` (with or without ports) without `OAUTH_ALLOW_INSECURE_HTTP=true`. Per RFC 8252 §7.3 (native-app loopback).

Today operators have to flip `OAUTH_ALLOW_INSECURE_HTTP=true` for local dev loops like `http://localhost:5556` — which then disables the gate for every other http:// check at the same time. The narrow loopback exception preserves the global insecure flag as a meaningful signal.

Pure string match on `u.Hostname()` — no DNS resolution. Lookalikes like `http://127.0.0.1.evil.com` and `http://localhost.evil.com` still fail the gate.

Includes the goconst const-extract from #279 so this PR's CI is green standalone.

## Consumer migration

For dev loops:

```diff
- OAUTH_ISSUER=http://localhost:5556
- OAUTH_ALLOW_INSECURE_HTTP=true
+ OAUTH_ISSUER=http://localhost:5556
```

`OAUTH_ALLOW_INSECURE_HTTP` should now be reserved for non-loopback http:// issuers (rare).

## Test plan

- [x] `go test ./oauthconfig/...` — table-driven `TestFromEnv_LoopbackIssuerException`: localhost/127.0.0.1/::1 (with and without ports), mixed-case hostname, https-on-loopback still fine, non-loopback http rejected, lookalike rejected.
- [x] Existing `TestFromEnv_InsecureHTTPGate` subtests still pass.
- [x] `go vet ./...` / `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)