### PR TITLE
feat(server): add Server.RefreshSession(ctx, familyID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Server.RefreshSession(ctx, familyID)` for on-demand session refresh** (closes #285)
+  - In-process API to refresh an upstream provider token by family ID, callable from any goroutine. Reuses the existing `RefreshAccessToken` path (same rotation, reuse detection, audit, and `TokenRefreshHandler` dispatch) — just driven by family ID instead of by a refresh token in the request.
+  - Concurrent calls for the same family ID are coalesced via `singleflight`: only one provider refresh hits the upstream, the rest share the result.
+  - New optional `storage.ActiveRefreshTokenByFamilyStore` interface (memory + Valkey) returns the highest-generation non-revoked refresh token for a family. `RefreshSession` calls this to find the live token.
+  - Use case: an integrating server (e.g. `muster`) about to forward a cached ID token discovers it's expired. Pre-PR there was no way to force a refresh on the request thread without constructing a fake `/oauth/token` POST. Now: `srv.RefreshSession(ctx, familyID)` and re-read the cached entry.
 - **JWT access-token issuance mode (RFC 9068)**
   - New `Config.AccessTokenFormat` (default `AccessTokenFormatOpaque`, opt-in `AccessTokenFormatJWT`). In JWT mode the server signs access tokens with `Config.AccessTokenSigningKey` (RSA or ECDSA P-256/P-384) under `Config.AccessTokenSigningKeyID`/`Config.AccessTokenSigningAlgorithm` (RS256/RS384/RS512/ES256/ES384). HMAC variants and `none` are rejected at startup as alg-confusion defense.
   - New `/.well-known/jwks.json` endpoint publishes the public half (RFC 7517). Authorization Server Metadata gains `jwks_uri` and `access_token_signing_alg_values_supported` only in JWT mode; opaque mode is byte-identical to v1.

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -405,7 +405,7 @@ func validateTimeAndIssuer(claims *IDTokenClaims, expectedIssuer string) error {
 		expected.Issuer = expectedIssuer
 	}
 
-	err := claims.Claims.ValidateWithLeeway(expected, DefaultClockSkewLeeway)
+	err := claims.ValidateWithLeeway(expected, DefaultClockSkewLeeway)
 	if err == nil {
 		return nil
 	}

--- a/server/flows_refresh_session.go
+++ b/server/flows_refresh_session.go
@@ -28,10 +28,11 @@ import (
 //
 // Returns an error if:
 //   - the storage backend does not implement
-//     [storage.ActiveRefreshTokenByFamilyStore] or
-//     [storage.RefreshTokenFamilyByIDStore]
-//   - no active (non-revoked) refresh token is found for the family
-//   - the family has been revoked
+//     [storage.ActiveRefreshTokenByFamilyStore]
+//   - no entry for the family exists at all (wrapped
+//     [storage.ErrRefreshTokenFamilyNotFound])
+//   - the family exists but every member is revoked (wrapped
+//     [storage.ErrRefreshTokenFamilyRevoked])
 //   - the upstream provider's refresh call fails
 //
 // The same lifecycle hooks fire as for the public refresh-token-grant
@@ -71,41 +72,25 @@ func (s *Server) RefreshSession(ctx context.Context, familyID string) (*oauth2.T
 }
 
 // refreshSessionImpl is the un-coalesced body of RefreshSession. Looks up
-// the active refresh token + the owning client ID by family ID, then
-// delegates to the existing RefreshAccessToken path so rotation, reuse
-// detection, audit logging, and TokenRefreshHandler dispatch all behave
-// identically to the public token-endpoint flow.
+// the active refresh token + owning client ID with a single storage call,
+// then delegates to the existing RefreshAccessToken path so rotation,
+// reuse detection, audit logging, and TokenRefreshHandler dispatch all
+// behave identically to the public token-endpoint flow.
 func (s *Server) refreshSessionImpl(ctx context.Context, familyID string) (*oauth2.Token, error) {
 	activeStore, ok := s.tokenStore.(storage.ActiveRefreshTokenByFamilyStore)
 	if !ok {
 		return nil, fmt.Errorf("storage backend does not implement storage.ActiveRefreshTokenByFamilyStore — RefreshSession requires it")
 	}
-	indexed, ok := s.tokenStore.(storage.RefreshTokenFamilyByIDStore)
-	if !ok {
-		return nil, fmt.Errorf("storage backend does not implement storage.RefreshTokenFamilyByIDStore — RefreshSession requires it")
-	}
 
-	family, err := indexed.GetRefreshTokenFamilyByID(ctx, familyID)
-	if err != nil {
-		if errors.Is(err, storage.ErrRefreshTokenFamilyNotFound) {
-			return nil, fmt.Errorf("family %q: %w", familyID, err)
-		}
-		return nil, fmt.Errorf("lookup family by ID: %w", err)
-	}
-	if family == nil {
-		return nil, fmt.Errorf("family %q: %w", familyID, storage.ErrRefreshTokenFamilyNotFound)
-	}
-	if family.Revoked {
-		return nil, fmt.Errorf("family %q is revoked", familyID)
-	}
-
-	refreshToken, err := activeStore.GetActiveRefreshTokenByFamily(ctx, familyID)
-	if err != nil {
-		if errors.Is(err, storage.ErrRefreshTokenFamilyNotFound) {
-			return nil, fmt.Errorf("no active refresh token for family %q: %w", familyID, err)
-		}
+	refreshToken, clientID, err := activeStore.GetActiveRefreshTokenByFamily(ctx, familyID)
+	switch {
+	case errors.Is(err, storage.ErrRefreshTokenFamilyRevoked):
+		return nil, fmt.Errorf("family %q: %w", familyID, err)
+	case errors.Is(err, storage.ErrRefreshTokenFamilyNotFound):
+		return nil, fmt.Errorf("family %q: %w", familyID, err)
+	case err != nil:
 		return nil, fmt.Errorf("lookup active refresh token: %w", err)
 	}
 
-	return s.RefreshAccessToken(ctx, refreshToken, family.ClientID)
+	return s.RefreshAccessToken(ctx, refreshToken, clientID)
 }

--- a/server/flows_refresh_session.go
+++ b/server/flows_refresh_session.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+)
+
+// RefreshSession refreshes the upstream provider token for the session
+// identified by familyID. Equivalent to the public /oauth/token
+// refresh-token grant, but callable in-process from any goroutine — useful
+// for integrations that need to force a refresh from a request thread
+// (e.g. when a cached ID token has expired and the caller is about to
+// forward it).
+//
+// Returns the new provider token. The caller can extract the id_token
+// from the Extra field via [ExtractIDToken] for SSO-forwarding flows.
+//
+// Concurrent calls for the same familyID are coalesced — only one
+// refresh hits the upstream provider; the rest wait for and share the
+// result. This matches the proactive-refresh path's coalescing behavior.
+//
+// Returns an error if:
+//   - the storage backend does not implement
+//     [storage.ActiveRefreshTokenByFamilyStore] or
+//     [storage.RefreshTokenFamilyByIDStore]
+//   - no active (non-revoked) refresh token is found for the family
+//   - the family has been revoked
+//   - the upstream provider's refresh call fails
+//
+// The same lifecycle hooks fire as for the public refresh-token-grant
+// path: TokenRefreshHandler is called with the userID + familyID + new
+// token, refresh-token rotation produces a new family generation, and
+// the new tokens are saved to the TokenStore.
+func (s *Server) RefreshSession(ctx context.Context, familyID string) (*oauth2.Token, error) {
+	if familyID == "" {
+		return nil, fmt.Errorf("familyID is required")
+	}
+
+	result, err, _ := s.refreshSessionGroup.Do(familyID, func() (any, error) {
+		return s.refreshSessionImpl(ctx, familyID)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.(*oauth2.Token), nil
+}
+
+// refreshSessionImpl is the un-coalesced body of RefreshSession. Looks up
+// the active refresh token + the owning client ID by family ID, then
+// delegates to the existing RefreshAccessToken path so rotation, reuse
+// detection, audit logging, and TokenRefreshHandler dispatch all behave
+// identically to the public token-endpoint flow.
+func (s *Server) refreshSessionImpl(ctx context.Context, familyID string) (*oauth2.Token, error) {
+	activeStore, ok := s.tokenStore.(storage.ActiveRefreshTokenByFamilyStore)
+	if !ok {
+		return nil, fmt.Errorf("storage backend does not implement storage.ActiveRefreshTokenByFamilyStore — RefreshSession requires it")
+	}
+	indexed, ok := s.tokenStore.(storage.RefreshTokenFamilyByIDStore)
+	if !ok {
+		return nil, fmt.Errorf("storage backend does not implement storage.RefreshTokenFamilyByIDStore — RefreshSession requires it")
+	}
+
+	family, err := indexed.GetRefreshTokenFamilyByID(ctx, familyID)
+	if err != nil {
+		if errors.Is(err, storage.ErrRefreshTokenFamilyNotFound) {
+			return nil, fmt.Errorf("family %q: %w", familyID, err)
+		}
+		return nil, fmt.Errorf("lookup family by ID: %w", err)
+	}
+	if family == nil {
+		return nil, fmt.Errorf("family %q: %w", familyID, storage.ErrRefreshTokenFamilyNotFound)
+	}
+	if family.Revoked {
+		return nil, fmt.Errorf("family %q is revoked", familyID)
+	}
+
+	refreshToken, err := activeStore.GetActiveRefreshTokenByFamily(ctx, familyID)
+	if err != nil {
+		if errors.Is(err, storage.ErrRefreshTokenFamilyNotFound) {
+			return nil, fmt.Errorf("no active refresh token for family %q: %w", familyID, err)
+		}
+		return nil, fmt.Errorf("lookup active refresh token: %w", err)
+	}
+
+	return s.RefreshAccessToken(ctx, refreshToken, family.ClientID)
+}

--- a/server/flows_refresh_session.go
+++ b/server/flows_refresh_session.go
@@ -20,9 +20,11 @@ import (
 // Returns the new provider token. The caller can extract the id_token
 // from the Extra field via [ExtractIDToken] for SSO-forwarding flows.
 //
-// Concurrent calls for the same familyID are coalesced — only one
-// refresh hits the upstream provider; the rest wait for and share the
-// result. This matches the proactive-refresh path's coalescing behavior.
+// Overlapping in-process calls for the same familyID are coalesced —
+// only one refresh hits the upstream provider; the rest wait for and
+// share the result. Calls that arrive sequentially (after the previous
+// one returns) each run their own refresh, as expected. This matches
+// the proactive-refresh path's coalescing behavior.
 //
 // Returns an error if:
 //   - the storage backend does not implement
@@ -36,6 +38,24 @@ import (
 // path: TokenRefreshHandler is called with the userID + familyID + new
 // token, refresh-token rotation produces a new family generation, and
 // the new tokens are saved to the TokenStore.
+//
+// Failure semantics: if the call fails after the active refresh token
+// has been atomically deleted (e.g. the upstream provider's refresh
+// errors out), the family is left without a usable refresh token. The
+// caller should treat that as session-loss and propagate a 401 / force
+// re-authentication. This matches RefreshAccessToken behavior — it is
+// the standard OAuth 2.1 rotation contract, not a regression from this
+// API.
+//
+// Cross-process race: when storage is shared (Valkey, Postgres, …) and
+// another instance rotates the family between this call's lookup and
+// its atomic delete, the atomic delete returns "not found" and is
+// surfaced to the caller as an invalid-grant error. RefreshSession
+// does not retry across this race because the underlying error is
+// indistinguishable from a genuine reuse-detection event, and a naive
+// retry would falsely trigger family revocation on the rotated state.
+// Callers in distributed deployments that observe this should re-read
+// the cached entry — another instance has produced a fresh token.
 func (s *Server) RefreshSession(ctx context.Context, familyID string) (*oauth2.Token, error) {
 	if familyID == "" {
 		return nil, fmt.Errorf("familyID is required")

--- a/server/flows_refresh_session.go
+++ b/server/flows_refresh_session.go
@@ -48,15 +48,16 @@ import (
 // the standard OAuth 2.1 rotation contract, not a regression from this
 // API.
 //
-// Cross-process race: when storage is shared (Valkey, Postgres, …) and
-// another instance rotates the family between this call's lookup and
-// its atomic delete, the atomic delete returns "not found" and is
-// surfaced to the caller as an invalid-grant error. RefreshSession
-// does not retry across this race because the underlying error is
-// indistinguishable from a genuine reuse-detection event, and a naive
-// retry would falsely trigger family revocation on the rotated state.
-// Callers in distributed deployments that observe this should re-read
-// the cached entry — another instance has produced a fresh token.
+// Cross-process race: when the storage backend is shared across
+// instances and another instance rotates the family between this call's
+// lookup and its atomic delete, the atomic delete returns "not found"
+// and is surfaced to the caller as an invalid-grant error.
+// RefreshSession does not retry across this race because the underlying
+// error is indistinguishable from a genuine reuse-detection event, and
+// a naive retry would falsely trigger family revocation on the rotated
+// state. Callers in distributed deployments that observe this should
+// re-read the cached entry — another instance has produced a fresh
+// token.
 func (s *Server) RefreshSession(ctx context.Context, familyID string) (*oauth2.Token, error) {
 	if familyID == "" {
 		return nil, fmt.Errorf("familyID is required")
@@ -76,6 +77,15 @@ func (s *Server) RefreshSession(ctx context.Context, familyID string) (*oauth2.T
 // then delegates to the existing RefreshAccessToken path so rotation,
 // reuse detection, audit logging, and TokenRefreshHandler dispatch all
 // behave identically to the public token-endpoint flow.
+//
+// The clientID returned from storage is passed back into
+// RefreshAccessToken so its OAuth 2.1 client-binding validation runs.
+// In this in-process flow that check trivially passes (the value comes
+// from storage and goes straight back into a check against itself); the
+// useful path is the public refresh-token-grant flow where storage's
+// clientID is compared against an untrusted value supplied by the
+// caller. Calling RefreshAccessToken with the storage clientID keeps
+// the audit log and reuse-detection paths uniform across both flows.
 func (s *Server) refreshSessionImpl(ctx context.Context, familyID string) (*oauth2.Token, error) {
 	activeStore, ok := s.tokenStore.(storage.ActiveRefreshTokenByFamilyStore)
 	if !ok {
@@ -84,13 +94,15 @@ func (s *Server) refreshSessionImpl(ctx context.Context, familyID string) (*oaut
 
 	refreshToken, clientID, err := activeStore.GetActiveRefreshTokenByFamily(ctx, familyID)
 	switch {
-	case errors.Is(err, storage.ErrRefreshTokenFamilyRevoked):
+	case err == nil:
+		return s.RefreshAccessToken(ctx, refreshToken, clientID)
+	case errors.Is(err, storage.ErrRefreshTokenFamilyNotFound),
+		errors.Is(err, storage.ErrRefreshTokenFamilyRevoked):
+		// Both sentinels are the caller's actionable signal — wrap with
+		// the familyID for log readability, preserve the sentinel for
+		// errors.Is at the call site.
 		return nil, fmt.Errorf("family %q: %w", familyID, err)
-	case errors.Is(err, storage.ErrRefreshTokenFamilyNotFound):
-		return nil, fmt.Errorf("family %q: %w", familyID, err)
-	case err != nil:
+	default:
 		return nil, fmt.Errorf("lookup active refresh token: %w", err)
 	}
-
-	return s.RefreshAccessToken(ctx, refreshToken, clientID)
 }

--- a/server/flows_refresh_session_test.go
+++ b/server/flows_refresh_session_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// seedFamilyForRefresh writes a refresh-token-family entry directly to the
+// memory store so RefreshSession has something to look up. Returns the
+// refresh token used so tests can assert it gets rotated.
+func seedFamilyForRefresh(t *testing.T, store *memory.Store, userID, clientID, familyID, refreshToken string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, store.SaveRefreshTokenWithFamily(
+		ctx, refreshToken, userID, clientID, familyID, 0, time.Now().Add(24*time.Hour),
+	))
+	// Also seed the provider token so the Atomic delete + provider refresh path can run.
+	require.NoError(t, store.SaveToken(ctx, refreshToken, &oauth2.Token{
+		AccessToken:  "provider-access",
+		RefreshToken: "provider-refresh",
+		Expiry:       time.Now().Add(time.Hour),
+		TokenType:    "Bearer",
+	}))
+}
+
+func TestRefreshSession_HappyPath(t *testing.T) {
+	srv, store, provider := setupFlowTestServer(t)
+	ctx := context.Background()
+
+	const (
+		userID       = "user-1"
+		clientID     = "client-x"
+		familyID     = "fam-happy"
+		refreshToken = "rt-happy-1"
+	)
+	seedFamilyForRefresh(t, store, userID, clientID, familyID, refreshToken)
+
+	// Mock provider returns a fresh token on RefreshToken.
+	provider.RefreshTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		return (&oauth2.Token{
+			AccessToken:  "new-provider-access",
+			RefreshToken: "new-provider-refresh",
+			Expiry:       time.Now().Add(time.Hour),
+			TokenType:    "Bearer",
+		}).WithExtra(map[string]any{"id_token": "new.id.token"}), nil
+	}
+
+	got, err := srv.RefreshSession(ctx, familyID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.NotEmpty(t, got.AccessToken)
+	require.NotEmpty(t, got.RefreshToken)
+	// id_token forwarded from provider to the response.
+	require.Equal(t, "new.id.token", got.Extra("id_token"))
+}
+
+func TestRefreshSession_FamilyNotFound(t *testing.T) {
+	srv, _, _ := setupFlowTestServer(t)
+
+	_, err := srv.RefreshSession(context.Background(), "no-such-family")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, storage.ErrRefreshTokenFamilyNotFound), "want wrapped ErrRefreshTokenFamilyNotFound, got %v", err)
+}
+
+func TestRefreshSession_RevokedFamily(t *testing.T) {
+	srv, store, _ := setupFlowTestServer(t)
+	ctx := context.Background()
+
+	const familyID = "fam-revoked"
+	seedFamilyForRefresh(t, store, "user-1", "client-x", familyID, "rt-revoked")
+
+	require.NoError(t, store.RevokeRefreshTokenFamily(ctx, familyID))
+
+	_, err := srv.RefreshSession(ctx, familyID)
+	require.Error(t, err, "RefreshSession on a revoked family must fail")
+	// After revoke, GetActiveRefreshTokenByFamily returns
+	// ErrRefreshTokenFamilyNotFound (no non-revoked entry); the family
+	// metadata lookup also flags Revoked. Either path produces an error.
+	require.NotContains(t, err.Error(), "no error", "sanity")
+}
+
+func TestRefreshSession_ProviderRefreshFails(t *testing.T) {
+	srv, store, provider := setupFlowTestServer(t)
+	ctx := context.Background()
+
+	const familyID = "fam-provider-fail"
+	seedFamilyForRefresh(t, store, "user-1", "client-x", familyID, "rt-provider-fail")
+
+	provider.RefreshTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		return nil, fmt.Errorf("upstream IdP returned 500")
+	}
+
+	_, err := srv.RefreshSession(ctx, familyID)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "upstream IdP returned 500")
+}
+
+func TestRefreshSession_RequiresFamilyID(t *testing.T) {
+	srv, _, _ := setupFlowTestServer(t)
+	_, err := srv.RefreshSession(context.Background(), "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "familyID is required")
+}
+
+func TestRefreshSession_CoalescesConcurrentCalls(t *testing.T) {
+	srv, store, provider := setupFlowTestServer(t)
+	ctx := context.Background()
+
+	const (
+		familyID     = "fam-coalesce"
+		refreshToken = "rt-coalesce"
+	)
+	seedFamilyForRefresh(t, store, "user-1", "client-x", familyID, refreshToken)
+
+	var providerCalls atomic.Int32
+	// Block briefly inside the provider call so concurrent callers all
+	// arrive at the singleflight before the first one finishes.
+	provider.RefreshTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
+		providerCalls.Add(1)
+		time.Sleep(50 * time.Millisecond)
+		return &oauth2.Token{
+			AccessToken:  "new-provider-access",
+			RefreshToken: "new-provider-refresh",
+			Expiry:       time.Now().Add(time.Hour),
+			TokenType:    "Bearer",
+		}, nil
+	}
+
+	const concurrent = 8
+	var wg sync.WaitGroup
+	results := make([]*oauth2.Token, concurrent)
+	errs := make([]error, concurrent)
+
+	for i := range concurrent {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i], errs[i] = srv.RefreshSession(ctx, familyID)
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, int32(1), providerCalls.Load(), "singleflight should coalesce concurrent calls into one provider hit")
+	for i := range concurrent {
+		require.NoError(t, errs[i], "call %d", i)
+		require.NotNil(t, results[i], "call %d", i)
+	}
+}

--- a/server/flows_refresh_session_test.go
+++ b/server/flows_refresh_session_test.go
@@ -84,12 +84,8 @@ func TestRefreshSession_RevokedFamily(t *testing.T) {
 
 	_, err := srv.RefreshSession(ctx, familyID)
 	require.Error(t, err, "RefreshSession on a revoked family must fail")
-	// The family-by-ID lookup runs first and short-circuits on
-	// family.Revoked, producing the explicit "is revoked" message.
-	// Pinning this string fails closed: a refactor that swallows the
-	// revoke check (e.g. by reordering the lookups) would no longer
-	// produce this text and the test would catch it.
-	require.Contains(t, err.Error(), "is revoked")
+	require.True(t, errors.Is(err, storage.ErrRefreshTokenFamilyRevoked),
+		"want wrapped ErrRefreshTokenFamilyRevoked, got %v", err)
 }
 
 func TestRefreshSession_ProviderRefreshFails(t *testing.T) {

--- a/server/flows_refresh_session_test.go
+++ b/server/flows_refresh_session_test.go
@@ -84,10 +84,12 @@ func TestRefreshSession_RevokedFamily(t *testing.T) {
 
 	_, err := srv.RefreshSession(ctx, familyID)
 	require.Error(t, err, "RefreshSession on a revoked family must fail")
-	// After revoke, GetActiveRefreshTokenByFamily returns
-	// ErrRefreshTokenFamilyNotFound (no non-revoked entry); the family
-	// metadata lookup also flags Revoked. Either path produces an error.
-	require.NotContains(t, err.Error(), "no error", "sanity")
+	// The family-by-ID lookup runs first and short-circuits on
+	// family.Revoked, producing the explicit "is revoked" message.
+	// Pinning this string fails closed: a refactor that swallows the
+	// revoke check (e.g. by reordering the lookups) would no longer
+	// produce this text and the test would catch it.
+	require.Contains(t, err.Error(), "is revoked")
 }
 
 func TestRefreshSession_ProviderRefreshFails(t *testing.T) {
@@ -123,12 +125,18 @@ func TestRefreshSession_CoalescesConcurrentCalls(t *testing.T) {
 	)
 	seedFamilyForRefresh(t, store, "user-1", "client-x", familyID, refreshToken)
 
+	// Channel-based synchronization rather than time.Sleep:
+	//   - the provider blocks on `release` until the test signals
+	//   - the test launches all goroutines, waits for them to enqueue
+	//     into the singleflight, then closes `release`
+	// This removes any timing dependency — the test is correct under
+	// arbitrary scheduler load.
+	const concurrent = 8
 	var providerCalls atomic.Int32
-	// Block briefly inside the provider call so concurrent callers all
-	// arrive at the singleflight before the first one finishes.
+	release := make(chan struct{})
 	provider.RefreshTokenFunc = func(_ context.Context, _ string) (*oauth2.Token, error) {
 		providerCalls.Add(1)
-		time.Sleep(50 * time.Millisecond)
+		<-release
 		return &oauth2.Token{
 			AccessToken:  "new-provider-access",
 			RefreshToken: "new-provider-refresh",
@@ -137,8 +145,8 @@ func TestRefreshSession_CoalescesConcurrentCalls(t *testing.T) {
 		}, nil
 	}
 
-	const concurrent = 8
 	var wg sync.WaitGroup
+	started := make(chan struct{}, concurrent)
 	results := make([]*oauth2.Token, concurrent)
 	errs := make([]error, concurrent)
 
@@ -146,9 +154,27 @@ func TestRefreshSession_CoalescesConcurrentCalls(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
+			started <- struct{}{}
 			results[i], errs[i] = srv.RefreshSession(ctx, familyID)
 		}(i)
 	}
+
+	// Wait for all goroutines to have entered RefreshSession. The
+	// first one will be inside the provider RefreshTokenFunc waiting
+	// on release; the others will be queued on the singleflight Do.
+	for range concurrent {
+		<-started
+	}
+	// Tiny grace period so the first call has reached the blocked
+	// provider func before the rest pile into singleflight; without it
+	// the very first goroutine could still be in setup and the second
+	// could overtake into a second singleflight execution. Bounded by
+	// the sync we just did, this is not a wall-clock dependence.
+	require.Eventually(t, func() bool {
+		return providerCalls.Load() == 1
+	}, time.Second, 5*time.Millisecond, "first call should reach provider before others queue")
+
+	close(release)
 	wg.Wait()
 
 	require.Equal(t, int32(1), providerCalls.Load(), "singleflight should coalesce concurrent calls into one provider hit")

--- a/server/server.go
+++ b/server/server.go
@@ -94,6 +94,7 @@ type Server struct {
 	tokenPairs                    sync.Map                                // Maps client access token -> client refresh token for paired updates
 	tokenPairsByRefresh           sync.Map                                // Maps client refresh token -> client access token for pair cleanup
 	refreshGroup                  singleflight.Group                      // Deduplicates concurrent provider token refreshes per access token
+	refreshSessionGroup           singleflight.Group                      // Deduplicates concurrent RefreshSession calls per family ID
 	Logger                        *slog.Logger
 	Config                        *Config
 	shutdownOnce                  sync.Once // Ensures Shutdown is called only once

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -108,15 +108,16 @@ type Store struct {
 
 // Compile-time interface checks to ensure Store implements all storage interfaces
 var (
-	_ storage.TokenStore                  = (*Store)(nil)
-	_ storage.ClientStore                 = (*Store)(nil)
-	_ storage.FlowStore                   = (*Store)(nil)
-	_ storage.Combined                    = (*Store)(nil)
-	_ storage.RefreshTokenFamilyStore     = (*Store)(nil)
-	_ storage.TokenRevocationStore        = (*Store)(nil)
-	_ storage.TokenMetadataStore          = (*Store)(nil)
-	_ storage.RevokedTokenStore           = (*Store)(nil)
-	_ storage.RefreshTokenFamilyByIDStore = (*Store)(nil)
+	_ storage.TokenStore                      = (*Store)(nil)
+	_ storage.ClientStore                     = (*Store)(nil)
+	_ storage.FlowStore                       = (*Store)(nil)
+	_ storage.Combined                        = (*Store)(nil)
+	_ storage.RefreshTokenFamilyStore         = (*Store)(nil)
+	_ storage.TokenRevocationStore            = (*Store)(nil)
+	_ storage.TokenMetadataStore              = (*Store)(nil)
+	_ storage.RevokedTokenStore               = (*Store)(nil)
+	_ storage.RefreshTokenFamilyByIDStore     = (*Store)(nil)
+	_ storage.ActiveRefreshTokenByFamilyStore = (*Store)(nil)
 )
 
 // New creates a new in-memory store with default cleanup interval (1 minute)
@@ -655,6 +656,39 @@ func (s *Store) GetRefreshTokenFamily(_ context.Context, refreshToken string) (*
 		Revoked:    family.Revoked,
 		RevokedAt:  family.RevokedAt,
 	}, nil
+}
+
+// GetActiveRefreshTokenByFamily returns the most recent (highest
+// generation) non-revoked refresh token for the family
+// (storage.ActiveRefreshTokenByFamilyStore). Linear scan, same shape as
+// GetRefreshTokenFamilyByID. Returns ErrRefreshTokenFamilyNotFound when
+// no live entry matches — including when the family was revoked.
+func (s *Store) GetActiveRefreshTokenByFamily(_ context.Context, familyID string) (string, error) {
+	if familyID == "" {
+		return "", storage.ErrRefreshTokenFamilyNotFound
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var (
+		bestToken string
+		bestGen   int
+		found     bool
+	)
+	for token, family := range s.refreshTokenFamilies {
+		if family.FamilyID != familyID || family.Revoked {
+			continue
+		}
+		if !found || family.Generation > bestGen {
+			bestToken = token
+			bestGen = family.Generation
+			found = true
+		}
+	}
+	if !found {
+		return "", storage.ErrRefreshTokenFamilyNotFound
+	}
+	return bestToken, nil
 }
 
 // GetRefreshTokenFamilyByID returns family metadata indexed by family ID

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -659,36 +659,49 @@ func (s *Store) GetRefreshTokenFamily(_ context.Context, refreshToken string) (*
 }
 
 // GetActiveRefreshTokenByFamily returns the most recent (highest
-// generation) non-revoked refresh token for the family
-// (storage.ActiveRefreshTokenByFamilyStore). Linear scan, same shape as
-// GetRefreshTokenFamilyByID. Returns ErrRefreshTokenFamilyNotFound when
-// no live entry matches — including when the family was revoked.
-func (s *Store) GetActiveRefreshTokenByFamily(_ context.Context, familyID string) (string, error) {
+// generation) non-revoked refresh token for the family along with the
+// owning client ID (storage.ActiveRefreshTokenByFamilyStore). Linear
+// scan, same shape as GetRefreshTokenFamilyByID.
+//
+// Returns ErrRefreshTokenFamilyNotFound when no entry matches at all,
+// or ErrRefreshTokenFamilyRevoked when entries exist but every member
+// is revoked.
+func (s *Store) GetActiveRefreshTokenByFamily(_ context.Context, familyID string) (refreshToken, clientID string, err error) {
 	if familyID == "" {
-		return "", storage.ErrRefreshTokenFamilyNotFound
+		return "", "", storage.ErrRefreshTokenFamilyNotFound
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var (
-		bestToken string
-		bestGen   int
-		found     bool
+		bestToken    string
+		bestClientID string
+		bestGen      int
+		bestFound    bool
+		anyEntry     bool
 	)
 	for token, family := range s.refreshTokenFamilies {
-		if family.FamilyID != familyID || family.Revoked {
+		if family.FamilyID != familyID {
 			continue
 		}
-		if !found || family.Generation > bestGen {
+		anyEntry = true
+		if family.Revoked {
+			continue
+		}
+		if !bestFound || family.Generation > bestGen {
 			bestToken = token
+			bestClientID = family.ClientID
 			bestGen = family.Generation
-			found = true
+			bestFound = true
 		}
 	}
-	if !found {
-		return "", storage.ErrRefreshTokenFamilyNotFound
+	if !bestFound {
+		if anyEntry {
+			return "", "", storage.ErrRefreshTokenFamilyRevoked
+		}
+		return "", "", storage.ErrRefreshTokenFamilyNotFound
 	}
-	return bestToken, nil
+	return bestToken, bestClientID, nil
 }
 
 // GetRefreshTokenFamilyByID returns family metadata indexed by family ID

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -373,44 +373,47 @@ func TestStore_GetActiveRefreshTokenByFamily(t *testing.T) {
 	expiresAt := time.Now().Add(90 * 24 * time.Hour)
 
 	t.Run("empty familyID returns NotFound", func(t *testing.T) {
-		_, err := store.GetActiveRefreshTokenByFamily(ctx, "")
+		_, _, err := store.GetActiveRefreshTokenByFamily(ctx, "")
 		if err != storage.ErrRefreshTokenFamilyNotFound {
 			t.Errorf("err = %v, want ErrRefreshTokenFamilyNotFound", err)
 		}
 	})
 
 	t.Run("unknown family returns NotFound", func(t *testing.T) {
-		_, err := store.GetActiveRefreshTokenByFamily(ctx, "no-such-family")
+		_, _, err := store.GetActiveRefreshTokenByFamily(ctx, "no-such-family")
 		if err != storage.ErrRefreshTokenFamilyNotFound {
 			t.Errorf("err = %v, want ErrRefreshTokenFamilyNotFound", err)
 		}
 	})
 
-	t.Run("returns highest-generation non-revoked token", func(t *testing.T) {
+	t.Run("returns highest-generation non-revoked token + clientID", func(t *testing.T) {
 		// Three rotations of the same family. Highest Generation wins.
 		for i, token := range []string{"rt-gen0", "rt-gen1", "rt-gen2"} {
-			if err := store.SaveRefreshTokenWithFamily(ctx, token, "u", "c", familyID, i, expiresAt); err != nil {
+			if err := store.SaveRefreshTokenWithFamily(ctx, token, "u", "client-from-rotation", familyID, i, expiresAt); err != nil {
 				t.Fatalf("seed %s: %v", token, err)
 			}
 		}
 
-		got, err := store.GetActiveRefreshTokenByFamily(ctx, familyID)
+		token, clientID, err := store.GetActiveRefreshTokenByFamily(ctx, familyID)
 		if err != nil {
 			t.Fatalf("err = %v", err)
 		}
-		if got != "rt-gen2" {
-			t.Errorf("active token = %q, want rt-gen2 (highest generation)", got)
+		if token != "rt-gen2" {
+			t.Errorf("active token = %q, want rt-gen2 (highest generation)", token)
+		}
+		if clientID != "client-from-rotation" {
+			t.Errorf("clientID = %q, want client-from-rotation", clientID)
 		}
 	})
 
-	t.Run("revoked family returns NotFound", func(t *testing.T) {
+	t.Run("revoked family returns Revoked sentinel", func(t *testing.T) {
 		if err := store.RevokeRefreshTokenFamily(ctx, familyID); err != nil {
 			t.Fatalf("revoke: %v", err)
 		}
 
-		_, err := store.GetActiveRefreshTokenByFamily(ctx, familyID)
-		if err != storage.ErrRefreshTokenFamilyNotFound {
-			t.Errorf("err = %v, want ErrRefreshTokenFamilyNotFound after revoke", err)
+		_, _, err := store.GetActiveRefreshTokenByFamily(ctx, familyID)
+		if err != storage.ErrRefreshTokenFamilyRevoked {
+			t.Errorf("err = %v, want ErrRefreshTokenFamilyRevoked after revoke", err)
 		}
 	})
 }

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -364,6 +364,57 @@ func TestStore_SaveRefreshTokenWithFamily(t *testing.T) {
 	}
 }
 
+func TestStore_GetActiveRefreshTokenByFamily(t *testing.T) {
+	ctx := context.Background()
+	store := New()
+	defer store.Stop()
+
+	const familyID = "fam-active"
+	expiresAt := time.Now().Add(90 * 24 * time.Hour)
+
+	t.Run("empty familyID returns NotFound", func(t *testing.T) {
+		_, err := store.GetActiveRefreshTokenByFamily(ctx, "")
+		if err != storage.ErrRefreshTokenFamilyNotFound {
+			t.Errorf("err = %v, want ErrRefreshTokenFamilyNotFound", err)
+		}
+	})
+
+	t.Run("unknown family returns NotFound", func(t *testing.T) {
+		_, err := store.GetActiveRefreshTokenByFamily(ctx, "no-such-family")
+		if err != storage.ErrRefreshTokenFamilyNotFound {
+			t.Errorf("err = %v, want ErrRefreshTokenFamilyNotFound", err)
+		}
+	})
+
+	t.Run("returns highest-generation non-revoked token", func(t *testing.T) {
+		// Three rotations of the same family. Highest Generation wins.
+		for i, token := range []string{"rt-gen0", "rt-gen1", "rt-gen2"} {
+			if err := store.SaveRefreshTokenWithFamily(ctx, token, "u", "c", familyID, i, expiresAt); err != nil {
+				t.Fatalf("seed %s: %v", token, err)
+			}
+		}
+
+		got, err := store.GetActiveRefreshTokenByFamily(ctx, familyID)
+		if err != nil {
+			t.Fatalf("err = %v", err)
+		}
+		if got != "rt-gen2" {
+			t.Errorf("active token = %q, want rt-gen2 (highest generation)", got)
+		}
+	})
+
+	t.Run("revoked family returns NotFound", func(t *testing.T) {
+		if err := store.RevokeRefreshTokenFamily(ctx, familyID); err != nil {
+			t.Fatalf("revoke: %v", err)
+		}
+
+		_, err := store.GetActiveRefreshTokenByFamily(ctx, familyID)
+		if err != storage.ErrRefreshTokenFamilyNotFound {
+			t.Errorf("err = %v, want ErrRefreshTokenFamilyNotFound after revoke", err)
+		}
+	})
+}
+
 func TestStore_RevokeRefreshTokenFamily(t *testing.T) {
 	ctx := context.Background()
 	store := New()

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -194,6 +194,26 @@ type RefreshTokenFamilyByIDStore interface {
 	GetRefreshTokenFamilyByID(ctx context.Context, familyID string) (*RefreshTokenFamilyMetadata, error)
 }
 
+// ActiveRefreshTokenByFamilyStore is an optional extension that exposes
+// the most recent (highest-generation) non-revoked refresh token for a
+// family, looked up by family ID. Required by Server.RefreshSession,
+// which otherwise has no way to refresh a session given only the family
+// ID — the public refresh-token-grant path needs the refresh token
+// itself, which the caller does not have on the in-process refresh path.
+//
+// Implementations must return ErrRefreshTokenFamilyNotFound when no
+// active (non-revoked, non-expired) refresh token is found for the
+// family, including when the family was revoked.
+//
+// Memory and Valkey both implement this interface. Backends that don't
+// will cause Server.RefreshSession to return an error at call time.
+type ActiveRefreshTokenByFamilyStore interface {
+	// GetActiveRefreshTokenByFamily returns the most recent (highest
+	// generation) non-revoked refresh token for the family, or
+	// ErrRefreshTokenFamilyNotFound when none exists.
+	GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (string, error)
+}
+
 // RefreshTokenFamilyMetadata contains metadata about a token family
 type RefreshTokenFamilyMetadata struct {
 	FamilyID   string

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -74,6 +74,13 @@ var (
 	// ErrRefreshTokenFamilyNotFound indicates the refresh token family does not exist.
 	// This is normal for tokens created before family tracking was enabled.
 	ErrRefreshTokenFamilyNotFound = errors.New("refresh token family not found")
+
+	// ErrRefreshTokenFamilyRevoked indicates the family exists but every
+	// member is revoked. Distinct from ErrRefreshTokenFamilyNotFound so
+	// callers can produce a better error message — "session was revoked"
+	// vs "no such session". The two states converge to NotFound after the
+	// revoked-family retention period elapses and the entries are wiped.
+	ErrRefreshTokenFamilyRevoked = errors.New("refresh token family is revoked")
 )
 
 // IsNotFoundError checks if an error indicates a "not found" condition.
@@ -201,17 +208,23 @@ type RefreshTokenFamilyByIDStore interface {
 // ID — the public refresh-token-grant path needs the refresh token
 // itself, which the caller does not have on the in-process refresh path.
 //
-// Implementations must return ErrRefreshTokenFamilyNotFound when no
-// active (non-revoked, non-expired) refresh token is found for the
-// family, including when the family was revoked.
+// The method returns both the refresh token and the owning client ID in
+// one call so RefreshSession does not need a second lookup to get the
+// client ID for OAuth 2.1 refresh-token client binding validation.
 //
 // Memory and Valkey both implement this interface. Backends that don't
 // will cause Server.RefreshSession to return an error at call time.
 type ActiveRefreshTokenByFamilyStore interface {
 	// GetActiveRefreshTokenByFamily returns the most recent (highest
-	// generation) non-revoked refresh token for the family, or
-	// ErrRefreshTokenFamilyNotFound when none exists.
-	GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (string, error)
+	// generation) non-revoked refresh token for the family along with
+	// the owning client ID.
+	//
+	// Returns ErrRefreshTokenFamilyNotFound when no entry for the family
+	// exists in storage at all (never created, or aged out of revoked-
+	// family retention). Returns ErrRefreshTokenFamilyRevoked when the
+	// family exists but every member is revoked — a distinct state so
+	// callers can surface "session was revoked" vs "no such session".
+	GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (refreshToken, clientID string, err error)
 }
 
 // RefreshTokenFamilyMetadata contains metadata about a token family

--- a/storage/valkey/security.go
+++ b/storage/valkey/security.go
@@ -229,6 +229,56 @@ func (s *Store) GetRefreshTokenFamilyByID(ctx context.Context, familyID string) 
 	return nil, storage.ErrRefreshTokenFamilyNotFound
 }
 
+// GetActiveRefreshTokenByFamily returns the most recent (highest generation)
+// non-revoked refresh token for the family
+// (storage.ActiveRefreshTokenByFamilyStore). Iterates the same Set used by
+// GetRefreshTokenFamilyByID, fetches per-token metadata, and picks the
+// highest-Generation entry whose Revoked flag is unset.
+//
+// Returns ErrRefreshTokenFamilyNotFound when the Set is empty, every
+// member's metadata is missing, or every member is revoked.
+func (s *Store) GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (active string, err error) {
+	op := s.startTracedOp(ctx, "get_active_refresh_token_by_family")
+	defer op.end(&err)
+
+	if familyID == "" {
+		return "", storage.ErrRefreshTokenFamilyNotFound
+	}
+
+	familySetKey := s.familyKey(familyID)
+	tokens, err := s.client.Do(op.ctx, s.client.B().Smembers().Key(familySetKey).Build()).AsStrSlice()
+	if err != nil {
+		if isNilError(err) {
+			return "", storage.ErrRefreshTokenFamilyNotFound
+		}
+		return "", fmt.Errorf("read family members: %w", err)
+	}
+	if len(tokens) == 0 {
+		return "", storage.ErrRefreshTokenFamilyNotFound
+	}
+
+	var (
+		bestToken string
+		bestGen   int
+		found     bool
+	)
+	for _, refreshToken := range tokens {
+		meta, err := getAndUnmarshal(op.ctx, s, s.refreshTokenMetaKey(refreshToken), storage.ErrRefreshTokenFamilyNotFound, fromRefreshTokenFamilyJSON)
+		if err != nil || meta == nil || meta.Revoked {
+			continue
+		}
+		if !found || meta.Generation > bestGen {
+			bestToken = refreshToken
+			bestGen = meta.Generation
+			found = true
+		}
+	}
+	if !found {
+		return "", storage.ErrRefreshTokenFamilyNotFound
+	}
+	return bestToken, nil
+}
+
 // RevokeRefreshTokenFamily revokes all tokens in a family (for reuse detection)
 // This is called when token reuse is detected (OAuth 2.1 security requirement)
 func (s *Store) RevokeRefreshTokenFamily(ctx context.Context, familyID string) (err error) {

--- a/storage/valkey/security.go
+++ b/storage/valkey/security.go
@@ -208,13 +208,9 @@ func (s *Store) GetRefreshTokenFamilyByID(ctx context.Context, familyID string) 
 		return nil, storage.ErrRefreshTokenFamilyNotFound
 	}
 
-	familySetKey := s.familyKey(familyID)
-	tokens, err := s.client.Do(op.ctx, s.client.B().Smembers().Key(familySetKey).Build()).AsStrSlice()
+	tokens, err := s.getFamilyTokens(op.ctx, familyID)
 	if err != nil {
-		if isNilError(err) {
-			return nil, storage.ErrRefreshTokenFamilyNotFound
-		}
-		return nil, fmt.Errorf("read family members: %w", err)
+		return nil, err
 	}
 	if len(tokens) == 0 {
 		return nil, storage.ErrRefreshTokenFamilyNotFound
@@ -246,7 +242,7 @@ func (s *Store) GetActiveRefreshTokenByFamily(ctx context.Context, familyID stri
 		return "", "", storage.ErrRefreshTokenFamilyNotFound
 	}
 
-	tokens, err := s.readFamilyMembers(op.ctx, familyID)
+	tokens, err := s.getFamilyTokens(op.ctx, familyID)
 	if err != nil {
 		return "", "", err
 	}
@@ -263,21 +259,6 @@ func (s *Store) GetActiveRefreshTokenByFamily(ctx context.Context, familyID stri
 	default:
 		return "", "", storage.ErrRefreshTokenFamilyNotFound
 	}
-}
-
-// readFamilyMembers reads the Set of refresh tokens belonging to a
-// family. Returns ErrRefreshTokenFamilyNotFound when the Set is missing
-// or unreadable as nil.
-func (s *Store) readFamilyMembers(ctx context.Context, familyID string) ([]string, error) {
-	familySetKey := s.familyKey(familyID)
-	tokens, err := s.client.Do(ctx, s.client.B().Smembers().Key(familySetKey).Build()).AsStrSlice()
-	if err != nil {
-		if isNilError(err) {
-			return nil, storage.ErrRefreshTokenFamilyNotFound
-		}
-		return nil, fmt.Errorf("read family members: %w", err)
-	}
-	return tokens, nil
 }
 
 // pickActiveMember walks the family member set and returns the

--- a/storage/valkey/security.go
+++ b/storage/valkey/security.go
@@ -230,53 +230,80 @@ func (s *Store) GetRefreshTokenFamilyByID(ctx context.Context, familyID string) 
 }
 
 // GetActiveRefreshTokenByFamily returns the most recent (highest generation)
-// non-revoked refresh token for the family
-// (storage.ActiveRefreshTokenByFamilyStore). Iterates the same Set used by
-// GetRefreshTokenFamilyByID, fetches per-token metadata, and picks the
-// highest-Generation entry whose Revoked flag is unset.
+// non-revoked refresh token for the family along with the owning client ID
+// (storage.ActiveRefreshTokenByFamilyStore). Iterates the same Set used
+// by GetRefreshTokenFamilyByID, fetches per-token metadata, and picks
+// the highest-Generation entry whose Revoked flag is unset.
 //
-// Returns ErrRefreshTokenFamilyNotFound when the Set is empty, every
-// member's metadata is missing, or every member is revoked.
-func (s *Store) GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (active string, err error) {
+// Returns ErrRefreshTokenFamilyNotFound when the Set is empty, or
+// ErrRefreshTokenFamilyRevoked when entries exist but every reachable
+// member's metadata is revoked.
+func (s *Store) GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (refreshToken, clientID string, err error) {
 	op := s.startTracedOp(ctx, "get_active_refresh_token_by_family")
 	defer op.end(&err)
 
 	if familyID == "" {
-		return "", storage.ErrRefreshTokenFamilyNotFound
+		return "", "", storage.ErrRefreshTokenFamilyNotFound
 	}
 
-	familySetKey := s.familyKey(familyID)
-	tokens, err := s.client.Do(op.ctx, s.client.B().Smembers().Key(familySetKey).Build()).AsStrSlice()
+	tokens, err := s.readFamilyMembers(op.ctx, familyID)
 	if err != nil {
-		if isNilError(err) {
-			return "", storage.ErrRefreshTokenFamilyNotFound
-		}
-		return "", fmt.Errorf("read family members: %w", err)
+		return "", "", err
 	}
 	if len(tokens) == 0 {
-		return "", storage.ErrRefreshTokenFamilyNotFound
+		return "", "", storage.ErrRefreshTokenFamilyNotFound
 	}
 
-	var (
-		bestToken string
-		bestGen   int
-		found     bool
-	)
-	for _, refreshToken := range tokens {
-		meta, err := getAndUnmarshal(op.ctx, s, s.refreshTokenMetaKey(refreshToken), storage.ErrRefreshTokenFamilyNotFound, fromRefreshTokenFamilyJSON)
-		if err != nil || meta == nil || meta.Revoked {
+	bestToken, bestClientID, anyMetaSeen := s.pickActiveMember(op.ctx, tokens)
+	switch {
+	case bestToken != "":
+		return bestToken, bestClientID, nil
+	case anyMetaSeen:
+		return "", "", storage.ErrRefreshTokenFamilyRevoked
+	default:
+		return "", "", storage.ErrRefreshTokenFamilyNotFound
+	}
+}
+
+// readFamilyMembers reads the Set of refresh tokens belonging to a
+// family. Returns ErrRefreshTokenFamilyNotFound when the Set is missing
+// or unreadable as nil.
+func (s *Store) readFamilyMembers(ctx context.Context, familyID string) ([]string, error) {
+	familySetKey := s.familyKey(familyID)
+	tokens, err := s.client.Do(ctx, s.client.B().Smembers().Key(familySetKey).Build()).AsStrSlice()
+	if err != nil {
+		if isNilError(err) {
+			return nil, storage.ErrRefreshTokenFamilyNotFound
+		}
+		return nil, fmt.Errorf("read family members: %w", err)
+	}
+	return tokens, nil
+}
+
+// pickActiveMember walks the family member set and returns the
+// highest-generation non-revoked token + its client ID. The third
+// return value reports whether any parseable metadata was observed —
+// used by the caller to distinguish "family revoked" (every member
+// flagged Revoked) from "family not found" (no metadata reachable at
+// all, e.g. retention-cleanup deleted it).
+func (s *Store) pickActiveMember(ctx context.Context, tokens []string) (token, clientID string, anyMetaSeen bool) {
+	var bestGen int
+	for _, candidate := range tokens {
+		meta, err := getAndUnmarshal(ctx, s, s.refreshTokenMetaKey(candidate), storage.ErrRefreshTokenFamilyNotFound, fromRefreshTokenFamilyJSON)
+		if err != nil || meta == nil {
 			continue
 		}
-		if !found || meta.Generation > bestGen {
-			bestToken = refreshToken
+		anyMetaSeen = true
+		if meta.Revoked {
+			continue
+		}
+		if token == "" || meta.Generation > bestGen {
+			token = candidate
+			clientID = meta.ClientID
 			bestGen = meta.Generation
-			found = true
 		}
 	}
-	if !found {
-		return "", storage.ErrRefreshTokenFamilyNotFound
-	}
-	return bestToken, nil
+	return token, clientID, anyMetaSeen
 }
 
 // RevokeRefreshTokenFamily revokes all tokens in a family (for reuse detection)

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -117,14 +117,15 @@ type Store struct {
 
 // Compile-time interface checks to ensure Store implements all storage interfaces
 var (
-	_ storage.TokenStore              = (*Store)(nil)
-	_ storage.ClientStore             = (*Store)(nil)
-	_ storage.FlowStore               = (*Store)(nil)
-	_ storage.Combined                = (*Store)(nil)
-	_ storage.RefreshTokenFamilyStore = (*Store)(nil)
-	_ storage.TokenRevocationStore    = (*Store)(nil)
-	_ storage.TokenMetadataStore      = (*Store)(nil)
-	_ storage.RevokedTokenStore       = (*Store)(nil)
+	_ storage.TokenStore                      = (*Store)(nil)
+	_ storage.ClientStore                     = (*Store)(nil)
+	_ storage.FlowStore                       = (*Store)(nil)
+	_ storage.Combined                        = (*Store)(nil)
+	_ storage.RefreshTokenFamilyStore         = (*Store)(nil)
+	_ storage.TokenRevocationStore            = (*Store)(nil)
+	_ storage.TokenMetadataStore              = (*Store)(nil)
+	_ storage.RevokedTokenStore               = (*Store)(nil)
+	_ storage.ActiveRefreshTokenByFamilyStore = (*Store)(nil)
 )
 
 // New creates a new Valkey-backed storage instance.


### PR DESCRIPTION
Closes #285. Stacked on top of the existing #286 → #294 → #295 → #296 chain. Re-base onto each predecessor as it lands; final base is `main`.

In-process API for refreshing an upstream provider token by family ID. Callable from any goroutine — useful when an integration (e.g. `muster`) discovers a cached ID token has expired on a request thread and needs to force a refresh before forwarding it. Pre-PR the only path was a fake `/oauth/token` POST to the same process, which re-authenticates the client and bypasses the in-process layer awkwardly.

## API

```go
func (s *Server) RefreshSession(ctx context.Context, familyID string) (*oauth2.Token, error)
```

- Returns the new provider token. Caller extracts `id_token` from `Extra` for SSO-forwarding flows.
- Reuses the existing `RefreshAccessToken` path → same rotation, reuse detection, audit logging, and `TokenRefreshHandler` dispatch.
- Concurrent calls for the same `familyID` are coalesced via `singleflight` — only one upstream provider refresh; the rest share the result.

## Storage interface

```go
type ActiveRefreshTokenByFamilyStore interface {
    GetActiveRefreshTokenByFamily(ctx context.Context, familyID string) (string, error)
}
```

Returns the highest-generation non-revoked refresh token for the family, or `ErrRefreshTokenFamilyNotFound`.

Implemented optionally rather than added to `RefreshTokenFamilyStore` to avoid breaking third-party storage backends. Memory and Valkey both implement it. `RefreshSession` returns a clear error when the configured backend doesn't.

## Tests

| Layer | Coverage |
|---|---|
| Storage (memory) | empty familyID, unknown family, highest-generation winner across multiple rotations, revoked family rejection |
| Server | happy path, family not found, revoked family, provider refresh failure, missing familyID arg, concurrent coalescing (8 goroutines → 1 provider call) |

## Caller in muster

[giantswarm/muster#549](https://github.com/giantswarm/muster/issues/549) wires `RefreshSession` into `getIDTokenForForwarding`: if the cached entry is expired, call `RefreshSession`, re-read from the proxy store, then forward.