### PR TITLE
docs: replace phantom API references across doc.go, docs/, SECURITY_ARCHITECTURE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **docs: replace phantom API references across `doc.go`, `docs/security.md`, `docs/getting-started.md`, `docs/silent-authentication.md`, `server/doc.go`, and `SECURITY_ARCHITECTURE.md`**. Snippets now show `oauth.With*` options on `NewServer` instead of removed `Set*` setters, the real `providers.Provider` interface, the current `google.NewProvider(&google.Config{...})` and `memory.New()` constructors, a `crypto/rand` + `sha256` PKCE helper (no fictional `oauth.GeneratePKCE`), `go-jose/go-jose/v4` in the JWT threat-model row, and MCP spec date 2025-11-25 in the root package overview. `docs/README.md` index now links `silent-authentication.md`.
 - **`security.Auditor` methods take `context.Context`**
   - `LogEvent` and the 11 typed helpers (`LogTokenIssued`, `LogTokenRefreshed`, `LogTokenRevoked`, `LogAuthFailure`, `LogRateLimitExceeded`, `LogClientRegistrationRateLimitExceeded`, `LogClientRegistered`, `LogInvalidPKCE`, `LogTokenReuse`, `LogSuspiciousActivity`, `LogInvalidRedirect`) now take `ctx context.Context` as the first argument. The ctx is forwarded to the underlying `slog.Handler.Handle`, so otelslog-style handlers attach trace/span IDs to audit records.
   - **Breaking**: prepend `ctx` at every call site (`r.Context()` for HTTP-driven flows, `context.Background()` for background emissions).

--- a/SECURITY_ARCHITECTURE.md
+++ b/SECURITY_ARCHITECTURE.md
@@ -812,7 +812,7 @@ The trade-off is explicit and operator-chosen. JWT mode is appropriate when the 
 | `typ` confusion with id_token | `typ: "at+jwt"` set on issuance, verified on validation per RFC 9068 §2.1 | `jwtIssuer.Issue`, `checkJWTHeaderAndIssuer` |
 | Token logging | Never log full JWTs; reuse `helpers.TokenSuffix(token, 8)` for trace fields | All log statements in `flows_jwt.go` |
 | JWKS exposed when not used | 404 in opaque mode; `jwks_uri` omitted from discovery | `ServeJWKS`, `addOptionalMetadata` |
-| Timing attacks on signature comparison | Use library parser (`golang-jwt/jwt/v5`); no bespoke crypto | (delegated) |
+| Timing attacks on signature comparison | Use library parser (`go-jose/go-jose/v4`); no bespoke crypto | (delegated) |
 | In-flight tokens after refresh-family revocation | `family_id` claim; family revocation invalidates all in-flight access tokens in the family | `checkJWTFamily`, `RefreshTokenFamilyByIDStore` |
 
 #### Key management

--- a/doc.go
+++ b/doc.go
@@ -6,9 +6,9 @@
 // at the type level; the upstream IdP is injected via the
 // [providers.Provider] interface.
 //
-// The package aligns with the Model Context Protocol authorization
-// specification dated 2025-11-25. The previous 2025-06-18 revision is also
-// supported (backward compatible).
+// The package implements the Model Context Protocol authorization
+// specification dated 2025-11-25 and the 2025-06-18 revision; both are
+// supported on the same endpoints.
 //
 // Architecture:
 //   - MCP Server: OAuth 2.1 Resource Server (advertises this library's issuer)

--- a/doc.go
+++ b/doc.go
@@ -1,137 +1,83 @@
-// Package oauth provides OAuth 2.1 authentication for the MCP server.
+// Package oauth provides an OAuth 2.1 authorization server for MCP applications.
 //
-// This package implements OAuth 2.1 authentication according to the Model Context Protocol
-// (MCP) specification dated 2025-06-18. The MCP server acts as an OAuth 2.1 Resource Server,
-// using Google as the Authorization Server for secure authentication.
+// This package implements an OAuth 2.1 authorization server that fronts an
+// upstream identity provider (Google, GitHub, Dex, generic OIDC, ...) and
+// issues access and refresh tokens to MCP clients. It is provider-agnostic
+// at the type level; the upstream IdP is injected via the
+// [providers.Provider] interface.
+//
+// The package aligns with the Model Context Protocol authorization
+// specification dated 2025-11-25. The previous 2025-06-18 revision is also
+// supported (backward compatible).
 //
 // Architecture:
-//   - MCP Server: OAuth 2.1 Resource Server (validates Google tokens)
-//   - Google: OAuth 2.1 Authorization Server (issues tokens, handles user auth)
-//   - MCP Client: OAuth 2.1 Client (handles OAuth flow, includes tokens in requests)
+//   - MCP Server: OAuth 2.1 Resource Server (advertises this library's issuer)
+//   - This library: OAuth 2.1 Authorization Server (issues bearers, validates them)
+//   - Upstream IdP: handles end-user authentication via the chosen [providers.Provider]
+//   - MCP Client: OAuth 2.1 Client (runs the auth-code-with-PKCE flow)
 //
-// Key Features:
-//   - Protected Resource Metadata (RFC 9728) - advertises Google as authorization server
-//   - Bearer token validation via Google's userinfo endpoint
-//   - Automatic token refresh with rotation (OAuth 2.1 security best practice)
-//   - Rate limiting per IP address and per user with token bucket algorithm
-//   - Secure token storage with optional AES-256-GCM encryption at rest
-//   - Token expiration handling with automatic cleanup
-//   - Token revocation endpoint (RFC 7009)
-//   - Comprehensive audit logging for security events
-//   - Client type enforcement (public vs confidential)
-//   - PKCE S256 enforcement (plain method disabled for security)
-//   - Integration with Google APIs (Gmail, Drive, Calendar, etc.)
-//
-// Security Features (Production-Ready):
-//
-// 1. Token Encryption at Rest (AES-256-GCM):
-//   - Tokens can be encrypted in memory using AES-256-GCM
-//   - Authenticated encryption prevents tampering
-//   - Configure via Security.EncryptionKey (32 bytes)
-//   - Use GenerateEncryptionKey() or load from secure storage (KMS, Vault)
-//
-// 2. Refresh Token Rotation (OAuth 2.1):
-//   - New refresh token issued on each use
-//   - Old refresh token invalidated immediately
-//   - Detects stolen tokens via reuse detection
-//   - Enabled by default (disable via Security.DisableRefreshTokenRotation)
-//
-// 3. Comprehensive Audit Logging:
-//   - All authentication events logged with structured logging
-//   - Security events: failed auth, rate limits, invalid tokens, token reuse
-//   - All sensitive data (tokens, emails) hashed before logging (SHA-256)
-//   - Enabled by default (disable via Security.EnableAuditLogging=false)
-//
-// 4. Client Type Validation:
-//   - Public clients (mobile, SPA) must use "none" auth method
-//   - Confidential clients must use client_secret_basic or client_secret_post
-//   - Prevents security violations (confidential client without secret)
-//
-// 5. PKCE Security:
-//   - Only S256 method supported (plain method disabled per OAuth 2.1)
-//   - 43-128 character code_verifier enforced
-//   - Prevents authorization code interception attacks
-//
-// 6. Token Revocation (RFC 7009):
-//   - Clients can revoke access and refresh tokens
-//   - Client authentication required
-//   - All revocations logged for audit trail
-//
-// 7. Cryptographically Secure Token Generation:
-//   - All tokens generated using crypto/rand (not math/rand)
-//   - 48-byte access and refresh tokens (384 bits of entropy)
-//   - 32-byte client IDs and secrets
-//
-// Security Considerations:
-//   - Token Storage: Tokens can be encrypted at rest with AES-256-GCM. Enable via
-//     Security.EncryptionKey for production deployments.
-//   - Logging: All sensitive data (tokens, emails, PII) is hashed before logging using
-//     SHA256 to prevent exposure in log files. Only use structured logging.
-//   - Clock Skew: A 5-second grace period is applied to token expiration checks to handle
-//     time synchronization issues between systems.
-//   - Refresh Token Protection: Tokens with valid refresh tokens are preserved even if
-//     the access token expires, allowing automatic renewal.
-//   - Rate Limiting: Per-IP and per-user rate limiting prevents brute force attacks and
-//     DoS attempts. Configure based on your threat model.
+// Key features:
+//   - Authorization Code flow with mandatory PKCE (S256 only by default)
+//   - Refresh token rotation with reuse detection
+//   - Dynamic client registration (RFC 7591) with rate limiting
+//   - Authorization Server Metadata (RFC 8414) and Protected Resource Metadata (RFC 9728)
+//   - Token revocation (RFC 7009) and introspection (RFC 7662, opt-in)
+//   - Optional self-issued JWT access tokens (RFC 9068) with published JWKS
+//   - Optional token-at-rest encryption (AES-256-GCM) via [WithEncryptor]
+//   - SSO token forwarding via Config.TrustedAudiences (validates upstream
+//     ID tokens directly when an aggregator forwards them as Bearer credentials)
 //
 // Compliance:
-//   - OAuth 2.1 Draft: Implements key security improvements
-//   - RFC 6749: OAuth 2.0 Authorization Framework
-//   - RFC 6750: Bearer Token Usage
-//   - RFC 7009: Token Revocation
-//   - RFC 7591: Dynamic Client Registration
-//   - RFC 7636: PKCE (S256 only)
-//   - RFC 8414: Authorization Server Metadata
-//   - RFC 9728: Protected Resource Metadata
-//
-// The package is designed to be used by the MCP server's HTTP and SSE transports
-// to add OAuth protection to their endpoints.
+//   - OAuth 2.1 Draft
+//   - RFC 6749, RFC 6750, RFC 7009, RFC 7591, RFC 7636 (S256), RFC 7662 (opt-in),
+//     RFC 8414, RFC 9068 (JWT mode), RFC 9728
 //
 // Example usage:
 //
-//	// Generate encryption key for production (do this once, store securely)
-//	encKey, _ := oauth.GenerateEncryptionKey()
-//	// Or load from environment: oauth.EncryptionKeyFromBase64(os.Getenv("OAUTH_ENCRYPTION_KEY"))
+//	import (
+//	    oauth "github.com/giantswarm/mcp-oauth"
+//	    "github.com/giantswarm/mcp-oauth/providers/google"
+//	    "github.com/giantswarm/mcp-oauth/storage/memory"
+//	)
 //
-//	// Create OAuth handler with full security features
-//	handler, err := oauth.NewHandler(&oauth.Config{
-//		Resource: "https://mcp.example.com",
-//		SupportedScopes: []string{
-//			"https://www.googleapis.com/auth/gmail.readonly",
-//			// ... other Google scopes
-//		},
-//		GoogleAuth: oauth.GoogleAuthConfig{
-//			ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
-//			ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
-//		},
-//		RateLimit: oauth.RateLimitConfig{
-//			Rate:     10,
-//			Burst:    20,
-//			UserRate: 100,
-//			UserBurst: 200,
-//		},
-//		Security: oauth.SecurityConfig{
-//			EncryptionKey: encKey,                      // Enable encryption
-//			EnableAuditLogging: true,                   // Enable audit logs
-//			DisableRefreshTokenRotation: false,         // Enable rotation
-//			AllowPublicClientRegistration: false,       // Require auth
-//			RegistrationAccessToken: "secure-token",    // Registration token
-//			RefreshTokenTTL: 90 * 24 * time.Hour,      // 90 days
-//		},
+//	provider, err := google.NewProvider(&google.Config{
+//	    ClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
+//	    ClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+//	    RedirectURL:  "https://your-domain.com/oauth/callback",
+//	    Scopes:       []string{"openid", "email", "profile"},
 //	})
 //	if err != nil {
-//		log.Fatal(err)
+//	    log.Fatal(err)
 //	}
 //
-//	// Protect MCP endpoints
-//	http.Handle("/mcp", handler.ValidateGoogleToken(mcpHandler))
+//	store := memory.New()
+//	defer store.Stop()
 //
-//	// Serve metadata endpoints
-//	http.HandleFunc("/.well-known/oauth-protected-resource",
-//		handler.ServeProtectedResourceMetadata)
-//	http.HandleFunc("/.well-known/oauth-authorization-server",
-//		handler.ServeAuthorizationServerMetadata)
+//	server, err := oauth.NewServer(
+//	    provider,
+//	    store, // TokenStore
+//	    store, // ClientStore
+//	    store, // FlowStore
+//	    &oauth.ServerConfig{
+//	        Issuer:          "https://your-domain.com",
+//	        SupportedScopes: []string{"openid", "email", "profile"},
+//	    },
+//	    nil, // logger
+//	)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
 //
-//	// Token revocation endpoint (RFC 7009)
-//	http.HandleFunc("/oauth/revoke", handler.ServeTokenRevocation)
+//	handler := oauth.NewHandler(server, nil)
+//	mux := http.NewServeMux()
+//	handler.RegisterOAuthRoutes(mux, oauth.OAuthRoutesOptions{
+//	    MCPPath:         "/mcp",
+//	    IncludeMetadata: true,
+//	})
+//	mux.Handle("/mcp", handler.ValidateToken(mcpHandler))
+//
+// See docs/getting-started.md for a runnable end-to-end example and
+// docs/security.md for the production checklist (encryption, rate
+// limiters, audit logging — all wired via With* options on
+// [NewServer]).
 package oauth

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder contains the documentation for the mcp-oauth library.
 | [Getting Started](./getting-started.md) | Installation, providers, storage, first OAuth server |
 | [Configuration](./configuration.md) | All configuration options, CORS, interstitial pages, proxy settings |
 | [Security](./security.md) | Security features, best practices, production checklist |
+| [Silent Authentication](./silent-authentication.md) | OIDC prompt parameters for seamless token refresh |
 | [Observability](./observability.md) | OpenTelemetry, Prometheus metrics, distributed tracing |
 
 ## Reference

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -54,7 +54,15 @@ if err != nil {
 Implement the `providers.Provider` interface:
 
 ```go
-import "github.com/giantswarm/mcp-oauth/providers"
+import (
+    "context"
+    "fmt"
+    "time"
+
+    "golang.org/x/oauth2"
+
+    "github.com/giantswarm/mcp-oauth/providers"
+)
 
 type MyProvider struct {
     // your fields
@@ -64,35 +72,48 @@ func (p *MyProvider) Name() string {
     return "my-provider"
 }
 
-func (p *MyProvider) AuthorizationURL(state string, opts *providers.AuthOptions) string {
-    // Build authorization URL for your identity provider
+func (p *MyProvider) DefaultScopes() []string {
+    return []string{"openid", "email", "profile"}
+}
+
+// AuthorizationURL builds the URL to redirect the user to the upstream IdP.
+// codeChallenge and codeChallengeMethod are the PKCE parameters (pass empty
+// strings to disable). opts carries optional OIDC parameters (prompt,
+// login_hint, max_age, ...); nil means defaults.
+func (p *MyProvider) AuthorizationURL(state, codeChallenge, codeChallengeMethod string, scopes []string, opts *providers.AuthorizationURLOptions) string {
     return fmt.Sprintf("https://auth.example.com/authorize?state=%s", state)
 }
 
-func (p *MyProvider) ExchangeCode(ctx context.Context, code string, opts *providers.ExchangeOptions) (*providers.TokenResponse, error) {
-    // Exchange authorization code for tokens
-    return &providers.TokenResponse{
+// ExchangeCode exchanges the authorization code for tokens. codeVerifier is
+// the PKCE verifier (pass empty string if not using PKCE).
+func (p *MyProvider) ExchangeCode(ctx context.Context, code, codeVerifier string) (*oauth2.Token, error) {
+    return &oauth2.Token{
         AccessToken:  "...",
         RefreshToken: "...",
-        ExpiresIn:    3600,
+        Expiry:       time.Now().Add(time.Hour),
     }, nil
 }
 
 func (p *MyProvider) ValidateToken(ctx context.Context, accessToken string) (*providers.UserInfo, error) {
-    // Validate token and return user info
     return &providers.UserInfo{
         ID:    "user-123",
         Email: "user@example.com",
     }, nil
 }
 
-func (p *MyProvider) RefreshToken(ctx context.Context, refreshToken string) (*providers.TokenResponse, error) {
-    // Refresh an expired token
-    return &providers.TokenResponse{...}, nil
+func (p *MyProvider) RefreshToken(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
+    return &oauth2.Token{
+        AccessToken:  "...",
+        RefreshToken: "...",
+        Expiry:       time.Now().Add(time.Hour),
+    }, nil
 }
 
 func (p *MyProvider) RevokeToken(ctx context.Context, token string) error {
-    // Revoke a token
+    return nil
+}
+
+func (p *MyProvider) HealthCheck(ctx context.Context) error {
     return nil
 }
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -51,9 +51,9 @@ Before deploying to production, verify these settings:
 
 ### Recommended
 
-- [ ] **Token Encryption**: Enable via `SetEncryptor()` for at-rest encryption
-- [ ] **Audit Logging**: Set up `Auditor` for security event logging
-- [ ] **Rate Limiting**: Configure IP, user, and client registration limits
+- [ ] **Token Encryption**: Pass `oauth.WithEncryptor(...)` to `oauth.NewServer` for at-rest encryption
+- [ ] **Audit Logging**: Pass `oauth.WithAuditor(...)` to `oauth.NewServer` for security event logging
+- [ ] **Rate Limiting**: Configure IP, user, and client registration limits via `oauth.WithRateLimiter`, `oauth.WithUserRateLimiter`, `oauth.WithClientRegistrationRateLimiter`
 - [ ] **Registration Protected**: Set `RegistrationAccessToken` or disable registration
 - [ ] **Proxy Configured**: Set `TrustProxy` and `TrustedProxyCount` if behind proxy
 - [ ] **Production Mode**: Set `ProductionMode=true` for strict redirect URI validation
@@ -93,9 +93,16 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Attach to server
-server.SetEncryptor(encryptor)
+// Attach to server at construction time
+server, err := oauth.NewServer(
+    provider, tokenStore, clientStore, flowStore,
+    &oauth.ServerConfig{Issuer: "https://your-domain.com"},
+    logger,
+    oauth.WithEncryptor(encryptor),
+)
 ```
+
+`WithEncryptor` propagates the encryptor to the token store when the store implements `SetEncryptor(*security.Encryptor)` (memory and Valkey both do).
 
 **Key Management:**
 - Generate keys using `security.GenerateKey()` (32 bytes, cryptographically random)
@@ -119,8 +126,11 @@ ipRateLimiter := security.NewRateLimiter(
 )
 defer ipRateLimiter.Stop()
 
-srv, err := server.New(provider, tokenStore, clientStore, flowStore, config, logger,
-    server.WithRateLimiter(ipRateLimiter),
+server, err := oauth.NewServer(
+    provider, tokenStore, clientStore, flowStore,
+    &oauth.ServerConfig{Issuer: "https://your-domain.com"},
+    logger,
+    oauth.WithRateLimiter(ipRateLimiter),
 )
 ```
 
@@ -146,10 +156,15 @@ userRateLimiter := security.NewRateLimiter(
 )
 defer userRateLimiter.Stop()
 
-srv, err := server.New(provider, tokenStore, clientStore, flowStore, config, logger,
-    server.WithUserRateLimiter(userRateLimiter),
+server, err := oauth.NewServer(
+    provider, tokenStore, clientStore, flowStore,
+    &oauth.ServerConfig{Issuer: "https://your-domain.com"},
+    logger,
+    oauth.WithUserRateLimiter(userRateLimiter),
 )
 ```
+
+To layer both IP and user limits, pass both options on the same `oauth.NewServer` call.
 
 ### Client Registration Rate Limiting
 
@@ -160,8 +175,11 @@ Prevent resource exhaustion through registration/deletion cycles:
 clientRegRateLimiter := security.NewClientRegistrationRateLimiter(logger)
 defer clientRegRateLimiter.Stop()
 
-srv, err := server.New(provider, tokenStore, clientStore, flowStore, config, logger,
-    server.WithClientRegistrationRateLimiter(clientRegRateLimiter),
+server, err := oauth.NewServer(
+    provider, tokenStore, clientStore, flowStore,
+    &oauth.ServerConfig{Issuer: "https://your-domain.com"},
+    logger,
+    oauth.WithClientRegistrationRateLimiter(clientRegRateLimiter),
 )
 
 // Or with custom configuration
@@ -194,7 +212,13 @@ Log all security-relevant events:
 import "github.com/giantswarm/mcp-oauth/security"
 
 auditor := security.NewAuditor(logger, true) // true = verbose mode
-server.SetAuditor(auditor)
+
+server, err := oauth.NewServer(
+    provider, tokenStore, clientStore, flowStore,
+    &oauth.ServerConfig{Issuer: "https://your-domain.com"},
+    logger,
+    oauth.WithAuditor(auditor),
+)
 ```
 
 ### Logged Events

--- a/docs/silent-authentication.md
+++ b/docs/silent-authentication.md
@@ -115,6 +115,9 @@ package main
 
 import (
     "context"
+    "crypto/rand"
+    "crypto/sha256"
+    "encoding/base64"
     "log/slog"
     "net/http"
 
@@ -131,7 +134,7 @@ type AuthHandler struct {
 // TrySilentAuth attempts silent authentication first
 func (h *AuthHandler) TrySilentAuth(w http.ResponseWriter, r *http.Request, userEmail string) {
     state := generateSecureState()
-    pkce := oauth.GeneratePKCE()
+    challenge, verifier := newPKCEPair()
 
     // First, try silent auth
     opts := &providers.AuthorizationURLOptions{
@@ -141,14 +144,14 @@ func (h *AuthHandler) TrySilentAuth(w http.ResponseWriter, r *http.Request, user
 
     authURL := h.provider.AuthorizationURL(
         state,
-        pkce.Challenge,
+        challenge,
         "S256",
         []string{"openid", "email", "profile"},
         opts,
     )
 
-    // Store state and PKCE for callback
-    h.storeAuthState(state, pkce, true) // true = silent attempt
+    // Store state and PKCE verifier for the callback
+    h.storeAuthState(state, verifier, true) // true = silent attempt
 
     http.Redirect(w, r, authURL, http.StatusFound)
 }
@@ -183,7 +186,7 @@ func (h *AuthHandler) HandleCallback(w http.ResponseWriter, r *http.Request) {
 
 func (h *AuthHandler) startInteractiveLogin(w http.ResponseWriter, r *http.Request, userEmail string) {
     state := generateSecureState()
-    pkce := oauth.GeneratePKCE()
+    challenge, verifier := newPKCEPair()
 
     // Interactive login - no prompt=none
     opts := &providers.AuthorizationURLOptions{
@@ -192,17 +195,33 @@ func (h *AuthHandler) startInteractiveLogin(w http.ResponseWriter, r *http.Reque
 
     authURL := h.provider.AuthorizationURL(
         state,
-        pkce.Challenge,
+        challenge,
         "S256",
         []string{"openid", "email", "profile"},
         opts,
     )
 
-    h.storeAuthState(state, pkce, false) // false = interactive
+    h.storeAuthState(state, verifier, false) // false = interactive
 
     http.Redirect(w, r, authURL, http.StatusFound)
 }
+
+// newPKCEPair returns an RFC 7636 S256 PKCE challenge and its verifier.
+// The verifier is the raw secret to keep server-side; the challenge is
+// what's sent in the authorization request.
+func newPKCEPair() (challenge, verifier string) {
+    b := make([]byte, 32)
+    if _, err := rand.Read(b); err != nil {
+        panic(err) // crypto/rand must not fail
+    }
+    verifier = base64.RawURLEncoding.EncodeToString(b)
+    sum := sha256.Sum256([]byte(verifier))
+    challenge = base64.RawURLEncoding.EncodeToString(sum[:])
+    return challenge, verifier
+}
 ```
+
+The helper uses `crypto/rand`, `crypto/sha256`, and `encoding/base64` from the standard library. There is no `oauth.GeneratePKCE` export — keep the verifier in your own per-flow state (the `authState` map above) and pass it to `Server.ExchangeAuthorizationCode` when the callback fires.
 
 ## Error Types
 

--- a/docs/silent-authentication.md
+++ b/docs/silent-authentication.md
@@ -221,7 +221,7 @@ func newPKCEPair() (challenge, verifier string) {
 }
 ```
 
-The helper uses `crypto/rand`, `crypto/sha256`, and `encoding/base64` from the standard library. There is no `oauth.GeneratePKCE` export — keep the verifier in your own per-flow state (the `authState` map above) and pass it to `Server.ExchangeAuthorizationCode` when the callback fires.
+The helper uses `crypto/rand`, `crypto/sha256`, and `encoding/base64` from the standard library. Keep the verifier in your own per-flow state (the `authState` map above) and pass it to `Server.ExchangeAuthorizationCode` when the callback fires.
 
 ## Error Types
 

--- a/examples/production/README.md
+++ b/examples/production/README.md
@@ -602,29 +602,29 @@ gitleaks protect --staged
 
 ### Rate Limiting
 
-The production setup uses **multiple layers of rate limiting** for defense in depth:
+The production setup uses **multiple layers of rate limiting** for defense in depth. Each limiter is constructed up front and wired into the server via functional options on `oauth.NewServer`:
 
-1. **IP-based Rate Limiting**: Prevents DoS attacks from external sources
-   ```go
-   rateLimiter := security.NewRateLimiter(10, 20, logger)
-   defer rateLimiter.Stop()
-   // Pass to server.New as an option:
-   //   server.New(..., server.WithRateLimiter(rateLimiter))
-   ```
+```go
+// 1. IP-based limiter — stops DoS before authentication.
+rateLimiter := security.NewRateLimiter(10, 20, logger)
+defer rateLimiter.Stop()
 
-2. **User-based Rate Limiting**: Prevents abuse from authenticated users
-   ```go
-   userRateLimiter := security.NewRateLimiter(100, 200, logger)
-   defer userRateLimiter.Stop()
-   // server.New(..., server.WithUserRateLimiter(userRateLimiter))
-   ```
+// 2. User-based limiter — bounds authenticated abuse.
+userRateLimiter := security.NewRateLimiter(100, 200, logger)
+defer userRateLimiter.Stop()
 
-3. **Client Registration Rate Limiting**: Prevents registration DoS
-   ```go
-   clientRegRateLimiter := security.NewClientRegistrationRateLimiter(logger)
-   defer clientRegRateLimiter.Stop()
-   // server.New(..., server.WithClientRegistrationRateLimiter(clientRegRateLimiter))
-   ```
+// 3. Client-registration limiter — prevents register/delete cycle DoS.
+clientRegRateLimiter := security.NewClientRegistrationRateLimiter(logger)
+defer clientRegRateLimiter.Stop()
+
+server, err := oauth.NewServer(
+    provider, tokenStore, clientStore, flowStore,
+    config, logger,
+    oauth.WithRateLimiter(rateLimiter),
+    oauth.WithUserRateLimiter(userRateLimiter),
+    oauth.WithClientRegistrationRateLimiter(clientRegRateLimiter),
+)
+```
 
 **Why multiple layers?**
 - IP limiting stops attacks before authentication

--- a/server/doc.go
+++ b/server/doc.go
@@ -39,11 +39,19 @@
 //
 // Example usage:
 //
-//	provider := google.NewProvider(clientID, clientSecret, redirectURL)
-//	store := memory.NewStore()
+//	provider, err := google.NewProvider(&google.Config{
+//	    ClientID:     clientID,
+//	    ClientSecret: clientSecret,
+//	    RedirectURL:  redirectURL,
+//	})
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	store := memory.New()
+//	defer store.Stop()
 //
 //	config := &server.Config{
-//	    Issuer: "https://auth.example.com",
+//	    Issuer:      "https://auth.example.com",
 //	    RequirePKCE: true,
 //	}
 //


### PR DESCRIPTION
Closes #308.

## Summary

- `doc.go`, `docs/security.md`, `docs/getting-started.md`, `docs/silent-authentication.md`, `server/doc.go` rewritten so every snippet compiles against current `main` (removed `Set*` setters, removed `oauth.GeneratePKCE` / `oauth.GenerateEncryptionKey` / `handler.ValidateGoogleToken`, ghost `providers.AuthOptions` / `ExchangeOptions` / `TokenResponse`).
- `Set*` setter usages replaced with `oauth.With*` options on `NewServer`. Custom-provider example rewritten against the real `providers.Provider` interface (`*oauth2.Token` return type, current method signatures, `HealthCheck` included). PKCE example uses raw `crypto/rand` + `crypto/sha256` instead of a non-existent helper.
- `examples/production/README.md` rate-limiting section: three `server.Set*RateLimiter(...)` blocks collapsed into a single `oauth.NewServer(..., oauth.With*RateLimiter(...))` snippet, matching the `docs/security.md` style. The scratch extraction compiles against current `main`.
- `SECURITY_ARCHITECTURE.md` threat-model row: `golang-jwt/jwt/v5` -> `go-jose/go-jose/v4`.
- Root `doc.go` spec-date pointer: 2025-06-18 -> 2025-11-25 (both revisions supported). Example block rewritten against the current `oauth.NewServer` / `oauth.NewHandler` / `Handler.RegisterOAuthRoutes` API.
- `docs/README.md` index now links `silent-authentication.md`.
- Prose audit: removed historical/"there is no X export" framing from `docs/silent-authentication.md` and from the root `doc.go` spec-version paragraph (present-tense API description only).

## Verification

Each non-trivial snippet was extracted into a scratch `.go` file and compiled against current `main` (`go build ./...`); the scratch files were removed before commit. The custom-provider snippet was additionally type-asserted against `providers.Provider`.

## Out of scope

- `docs/observability.md`: already rewritten against the actual emit set by the recent observability work; no drift left.