### PR TITLE
log: downgrade startup chatter to Debug; add LogValue on Server/stores; group audit attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`LogValue()` on `Server`, `storage/memory.Store`, and `storage/valkey.Store`** (slog.LogValuer)
+  - Callers can attach a one-shot structured snapshot of the server / store posture to any log line: `logger.Info("oauth ready", "server", srv, "store", store)`. The library no longer emits this state on its own.
+  - `Server.LogValue()` exposes `issuer`, `production_mode`, `access_token_format`, `encryption_at_rest`, `instrumentation_on`, a `redirect_uri_policy` group (`dns_validation`, `dns_validation_strict`, `authorization_time_validation`, `dns_timeout`, `allow_localhost`, `allow_private_ip`, `allow_link_local`), and `session_id_hmac_key_fingerprint` (sha256[:8] hex, omitted when unconfigured).
+  - `memory.Store.LogValue()` / `valkey.Store.LogValue()` expose `backend`, `encryption_at_rest`, `instrumentation_on`.
 - **`Server.RefreshSession(ctx, familyID)` for on-demand session refresh** (closes #285)
   - In-process API to refresh an upstream provider token by family ID, callable from any goroutine. Reuses the existing `RefreshAccessToken` path (same rotation, reuse detection, audit, and `TokenRefreshHandler` dispatch) — just driven by family ID instead of by a refresh token in the request.
   - Concurrent calls for the same family ID are coalesced via `singleflight`: only one provider refresh hits the upstream, the rest share the result.
@@ -37,6 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Startup chatter downgraded from INFO to DEBUG; audit logs grouped under `slog.Group("audit", ...)`**
+  - Every "X enabled / Using Y / Initialized Z / Registered W" line that fired once at startup is now `slog.LevelDebug`. Affected sites span `server`, `storage/memory`, `storage/valkey`, `security/client_registration_ratelimit`, `providers/oidc`, plus per-request lifecycle Infos (`Token proactively refreshed`, `Refresh token rotated`, `Token revoked`, `Token exchange successful`, ...). WARN/ERROR security warnings are unchanged.
+  - The Server-side "Redirect URI security status" Info is removed; the same fields are reachable via `Server.LogValue()`.
+  - `Auditor.LogEvent` now emits via `slog.LogAttrs` with every audit field bundled in a single `slog.Group("audit", ...)`. Consumers can route audit records separately by inspecting the group in their `slog.Handler`. The level stays at `INFO` and the message stays `"security_audit"`.
+  - Consumers compile unchanged; only their log volume changes. Crank to `slog.LevelDebug` to recover the prior verbosity.
 - **Server constructor now accepts functional options; the post-construction `Set*` methods are gone**
   - `server.New` and `server.NewWithCombined` (and the root-package `oauth.NewServer` / `oauth.NewServerWithCombined`) take a variadic `...Option` parameter. New constructors: `WithEncryptor`, `WithAuditor`, `WithRateLimiter`, `WithUserRateLimiter`, `WithSecurityEventRateLimiter`, `WithClientRegistrationRateLimiter`, `WithMetadataFetchRateLimiter`, `WithSessionCreationHandler`, `WithSessionRevocationHandler`, `WithTokenRefreshHandler`, `WithInstrumentation`. `WithEncryptor` and `WithInstrumentation` propagate to the storage backend identically to the old setters.
   - **Breaking**: `Server.SetEncryptor`, `SetAuditor`, `SetRateLimiter`, `SetUserRateLimiter`, `SetSecurityEventRateLimiter`, `SetClientRegistrationRateLimiter`, `SetMetadataFetchRateLimiter`, `SetSessionCreationHandler`, `SetSessionRevocationHandler`, `SetTokenRefreshHandler`, and `SetInstrumentation` are removed. Migration: pass the same value as a `With*` option to the constructor.

--- a/handler.go
+++ b/handler.go
@@ -91,7 +91,7 @@ func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Req
 
 	authHeader := r.Header.Get("Authorization")
 	if h.validateRegistrationToken(authHeader) {
-		h.logger.Info("Client registration authenticated with valid token")
+		h.logger.Debug("Client registration authenticated with valid token")
 		return false, "", true
 	}
 
@@ -109,7 +109,7 @@ func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Req
 	}
 
 	if allowed {
-		h.logger.Info("Client registration authorized via trusted scheme",
+		h.logger.Debug("Client registration authorized via trusted scheme",
 			"scheme", scheme, "client_ip", clientIP, "strict_matching", !h.server.Config.DisableStrictSchemeMatching)
 		return true, scheme, true
 	}
@@ -150,7 +150,7 @@ func (h *Handler) validatePublicClientRegistration(w http.ResponseWriter, req *c
 		return false
 	}
 
-	h.logger.Info("Public client registration authorized",
+	h.logger.Debug("Public client registration authorized",
 		"token_endpoint_auth_method", req.TokenEndpointAuthMethod, "client_type", req.ClientType,
 		"ip", clientIP, "via_trusted_scheme", registeredViaTrustedScheme)
 	return true
@@ -880,7 +880,7 @@ func (h *Handler) registerMetadataSubPath(mux *http.ServeMux, resourcePath strin
 		return
 	}
 
-	h.logger.Info("Registering metadata sub-path endpoint",
+	h.logger.Debug("Registering metadata sub-path endpoint",
 		"path", subPath,
 		"resource_path", resourcePath)
 
@@ -938,7 +938,7 @@ func (h *Handler) RegisterAuthorizationServerMetadataRoutes(mux *http.ServeMux) 
 	if issuerPath == "" || issuerPath == "/" {
 		// Single-tenant deployment
 		registerStandardEndpoints()
-		h.logger.Info("Registered authorization server metadata endpoints",
+		h.logger.Debug("Registered authorization server metadata endpoints",
 			"oauth_endpoint", "/.well-known/oauth-authorization-server",
 			"oidc_endpoint", "/.well-known/openid-configuration")
 		return
@@ -965,7 +965,7 @@ func (h *Handler) RegisterAuthorizationServerMetadataRoutes(mux *http.ServeMux) 
 	// Backward compatibility
 	registerStandardEndpoints()
 
-	h.logger.Info("Registered multi-tenant authorization server metadata endpoints",
+	h.logger.Debug("Registered multi-tenant authorization server metadata endpoints",
 		"issuer_path", issuerPath,
 		"oauth_path_insert", oauthPathInsert,
 		"oidc_path_insert", oidcPathInsert,
@@ -1370,7 +1370,7 @@ func (h *Handler) ServeCallback(w http.ResponseWriter, r *http.Request) {
 	// Browsers may fail silently on 302 redirects to custom schemes (cursor://, vscode://, etc.)
 	// Serve an HTML interstitial page that shows success and attempts JS redirect with manual fallback
 	if isCustomURLScheme(authCode.RedirectURI) {
-		h.logger.Info("Serving success interstitial for custom URL scheme",
+		h.logger.Debug("Serving success interstitial for custom URL scheme",
 			"client_id", authCode.ClientID,
 			"scheme", parsedRedirect.Scheme)
 		h.recordHTTPMetrics("callback", http.MethodGet, http.StatusOK, startTime)
@@ -1485,7 +1485,7 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	h.logger.Info("Token exchange successful", "client_id", client.ClientID, "ip", clientIP)
+	h.logger.Debug("Token exchange successful", "client_id", client.ClientID, "ip", clientIP)
 
 	// Record code exchanged metric
 	pkceMethod := ""

--- a/providers/oidc/discovery.go
+++ b/providers/oidc/discovery.go
@@ -225,7 +225,7 @@ func (c *DiscoveryClient) Discover(ctx context.Context, issuerURL string) (*Disc
 		fetchedAt: c.timeProvider.Now(),
 	})
 
-	c.logger.Info("OIDC discovery successful",
+	c.logger.Debug("OIDC discovery successful",
 		"issuer", issuerURL,
 		"authorization_endpoint", doc.AuthorizationEndpoint,
 		"token_endpoint", doc.TokenEndpoint)

--- a/security/audit.go
+++ b/security/audit.go
@@ -3,6 +3,7 @@
 package security
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"log/slog"
@@ -38,7 +39,9 @@ type Event struct {
 	Timestamp time.Time
 }
 
-// LogEvent logs a security event with hashed PII
+// LogEvent logs a security event with hashed PII. Attributes are emitted
+// under a single [slog.Group] named "audit" so consumers can split-route
+// audit records from operational logs in their slog.Handler.
 func (a *Auditor) LogEvent(event Event) {
 	if !a.enabled {
 		return
@@ -46,16 +49,17 @@ func (a *Auditor) LogEvent(event Event) {
 
 	event.Timestamp = time.Now()
 
-	a.logger.Info(
-		"security_audit",
-		"event_type", event.Type,
-		"user_id_hash", hashForLogging(event.UserID),
-		"client_id", event.ClientID,
-		"ip_address", event.IPAddress,
-		"user_agent", event.UserAgent,
-		"request_id", event.RequestID,
-		"details", event.Details,
-		"timestamp", event.Timestamp,
+	a.logger.LogAttrs(context.Background(), slog.LevelInfo, "security_audit",
+		slog.Group("audit",
+			slog.String("event_type", event.Type),
+			slog.String("user_id_hash", hashForLogging(event.UserID)),
+			slog.String("client_id", event.ClientID),
+			slog.String("ip_address", event.IPAddress),
+			slog.String("user_agent", event.UserAgent),
+			slog.String("request_id", event.RequestID),
+			slog.Any("details", event.Details),
+			slog.Time("timestamp", event.Timestamp),
+		),
 	)
 }
 

--- a/security/audit_test.go
+++ b/security/audit_test.go
@@ -2,8 +2,11 @@ package security
 
 import (
 	"bytes"
+	"encoding/json"
 	"log/slog"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAuditor(t *testing.T) {
@@ -291,4 +294,39 @@ func Test_hashForLogging_Different(t *testing.T) {
 	if hash1 == hash2 {
 		t.Error("hashForLogging() should return different hashes for different inputs")
 	}
+}
+
+// TestAuditor_LogEvent_EmitsAuditGroup asserts that LogEvent emits at INFO
+// and bundles every attribute under a single "audit" group so consumers can
+// route audit records separately from operational logs.
+func TestAuditor_LogEvent_EmitsAuditGroup(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	auditor := NewAuditor(logger, true)
+
+	auditor.LogEvent(Event{
+		Type:      "test_event",
+		UserID:    "user-123",
+		ClientID:  "client-456",
+		IPAddress: "192.168.1.1",
+		Details:   map[string]any{"key": "value"},
+	})
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+
+	require.Equal(t, "INFO", payload["level"])
+	require.Equal(t, "security_audit", payload["msg"])
+
+	audit, ok := payload["audit"].(map[string]any)
+	require.True(t, ok, "expected audit group in payload, got %v", payload)
+	require.Equal(t, "test_event", audit["event_type"])
+	require.Equal(t, "client-456", audit["client_id"])
+	require.Equal(t, "192.168.1.1", audit["ip_address"])
+	require.NotEmpty(t, audit["user_id_hash"], "user_id must be hashed, not raw")
+	require.NotEqual(t, "user-123", audit["user_id_hash"], "user_id must not be emitted as raw")
+
+	details, ok := audit["details"].(map[string]any)
+	require.True(t, ok, "expected details map under audit group, got %v", audit)
+	require.Equal(t, "value", details["key"])
 }

--- a/security/client_registration_ratelimit.go
+++ b/security/client_registration_ratelimit.go
@@ -123,7 +123,7 @@ func newClientRegistrationRateLimiterWithCleanupInterval(maxPerWindow int, windo
 	// Start background cleanup goroutine
 	go rl.cleanupLoop()
 
-	logger.Info("Client registration rate limiter initialized",
+	logger.Debug("Client registration rate limiter initialized",
 		"max_per_window", maxPerWindow,
 		"window", window,
 		"max_entries", maxEntries)

--- a/server/cimd.go
+++ b/server/cimd.go
@@ -206,7 +206,7 @@ func (s *Server) fetchClientMetadata(ctx context.Context, clientID string) (*Cli
 	allowPrivateIP := s.Config.AllowPrivateIPClientMetadata
 
 	if allowPrivateIP {
-		s.Logger.Info("CIMD fetch with private IP allowance enabled",
+		s.Logger.Debug("CIMD fetch with private IP allowance enabled",
 			"client_id", clientID,
 			"config", "AllowPrivateIPClientMetadata=true")
 	}
@@ -310,7 +310,7 @@ func (s *Server) processMetadataResponse(ctx context.Context, resp *http.Respons
 	})
 	s.recordCIMDFetchMetric(ctx, "success", fetchStart)
 
-	s.Logger.Info("Fetched client metadata from URL",
+	s.Logger.Debug("Fetched client metadata from URL",
 		"client_id", clientID,
 		"client_name", metadata.ClientName,
 		"redirect_uris", len(metadata.RedirectURIs),

--- a/server/cimd_cache.go
+++ b/server/cimd_cache.go
@@ -444,7 +444,7 @@ func (s *Server) fetchClientWithSingleflight(ctx context.Context, clientID strin
 	}
 
 	s.recordCIMDCacheMetric(ctx, "miss")
-	s.Logger.Info("Fetching client metadata from URL", "client_id", clientID)
+	s.Logger.Debug("Fetching client metadata from URL", "client_id", clientID)
 
 	metadata, suggestedTTL, fetchErr := s.fetchClientMetadata(ctx, clientID)
 	if fetchErr != nil {

--- a/server/client.go
+++ b/server/client.go
@@ -148,7 +148,7 @@ func (s *Server) trackClientIPAndLog(client *storage.Client, _ /* clientSecret -
 		s.Auditor.LogClientRegistered(client.ClientID, client.ClientType, clientIP)
 	}
 
-	s.Logger.Info("Registered new OAuth client",
+	s.Logger.Debug("Registered new OAuth client",
 		"client_id", client.ClientID,
 		"client_name", client.ClientName,
 		"client_type", client.ClientType,

--- a/server/config_validation.go
+++ b/server/config_validation.go
@@ -459,7 +459,7 @@ func validateTrustedAudiences(config *Config, logger *slog.Logger) {
 	config.TrustedAudiences = validAudiences
 
 	if len(validAudiences) > 0 {
-		logger.Info("TrustedAudiences configured for SSO token forwarding",
+		logger.Debug("TrustedAudiences configured for SSO token forwarding",
 			"audiences", validAudiences,
 			"count", len(validAudiences))
 	}
@@ -677,7 +677,7 @@ func validateScheme(scheme string, index int, logger *slog.Logger) (string, bool
 // logTrustedSchemesConfig logs configuration summary for trusted schemes
 func logTrustedSchemesConfig(config *Config, logger *slog.Logger) {
 	effectiveStrictMatching := !config.DisableStrictSchemeMatching
-	logger.Info("TrustedPublicRegistrationSchemes configured",
+	logger.Debug("TrustedPublicRegistrationSchemes configured",
 		"schemes", config.TrustedPublicRegistrationSchemes,
 		"strict_matching", effectiveStrictMatching)
 

--- a/server/config_validation_security.go
+++ b/server/config_validation_security.go
@@ -230,16 +230,9 @@ func logCoreSecurityWarnings(config *Config, logger *slog.Logger) {
 	}
 }
 
-// logRedirectURISecurityStatus logs the redirect URI security configuration status.
+// logRedirectURISecurityStatus emits WARN entries for any explicitly
+// disabled redirect-URI security feature.
 func logRedirectURISecurityStatus(config *Config, logger *slog.Logger) {
-	// Log current security status
-	logger.Info("Redirect URI security status",
-		"production_mode", config.ProductionMode,
-		"dns_validation", config.DNSValidation,
-		"dns_validation_strict", config.DNSValidationStrict,
-		"authorization_time_validation", config.ValidateRedirectURIAtAuthorization,
-		"dns_timeout", config.DNSValidationTimeout)
-
 	// Warn about explicitly disabled security features
 	if config.DisableProductionMode {
 		logger.Warn("SECURITY WARNING: ProductionMode is DISABLED",
@@ -264,9 +257,8 @@ func logRedirectURISecurityStatus(config *Config, logger *slog.Logger) {
 			"recommendation", "Only disable if authorization latency is critical")
 	}
 
-	// Info about Allow* escape hatches
 	if config.AllowLocalhostRedirectURIs {
-		logger.Info("Localhost redirect URIs are ALLOWED (RFC 8252 native app support)",
+		logger.Debug("Localhost redirect URIs are ALLOWED (RFC 8252 native app support)",
 			"note", "HTTP allowed on loopback for native apps",
 			"learn_more", "https://datatracker.ietf.org/doc/html/rfc8252#section-7.3")
 	}

--- a/server/flows.go
+++ b/server/flows.go
@@ -213,7 +213,7 @@ func (s *Server) attemptProactiveRefresh(ctx context.Context, accessToken string
 
 	s.fireTokenRefreshHandler(ctx, accessToken, newProviderToken)
 
-	s.Logger.Info("Token proactively refreshed",
+	s.Logger.Debug("Token proactively refreshed",
 		"old_expiry", storedToken.Expiry,
 		"new_expiry", newProviderToken.Expiry,
 		"token_suffix", helpers.TokenSuffix(accessToken, 8))
@@ -375,7 +375,7 @@ func (s *Server) validateStoredToken(ctx context.Context, accessToken string) (*
 
 		s.fireTokenRefreshHandler(ctx, accessToken, newProviderToken)
 
-		s.Logger.Info("Expired provider token refreshed during validation",
+		s.Logger.Debug("Expired provider token refreshed during validation",
 			"old_expiry", storedToken.Expiry,
 			"new_expiry", newProviderToken.Expiry,
 			"token_suffix", helpers.TokenSuffix(accessToken, 8))
@@ -809,7 +809,7 @@ func (s *Server) rotateRefreshToken(ctx context.Context, oldRefreshToken, userID
 	_ = s.tokenStore.DeleteToken(ctx, oldRefreshToken)
 	s.unregisterTokenPairByRefresh(oldRefreshToken)
 
-	s.Logger.Info("Refresh token rotated (OAuth 2.1)",
+	s.Logger.Debug("Refresh token rotated (OAuth 2.1)",
 		"user_id", userID, "generation", generation, "family_tracking", supportsFamilies)
 
 	// Save with family tracking if supported
@@ -1680,7 +1680,7 @@ func (s *Server) RevokeToken(ctx context.Context, token, clientID, clientIP stri
 		s.Auditor.LogTokenRevoked("", clientID, clientIP, "access_or_refresh")
 	}
 
-	s.Logger.Info("Token revoked", "client_id", clientID, "ip", clientIP)
+	s.Logger.Debug("Token revoked", "client_id", clientID, "ip", clientIP)
 	return nil
 }
 
@@ -1708,7 +1708,7 @@ func (s *Server) revokeTokenFamilyIfNeeded(ctx context.Context, family *storage.
 		s.Logger.Warn("Failed to revoke refresh token family", "family_id", family.FamilyID, "error", err)
 		return
 	}
-	s.Logger.Info("Revoked refresh token family on explicit revocation",
+	s.Logger.Debug("Revoked refresh token family on explicit revocation",
 		"family_id", family.FamilyID, "client_id", clientID, "ip", clientIP)
 
 	if s.sessionRevocationHandler != nil {
@@ -1861,7 +1861,7 @@ func (s *Server) RevokeAllTokensForUserClient(ctx context.Context, userID, clien
 		failureRate = float64(failedAtProvider) / float64(totalTokensToRevoke)
 	}
 
-	s.Logger.Info("Provider revocation complete",
+	s.Logger.Debug("Provider revocation complete",
 		"user_id", userID, "client_id", clientID, "revoked_at_provider", revokedAtProvider,
 		"failed_at_provider", failedAtProvider, "total_tokens", totalTokensToRevoke,
 		"failure_rate", fmt.Sprintf("%.2f%%", failureRate*100))
@@ -1929,7 +1929,7 @@ func (s *Server) revokeTokenWithRetry(ctx context.Context, token, tokenType, use
 		if err == nil {
 			// Success - log if this wasn't the first attempt
 			if attempt > 0 {
-				s.Logger.Info("Provider token revocation succeeded after retry",
+				s.Logger.Debug("Provider token revocation succeeded after retry",
 					"token_type", tokenType,
 					"attempt", attempt+1,
 					"max_retries", maxRetries,

--- a/server/flows_forwarded.go
+++ b/server/flows_forwarded.go
@@ -242,7 +242,7 @@ func (s *Server) logForwardedSessionIDKeyFingerprint() {
 		return
 	}
 	sum := sha256.Sum256(s.Config.SessionIDHMACKey)
-	s.Logger.Info("Forwarded-ID-token session correlation: SessionIDHMACKey is configured",
+	s.Logger.Debug("Forwarded-ID-token session correlation: SessionIDHMACKey is configured",
 		"key_fingerprint", hex.EncodeToString(sum[:8]),
 		"key_bytes", len(s.Config.SessionIDHMACKey),
 		"purpose", "All MCP servers in a correlation set must report the same key_fingerprint; a mismatch silently breaks cross-hop session-ID correlation")

--- a/server/flows_jwt.go
+++ b/server/flows_jwt.go
@@ -384,7 +384,7 @@ func (s *Server) revokeSelfIssuedJWT(ctx context.Context, tokenString, clientID,
 			},
 		})
 	}
-	s.Logger.Info("Self-issued JWT access token revoked",
+	s.Logger.Debug("Self-issued JWT access token revoked",
 		"jti", jti,
 		"client_id", clientID,
 		"ip", clientIP,

--- a/server/flows_sso.go
+++ b/server/flows_sso.go
@@ -161,7 +161,7 @@ func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.
 
 // logForwardedIDTokenAccepted logs a security event when a forwarded ID token is accepted.
 func (s *Server) logForwardedIDTokenAccepted(tokenString, matchedAudience, validatedIssuer string, userInfo *providers.UserInfo) {
-	s.Logger.Info("Forwarded ID token accepted via TrustedAudiences (SSO)",
+	s.Logger.Debug("Forwarded ID token accepted via TrustedAudiences (SSO)",
 		"user_id", userInfo.ID,
 		"email", userInfo.Email,
 		"matched_audience", matchedAudience,

--- a/server/flows_trusted_audiences_test.go
+++ b/server/flows_trusted_audiences_test.go
@@ -180,7 +180,7 @@ func TestValidateTokenAudience_WithTrustedAudiences(t *testing.T) {
 			t.Cleanup(func() { store.Stop() })
 
 			var logBuffer bytes.Buffer
-			logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+			logger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
 			auditor := security.NewAuditor(logger, true)
 
 			config := &Config{
@@ -300,7 +300,7 @@ func TestValidateTrustedAudiences(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var logBuffer bytes.Buffer
-			logger := slog.New(slog.NewTextHandler(&logBuffer, nil))
+			logger := slog.New(slog.NewTextHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 			config := &Config{
 				TrustedAudiences: tt.inputAudiences,

--- a/server/logvalue.go
+++ b/server/logvalue.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+)
+
+// LogValue implements [slog.LogValuer] so callers can emit a structured
+// snapshot of the server's security posture:
+//
+//	logger.Info("oauth server initialized", "server", srv)
+//
+// Fields are limited to state that is either derived (encryption-enabled,
+// instrumentation-wired) or mutated by [applySecureDefaults] (production
+// mode, redirect-URI validation flags) — i.e. state the caller's
+// pre-build Config does not faithfully reflect.
+func (s *Server) LogValue() slog.Value {
+	cfg := s.Config
+	attrs := []slog.Attr{
+		slog.String("issuer", cfg.Issuer),
+		slog.Bool("production_mode", cfg.ProductionMode),
+		slog.String("access_token_format", string(cfg.AccessTokenFormat)),
+		slog.Bool("encryption_at_rest", s.Encryptor != nil && s.Encryptor.IsEnabled()),
+		slog.Bool("instrumentation_on", s.Instrumentation != nil),
+		slog.Group("redirect_uri_policy",
+			slog.Bool("dns_validation", cfg.DNSValidation),
+			slog.Bool("dns_validation_strict", cfg.DNSValidationStrict),
+			slog.Bool("authorization_time_validation", cfg.ValidateRedirectURIAtAuthorization),
+			slog.Duration("dns_timeout", cfg.DNSValidationTimeout),
+			slog.Bool("allow_localhost", cfg.AllowLocalhostRedirectURIs),
+			slog.Bool("allow_private_ip", cfg.AllowPrivateIPRedirectURIs),
+			slog.Bool("allow_link_local", cfg.AllowLinkLocalRedirectURIs),
+		),
+	}
+	if len(cfg.SessionIDHMACKey) > 0 {
+		sum := sha256.Sum256(cfg.SessionIDHMACKey)
+		attrs = append(attrs, slog.String("session_id_hmac_key_fingerprint", hex.EncodeToString(sum[:8])))
+	}
+	return slog.GroupValue(attrs...)
+}

--- a/server/logvalue_test.go
+++ b/server/logvalue_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// captureHandler is a slog.Handler that retains every record it sees so
+// tests can assert on level distribution and attributes.
+type captureHandler struct {
+	mu      *bytes.Buffer
+	records []slog.Record
+}
+
+func newCaptureHandler() *captureHandler {
+	return &captureHandler{mu: &bytes.Buffer{}}
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *captureHandler) infoLines() []string {
+	var lines []string
+	for _, r := range h.records {
+		if r.Level == slog.LevelInfo {
+			lines = append(lines, r.Message)
+		}
+	}
+	return lines
+}
+
+func TestServer_New_EmitsNoInfo(t *testing.T) {
+	cap := newCaptureHandler()
+	logger := slog.New(cap)
+
+	_, err := New(
+		mock.NewProvider(),
+		memory.New(), memory.New(), memory.New(),
+		&Config{Issuer: "https://oauth.example.com", RegistrationAccessToken: "tok"},
+		logger,
+	)
+	require.NoError(t, err)
+
+	if got := cap.infoLines(); len(got) != 0 {
+		t.Fatalf("server.New emitted %d INFO record(s); want 0:\n%s",
+			len(got), strings.Join(got, "\n"))
+	}
+}
+
+func TestServer_LogValue_ExposesEffectiveConfig(t *testing.T) {
+	setup := newTestServerSetup(false)
+	srv, err := setup.createServer(&Config{
+		Issuer:                     "https://oauth.example.com",
+		RegistrationAccessToken:    "tok",
+		AllowLocalhostRedirectURIs: true,
+	})
+	require.NoError(t, err)
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger.Info("test", "server", srv)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+
+	server, ok := payload["server"].(map[string]any)
+	require.True(t, ok, "expected server group in log payload, got %v", payload)
+	require.Equal(t, "https://oauth.example.com", server["issuer"])
+	require.Equal(t, true, server["production_mode"], "applySecureDefaults should flip production_mode on")
+	require.Equal(t, false, server["encryption_at_rest"])
+	require.Equal(t, false, server["instrumentation_on"])
+
+	policy, ok := server["redirect_uri_policy"].(map[string]any)
+	require.True(t, ok, "expected redirect_uri_policy group, got %v", server)
+	require.Equal(t, true, policy["dns_validation"])
+	require.Equal(t, true, policy["dns_validation_strict"])
+	require.Equal(t, true, policy["authorization_time_validation"])
+	require.Equal(t, true, policy["allow_localhost"])
+	require.Equal(t, false, policy["allow_private_ip"])
+	require.Equal(t, false, policy["allow_link_local"])
+}

--- a/server/logvalue_test.go
+++ b/server/logvalue_test.go
@@ -17,12 +17,7 @@ import (
 // captureHandler is a slog.Handler that retains every record it sees so
 // tests can assert on level distribution and attributes.
 type captureHandler struct {
-	mu      *bytes.Buffer
 	records []slog.Record
-}
-
-func newCaptureHandler() *captureHandler {
-	return &captureHandler{mu: &bytes.Buffer{}}
 }
 
 func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
@@ -44,8 +39,8 @@ func (h *captureHandler) infoLines() []string {
 }
 
 func TestServer_New_EmitsNoInfo(t *testing.T) {
-	cap := newCaptureHandler()
-	logger := slog.New(cap)
+	h := &captureHandler{}
+	logger := slog.New(h)
 
 	_, err := New(
 		mock.NewProvider(),
@@ -55,7 +50,7 @@ func TestServer_New_EmitsNoInfo(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	if got := cap.infoLines(); len(got) != 0 {
+	if got := h.infoLines(); len(got) != 0 {
 		t.Fatalf("server.New emitted %d INFO record(s); want 0:\n%s",
 			len(got), strings.Join(got, "\n"))
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -194,7 +194,7 @@ func (s *Server) initializeAccessTokenIssuer() error {
 			return fmt.Errorf("initialize JWT access token issuer: %w", err)
 		}
 		s.accessTokenIssuer = issuer
-		s.Logger.Info("Access token format: JWT (RFC 9068)",
+		s.Logger.Debug("Access token format: JWT (RFC 9068)",
 			"alg", s.Config.AccessTokenSigningAlgorithm,
 			"kid", s.Config.AccessTokenSigningKeyID,
 			"jwks_uri", s.Config.JWKSEndpoint())
@@ -267,7 +267,7 @@ func (s *Server) initializeMetadataSupport() {
 
 	// SECURITY: Initialize rate limiter for metadata fetches (10 req/min per domain)
 	s.metadataFetchRateLimiter = security.NewRateLimiter(10, 20, s.Logger)
-	s.Logger.Info("Initialized metadata fetch rate limiter",
+	s.Logger.Debug("Initialized metadata fetch rate limiter",
 		"rate", "10 requests/min per domain",
 		"burst", 20,
 		"purpose", "DoS protection")
@@ -342,7 +342,7 @@ func (s *Server) logMandatoryAudienceScopes(logger *slog.Logger, providerDefault
 	}
 
 	if len(audienceScopes) > 0 {
-		logger.Info("Mandatory cross-client audience scopes configured - these will be merged into ALL authorization requests",
+		logger.Debug("Mandatory cross-client audience scopes configured - these will be merged into ALL authorization requests",
 			"audience_scopes", audienceScopes,
 			"provider", s.provider.Name(),
 			"count", len(audienceScopes))
@@ -494,7 +494,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	var shutdownErr error
 
 	s.shutdownOnce.Do(func() {
-		s.Logger.Info("Starting graceful shutdown...")
+		s.Logger.Debug("Starting graceful shutdown...")
 		done := make(chan struct{})
 
 		go func() {
@@ -520,7 +520,7 @@ func (s *Server) performShutdown(ctx context.Context) {
 	s.stopMetadataCacheCleanup()
 	s.shutdownInstrumentation(ctx)
 	s.stopStorage()
-	s.Logger.Info("Graceful shutdown completed")
+	s.Logger.Debug("Graceful shutdown completed")
 }
 
 // stopRateLimiters stops all rate limiters.

--- a/storage/memory/logvalue.go
+++ b/storage/memory/logvalue.go
@@ -1,0 +1,21 @@
+package memory
+
+import (
+	"log/slog"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+)
+
+// LogValue implements [slog.LogValuer] so callers can emit a one-shot
+// structured snapshot of the store's posture:
+//
+//	logger.Info("storage initialized", "store", store)
+func (s *Store) LogValue() slog.Value {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return slog.GroupValue(
+		slog.String("backend", storage.BackendMemory),
+		slog.Bool("encryption_at_rest", s.encryptor != nil && s.encryptor.IsEnabled()),
+		slog.Bool("instrumentation_on", s.instrumentation != nil),
+	)
+}

--- a/storage/memory/logvalue_test.go
+++ b/storage/memory/logvalue_test.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/storage"
+)
+
+type captureHandler struct {
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func (h *captureHandler) infoLines() []string {
+	var lines []string
+	for _, r := range h.records {
+		if r.Level == slog.LevelInfo {
+			lines = append(lines, r.Message)
+		}
+	}
+	return lines
+}
+
+func TestStore_Construction_EmitsNoInfo(t *testing.T) {
+	cap := &captureHandler{}
+	logger := slog.New(cap)
+
+	store := New()
+	store.SetLogger(logger)
+	store.SetRevokedFamilyRetentionDays(30)
+
+	key, err := security.GenerateKey()
+	require.NoError(t, err)
+	enc, err := security.NewEncryptor(key)
+	require.NoError(t, err)
+	store.SetEncryptor(enc)
+	store.SetInstrumentation(nil) // nil-safe path
+
+	if got := cap.infoLines(); len(got) != 0 {
+		t.Fatalf("store construction emitted %d INFO record(s); want 0:\n%s",
+			len(got), strings.Join(got, "\n"))
+	}
+}
+
+func TestStore_LogValue_ReflectsPosture(t *testing.T) {
+	store := New()
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger.Info("snapshot", "store", store)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+
+	got, ok := payload["store"].(map[string]any)
+	require.True(t, ok, "expected store group, got %v", payload)
+	require.Equal(t, storage.BackendMemory, got["backend"])
+	require.Equal(t, false, got["encryption_at_rest"])
+	require.Equal(t, false, got["instrumentation_on"])
+
+	// Enable encryption and verify the snapshot updates.
+	key, err := security.GenerateKey()
+	require.NoError(t, err)
+	enc, err := security.NewEncryptor(key)
+	require.NoError(t, err)
+	store.SetEncryptor(enc)
+
+	buf.Reset()
+	logger.Info("snapshot", "store", store)
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+	got = payload["store"].(map[string]any)
+	require.Equal(t, true, got["encryption_at_rest"])
+}

--- a/storage/memory/logvalue_test.go
+++ b/storage/memory/logvalue_test.go
@@ -37,8 +37,8 @@ func (h *captureHandler) infoLines() []string {
 }
 
 func TestStore_Construction_EmitsNoInfo(t *testing.T) {
-	cap := &captureHandler{}
-	logger := slog.New(cap)
+	h := &captureHandler{}
+	logger := slog.New(h)
 
 	store := New()
 	store.SetLogger(logger)
@@ -51,7 +51,7 @@ func TestStore_Construction_EmitsNoInfo(t *testing.T) {
 	store.SetEncryptor(enc)
 	store.SetInstrumentation(nil) // nil-safe path
 
-	if got := cap.infoLines(); len(got) != 0 {
+	if got := h.infoLines(); len(got) != 0 {
 		t.Fatalf("store construction emitted %d INFO record(s); want 0:\n%s",
 			len(got), strings.Join(got, "\n"))
 	}

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -132,10 +132,11 @@ func New() *Store {
 // Default: 90 days (if not set)
 func (s *Store) SetRevokedFamilyRetentionDays(days int64) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.revokedFamilyRetentionDays = days
-	s.logger.Info("Set revoked family retention period",
-		"retention_days", days)
+	s.mu.Unlock()
+	s.logger.Debug("revoked family retention period set",
+		"retention_days", days,
+		"store", s)
 }
 
 // NewWithInterval creates a new in-memory store with custom cleanup interval.
@@ -178,10 +179,10 @@ func (s *Store) SetLogger(logger *slog.Logger) {
 // SetEncryptor sets the token encryptor for encryption at rest
 func (s *Store) SetEncryptor(enc *security.Encryptor) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	s.encryptor = enc
+	s.mu.Unlock()
 	if enc != nil && enc.IsEnabled() {
-		s.logger.Info("Token encryption at rest enabled for storage")
+		s.logger.Debug("token encryption at rest enabled", "store", s)
 	}
 }
 
@@ -216,6 +217,7 @@ func (s *Store) SetInstrumentation(inst *instrumentation.Instrumentation) {
 		if err != nil {
 			s.logger.Warn("Failed to register storage size callbacks", "error", err)
 		}
+		s.logger.Debug("storage instrumentation enabled", "store", s)
 	}
 }
 

--- a/storage/valkey/logvalue.go
+++ b/storage/valkey/logvalue.go
@@ -6,16 +6,22 @@ import (
 	"github.com/giantswarm/mcp-oauth/storage"
 )
 
-// LogValue implements [slog.LogValuer] so callers can emit a one-shot
-// structured snapshot of the store's posture:
+// LogValue implements [slog.LogValuer] so callers can emit a structured
+// snapshot of the store's posture:
 //
 //	logger.Info("storage initialized", "store", store)
 func (s *Store) LogValue() slog.Value {
 	s.encryptorMu.RLock()
 	enc := s.encryptor
 	s.encryptorMu.RUnlock()
+
+	s.instMu.RLock()
+	inst := s.inst
+	s.instMu.RUnlock()
+
 	return slog.GroupValue(
 		slog.String("backend", storage.BackendValkey),
 		slog.Bool("encryption_at_rest", enc != nil && enc.IsEnabled()),
+		slog.Bool("instrumentation_on", inst != nil),
 	)
 }

--- a/storage/valkey/logvalue.go
+++ b/storage/valkey/logvalue.go
@@ -1,0 +1,21 @@
+package valkey
+
+import (
+	"log/slog"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+)
+
+// LogValue implements [slog.LogValuer] so callers can emit a one-shot
+// structured snapshot of the store's posture:
+//
+//	logger.Info("storage initialized", "store", store)
+func (s *Store) LogValue() slog.Value {
+	s.encryptorMu.RLock()
+	enc := s.encryptor
+	s.encryptorMu.RUnlock()
+	return slog.GroupValue(
+		slog.String("backend", storage.BackendValkey),
+		slog.Bool("encryption_at_rest", enc != nil && enc.IsEnabled()),
+	)
+}

--- a/storage/valkey/logvalue_test.go
+++ b/storage/valkey/logvalue_test.go
@@ -1,0 +1,55 @@
+package valkey
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/instrumentation"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/storage"
+)
+
+// TestStore_LogValue_ReflectsPosture exercises Store.LogValue without
+// opening a live Valkey connection — LogValue reads only struct fields,
+// so a directly-constructed Store{} is sufficient.
+func TestStore_LogValue_ReflectsPosture(t *testing.T) {
+	store := &Store{}
+
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logger.Info("snapshot", "store", store)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+
+	got, ok := payload["store"].(map[string]any)
+	require.True(t, ok, "expected store group, got %v", payload)
+	require.Equal(t, storage.BackendValkey, got["backend"])
+	require.Equal(t, false, got["encryption_at_rest"])
+	require.Equal(t, false, got["instrumentation_on"])
+
+	key, err := security.GenerateKey()
+	require.NoError(t, err)
+	enc, err := security.NewEncryptor(key)
+	require.NoError(t, err)
+	store.encryptor = enc
+
+	buf.Reset()
+	logger.Info("snapshot", "store", store)
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+	got = payload["store"].(map[string]any)
+	require.Equal(t, true, got["encryption_at_rest"])
+	require.Equal(t, false, got["instrumentation_on"])
+
+	store.inst = &instrumentation.Instrumentation{}
+
+	buf.Reset()
+	logger.Info("snapshot", "store", store)
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
+	got = payload["store"].(map[string]any)
+	require.Equal(t, true, got["instrumentation_on"])
+}

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -183,24 +183,21 @@ func New(cfg Config) (*Store, error) {
 		return nil, fmt.Errorf("failed to connect to valkey: %w", err)
 	}
 
-	logger.Info("Connected to Valkey storage",
-		"address", cfg.Address,
-		"db", cfg.DB,
-		"prefix", prefix)
-
-	return &Store{
+	s := &Store{
 		client:                     client,
 		prefix:                     prefix,
 		logger:                     logger,
 		revokedFamilyRetentionDays: retentionDays,
 		refreshTokenTTL:            refreshTokenTTL,
-	}, nil
+	}
+	logger.Debug("storage connected", "store", s)
+	return s, nil
 }
 
 // Close closes the Valkey client connection.
 func (s *Store) Close() {
 	s.client.Close()
-	s.logger.Info("Valkey storage connection closed")
+	s.logger.Debug("storage connection closed", "store", s)
 }
 
 // SetLogger sets a custom logger for the store.
@@ -213,10 +210,10 @@ func (s *Store) SetLogger(logger *slog.Logger) {
 // before storing in Valkey and decrypted when retrieved.
 func (s *Store) SetEncryptor(enc *security.Encryptor) {
 	s.encryptorMu.Lock()
-	defer s.encryptorMu.Unlock()
 	s.encryptor = enc
+	s.encryptorMu.Unlock()
 	if enc != nil && enc.IsEnabled() {
-		s.logger.Info("Token encryption at rest enabled for Valkey storage")
+		s.logger.Debug("token encryption at rest enabled", "store", s)
 	}
 }
 
@@ -254,8 +251,7 @@ func (s *Store) SetInstrumentation(inst *instrumentation.Instrumentation) {
 	if err != nil {
 		s.logger.Warn("Failed to register storage size callbacks", "error", err)
 	}
-
-	s.logger.Info("Valkey storage instrumentation enabled")
+	s.logger.Debug("storage instrumentation enabled", "store", s)
 }
 
 // countKeysByPattern counts keys matching a glob pattern using SCAN.


### PR DESCRIPTION
## Summary

Stops the library emitting ~20 INFO log lines during construction. Downstream consumers (notably `muster`, k8s-deployed) were drowning in startup chatter that duplicated config they themselves had written.

### What changed

- **INFO → DEBUG** for every "X enabled / Using Y / Initialized Z / Registered W" startup announcement, and for per-request operational Infos (`Token proactively refreshed`, `Refresh token rotated`, `Token revoked`, `Token exchange successful`, ...). Affected packages: `server`, `storage/memory`, `storage/valkey`, `security/client_registration_ratelimit`, `providers/oidc`, plus the root `handler.go`.
- **`Server.LogValue()`** (`slog.LogValuer`) exposes a structured snapshot of the server's effective security posture — fields the caller's pre-build `Config` doesn't faithfully reflect because `applySecureDefaults` mutates them (`production_mode`, `dns_validation`*, `authorization_time_validation`, `access_token_format`, encryption-at-rest, instrumentation-on, `redirect_uri_policy` group, `session_id_hmac_key_fingerprint`). Callers can attach it to any log line:

  ```go
  logger.Info("oauth ready", "server", srv, "store", store)
  ```

- **`memory.Store.LogValue()`** and **`valkey.Store.LogValue()`** expose `{backend, encryption_at_rest, instrumentation_on}`.
- **`Auditor.LogEvent`** now emits via `slog.LogAttrs` and bundles every audit field under a single `slog.Group("audit", ...)`. Level stays `INFO`, message stays `"security_audit"`. Consumers can route audit records separately by inspecting the group in their `slog.Handler`.
- Removed the standalone "Redirect URI security status" INFO line in `logRedirectURISecurityStatus`; every field it carried is reachable via `Server.LogValue().redirect_uri_policy.*`. WARN/ERROR security warnings on disabled features are unchanged.

### Design rules applied

1. *"I am configured the way you configured me"* is not a log line — the caller wrote the config struct and can read it back.
2. Where startup state is genuinely useful (encryption status, production-mode toggle, redirect-URI policy summary, HMAC fingerprint), expose a structured accessor (`LogValue`) rather than emit a log line.
3. Recursive announcements (`SetInstrumentation` announcing instrumentation, `SetEncryptor` announcing encryption) used to fire 3× because Server holds three store interface refs into the same `*Store` instance. Now they fire at DEBUG and carry `"store", s` so `LogValue()` provides the backend + posture.
4. Audit events stay at INFO and now carry the `audit` group for split-routing.

### Compatibility

- Consumers compile unchanged.
- Only log volume changes. Crank to `slog.LevelDebug` to recover the prior verbosity.
- WARN/ERROR security warnings are unchanged.
- Pre-existing tests asserting on log content updated to use `slog.LevelDebug`-enabled handlers where they assert on lines that moved.

### Tests

- `TestServer_New_EmitsNoInfo` — record-capturing handler asserts `server.New()` emits zero INFO records.
- `TestServer_LogValue_ExposesEffectiveConfig` — round-trips through `slog.JSONHandler`, asserts `production_mode` is `true` (defaults flipped on), `redirect_uri_policy` group present.
- `TestStore_Construction_EmitsNoInfo` — `memory.New()` + `SetEncryptor` + `SetInstrumentation` emits zero INFO.
- `TestStore_LogValue_ReflectsPosture` — backend = "memory", encryption_at_rest flips on after `SetEncryptor`.
- `TestAuditor_LogEvent_EmitsAuditGroup` — JSON-round-trip asserts level = INFO, attributes bundled under `audit` group, `user_id_hash` is hashed (not raw).