### PR TITLE
fix(handler): validate response_type and redirect /authorize errors per RFC 6749

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`/authorize` validates `response_type` and redirects protocol errors per RFC 6749 §4.1.2.1 (#303)**
+  - `response_type` is now validated against the AS metadata (`response_types_supported: ["code"]`). Missing or non-`code` values are rejected with `unsupported_response_type`.
+  - `invalid_request` (missing or short `state`), `unsupported_response_type`, and `server_error` are now returned by redirecting to `redirect_uri` with `error` / `error_description` / `state` query parameters, matching RFC 6749 §4.1.2.1. Previously these were emitted as JSON `400` / `500` bodies, which conforming clients cannot correlate to the authorization request.
+  - `invalid_client` (missing `client_id`) and `invalid_redirect_uri` (missing / non-`http(s)` `redirect_uri`) continue to return JSON, per RFC 6749 §3.1.2.4 which forbids redirecting to an unvalidated URI.
+
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**
   - `isMandatoryScope()` now returns true for `email`, `profile`, `groups`, and `offline_access` in addition to `openid` and cross-client audience scopes.
   - When an MCP client sends only custom scopes (e.g., `claudeai`), identity-critical scopes from the provider's defaults are now force-merged into the authorization request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,9 +135,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`/authorize` validates `response_type` and redirects protocol errors per RFC 6749 §4.1.2.1 (#303)**
-  - `response_type` is now validated against the AS metadata (`response_types_supported: ["code"]`). Missing or non-`code` values are rejected with `unsupported_response_type`.
-  - `invalid_request` (missing or short `state`), `unsupported_response_type`, and `server_error` are now returned by redirecting to `redirect_uri` with `error` / `error_description` / `state` query parameters, matching RFC 6749 §4.1.2.1. Previously these were emitted as JSON `400` / `500` bodies, which conforming clients cannot correlate to the authorization request.
-  - `invalid_client` (missing `client_id`) and `invalid_redirect_uri` (missing / non-`http(s)` `redirect_uri`) continue to return JSON, per RFC 6749 §3.1.2.4 which forbids redirecting to an unvalidated URI.
+  - Missing or non-`code` `response_type` is rejected with `unsupported_response_type`.
+  - `invalid_request` (missing or short `state`), `unsupported_response_type`, and `server_error` redirect to `redirect_uri` with `error` / `error_description` / `state` query parameters.
+  - `invalid_client` (missing or unregistered `client_id`) and `invalid_redirect_uri` (missing, non-`http(s)`, or not registered for the client) return JSON `400`.
+  - New `Server.ValidateRedirectURIForAuthorization(ctx, clientID, redirectURI)` exposes the gate handlers must run before redirecting any /authorize error to redirectURI.
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**
   - `isMandatoryScope()` now returns true for `email`, `profile`, `groups`, and `offline_access` in addition to `openid` and cross-client audience scopes.
@@ -668,7 +669,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     // Before (deprecated)
     err := oauth.NewOAuthError("invalid_request", "Missing parameter", 400)
     var oauthErr *oauth.OAuthError
-    
+
     // After (recommended)
     err := oauth.NewError("invalid_request", "Missing parameter", 400)
     var oauthErr *oauth.Error
@@ -775,7 +776,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Health Check**: Uses GitHub's `/rate_limit` endpoint for lightweight health monitoring
   - **Token Behavior**: Gracefully handles GitHub's non-expiring tokens (`ErrRefreshNotSupported`)
   - **Token Revocation**: Graceful degradation (returns nil) since GitHub lacks server-side revocation
-  - **Helper Methods**: 
+  - **Helper Methods**:
     - `GetUserOrganizations()` for listing user's organizations
     - `GetProviderToken()` for creating tokens for additional GitHub API calls
   - **Documentation**: Comprehensive `doc.go`, example application, and README with setup instructions
@@ -874,7 +875,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * Discord, Figma, Linear, Raycast, Warp, Zed, Windsurf, and more
     * Unknown schemes show capitalized scheme name
   - **UX Design**: Modern, clean styling with success checkmark animation
-  - **Security**: 
+  - **Security**:
     * Uses `html/template` with proper escaping for XSS prevention
     * Hash-based Content-Security-Policy (CSP Level 2) for inline script allowlisting
     * Static inline script reads redirect URL from DOM to maintain stable SHA-256 hash
@@ -985,7 +986,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Caching: In-memory LRU cache with TTL support (default: 5 minutes) and HTTP Cache-Control respect
     - Validation: Ensures client_id in document matches URL exactly (security requirement)
     - Integration: Transparent integration with existing authorization flow via `GetClient()`
-  - **Configuration**: 
+  - **Configuration**:
     - `EnableClientIDMetadataDocuments` - Enable feature (default: false for backward compatibility)
     - `ClientMetadataFetchTimeout` - Timeout for metadata fetch (default: 10s)
     - `ClientMetadataCacheTTL` - Cache TTL (default: 5m)
@@ -1022,7 +1023,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Resource binding stored with authorization codes and tokens
   - **Configuration**: New `ResourceIdentifier` field in `server.Config` (defaults to `Issuer` if not set)
   - **Backward Compatibility**: Resource parameter is optional to maintain compatibility with existing clients
-  - **Storage Changes**: 
+  - **Storage Changes**:
     - Added `Resource` field to `storage.AuthorizationState`
     - Added `Resource` and `Audience` fields to `storage.AuthorizationCode`
   - **Validation**: Resource must be absolute HTTPS URI (or HTTP for localhost development)
@@ -1048,7 +1049,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scope string length validation to prevent DoS attacks**
   - **Problem**: No limit on scope parameter length could allow DoS attacks via extremely long scope strings
   - **Risk**: Potential resource exhaustion through processing and validating arbitrarily long scope strings
-  - **Solution**: 
+  - **Solution**:
     - Added `MaxScopeLength` configuration parameter (default: 1000 characters)
     - Scope length validated early in authorization flow before parsing/processing
     - Clear error messages when limit exceeded
@@ -1064,7 +1065,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Problem**: Scopes from client authorization requests were not being passed to Google during provider authorization redirect
   - **Impact**: Google returned tokens without user info (no scopes = no permissions = no data), causing userID extraction to fail and token storage to fail with "userID cannot be empty" errors
   - **Root Cause**: The Provider interface's `AuthorizationURL` method didn't accept scopes parameter, so only provider's hardcoded scopes were used
-  - **Solution**: 
+  - **Solution**:
     - Modified `Provider.AuthorizationURL()` interface to accept `scopes []string` parameter
     - Updated Google provider to use client-requested scopes when provided, falling back to configured defaults when empty
     - Updated server flows to parse and pass client scopes to provider
@@ -1083,7 +1084,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact**: Initial implementation had confusing semantics around defaults
   - **Solution**: Renamed to `DisableWWWAuthenticateMetadata` following the library's "secure by default" principle
   - **Field change**: `EnableWWWAuthenticateMetadata` → `DisableWWWAuthenticateMetadata` (inverted logic)
-  - **Default behavior**: 
+  - **Default behavior**:
     - `DisableWWWAuthenticateMetadata: false` (default) → Full metadata ENABLED (secure by default)
     - `DisableWWWAuthenticateMetadata: true` → Minimal headers for backward compatibility
   - **Breaking Change**: 🔴 **YES** - Field renamed for clarity
@@ -1448,7 +1449,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Non-localhost HTTP deployments blocked unless explicitly allowed
   - Clear error messages guide developers to secure configuration
   - OAuth 2.1 compliance: HTTPS required for all production endpoints
-  - **Migration**: 
+  - **Migration**:
     - For localhost development: Add `AllowInsecureHTTP: true` to suppress warnings
     - For production HTTP (not recommended): Add `AllowInsecureHTTP: true` and review security risks
     - **Recommended**: Switch to HTTPS for all environments
@@ -1586,4 +1587,3 @@ See [SECURITY.md](SECURITY.md) for our security policy and how to report vulnera
 ## License
 
 This project is licensed under the Apache License 2.0 - see [LICENSE](LICENSE) for details.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`security.DecodeKey(s string) ([]byte, error)`**: convenience helper that tries [`KeyFromBase64`](security/encryption.go) then falls back to [`KeyFromHex`](security/encryption.go). Consolidates the dual-encoding decode pattern that consumers were re-implementing locally.
+- **`Server.ValidateRedirectURIForAuthorization(ctx, clientID, redirectURI) (*url.URL, error)`**: runs the client lookup and registered-redirect-URI check and returns the canonical `*url.URL` from server-side storage. Handlers redirecting `/authorize` protocol errors back to the client must use this value as the redirect target (RFC 6749 §3.1.2.4).
 
 ### Changed
 
@@ -151,7 +152,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Missing or non-`code` `response_type` is rejected with `unsupported_response_type`.
   - `invalid_request` (missing or short `state`), `unsupported_response_type`, and `server_error` redirect to `redirect_uri` with `error` / `error_description` / `state` query parameters.
   - `invalid_client` (missing or unregistered `client_id`) and `invalid_redirect_uri` (missing, non-`http(s)`, or not registered for the client) return JSON `400`.
-  - New `Server.ValidateRedirectURIForAuthorization(ctx, clientID, redirectURI)` exposes the gate handlers must run before redirecting any /authorize error to redirectURI.
 
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**
   - `isMandatoryScope()` now returns true for `email`, `profile`, `groups`, and `offline_access` in addition to `openid` and cross-client audience scopes.
@@ -682,7 +682,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     // Before (deprecated)
     err := oauth.NewOAuthError("invalid_request", "Missing parameter", 400)
     var oauthErr *oauth.OAuthError
-
+    
     // After (recommended)
     err := oauth.NewError("invalid_request", "Missing parameter", 400)
     var oauthErr *oauth.Error
@@ -789,7 +789,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Health Check**: Uses GitHub's `/rate_limit` endpoint for lightweight health monitoring
   - **Token Behavior**: Gracefully handles GitHub's non-expiring tokens (`ErrRefreshNotSupported`)
   - **Token Revocation**: Graceful degradation (returns nil) since GitHub lacks server-side revocation
-  - **Helper Methods**:
+  - **Helper Methods**: 
     - `GetUserOrganizations()` for listing user's organizations
     - `GetProviderToken()` for creating tokens for additional GitHub API calls
   - **Documentation**: Comprehensive `doc.go`, example application, and README with setup instructions
@@ -888,7 +888,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     * Discord, Figma, Linear, Raycast, Warp, Zed, Windsurf, and more
     * Unknown schemes show capitalized scheme name
   - **UX Design**: Modern, clean styling with success checkmark animation
-  - **Security**:
+  - **Security**: 
     * Uses `html/template` with proper escaping for XSS prevention
     * Hash-based Content-Security-Policy (CSP Level 2) for inline script allowlisting
     * Static inline script reads redirect URL from DOM to maintain stable SHA-256 hash
@@ -999,7 +999,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Caching: In-memory LRU cache with TTL support (default: 5 minutes) and HTTP Cache-Control respect
     - Validation: Ensures client_id in document matches URL exactly (security requirement)
     - Integration: Transparent integration with existing authorization flow via `GetClient()`
-  - **Configuration**:
+  - **Configuration**: 
     - `EnableClientIDMetadataDocuments` - Enable feature (default: false for backward compatibility)
     - `ClientMetadataFetchTimeout` - Timeout for metadata fetch (default: 10s)
     - `ClientMetadataCacheTTL` - Cache TTL (default: 5m)
@@ -1036,7 +1036,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Resource binding stored with authorization codes and tokens
   - **Configuration**: New `ResourceIdentifier` field in `server.Config` (defaults to `Issuer` if not set)
   - **Backward Compatibility**: Resource parameter is optional to maintain compatibility with existing clients
-  - **Storage Changes**:
+  - **Storage Changes**: 
     - Added `Resource` field to `storage.AuthorizationState`
     - Added `Resource` and `Audience` fields to `storage.AuthorizationCode`
   - **Validation**: Resource must be absolute HTTPS URI (or HTTP for localhost development)
@@ -1062,7 +1062,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scope string length validation to prevent DoS attacks**
   - **Problem**: No limit on scope parameter length could allow DoS attacks via extremely long scope strings
   - **Risk**: Potential resource exhaustion through processing and validating arbitrarily long scope strings
-  - **Solution**:
+  - **Solution**: 
     - Added `MaxScopeLength` configuration parameter (default: 1000 characters)
     - Scope length validated early in authorization flow before parsing/processing
     - Clear error messages when limit exceeded
@@ -1078,7 +1078,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Problem**: Scopes from client authorization requests were not being passed to Google during provider authorization redirect
   - **Impact**: Google returned tokens without user info (no scopes = no permissions = no data), causing userID extraction to fail and token storage to fail with "userID cannot be empty" errors
   - **Root Cause**: The Provider interface's `AuthorizationURL` method didn't accept scopes parameter, so only provider's hardcoded scopes were used
-  - **Solution**:
+  - **Solution**: 
     - Modified `Provider.AuthorizationURL()` interface to accept `scopes []string` parameter
     - Updated Google provider to use client-requested scopes when provided, falling back to configured defaults when empty
     - Updated server flows to parse and pass client scopes to provider
@@ -1097,7 +1097,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Impact**: Initial implementation had confusing semantics around defaults
   - **Solution**: Renamed to `DisableWWWAuthenticateMetadata` following the library's "secure by default" principle
   - **Field change**: `EnableWWWAuthenticateMetadata` → `DisableWWWAuthenticateMetadata` (inverted logic)
-  - **Default behavior**:
+  - **Default behavior**: 
     - `DisableWWWAuthenticateMetadata: false` (default) → Full metadata ENABLED (secure by default)
     - `DisableWWWAuthenticateMetadata: true` → Minimal headers for backward compatibility
   - **Breaking Change**: 🔴 **YES** - Field renamed for clarity
@@ -1462,7 +1462,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Non-localhost HTTP deployments blocked unless explicitly allowed
   - Clear error messages guide developers to secure configuration
   - OAuth 2.1 compliance: HTTPS required for all production endpoints
-  - **Migration**:
+  - **Migration**: 
     - For localhost development: Add `AllowInsecureHTTP: true` to suppress warnings
     - For production HTTP (not recommended): Add `AllowInsecureHTTP: true` and review security risks
     - **Recommended**: Switch to HTTPS for all environments
@@ -1600,3 +1600,4 @@ See [SECURITY.md](SECURITY.md) for our security policy and how to report vulnera
 ## License
 
 This project is licensed under the Apache License 2.0 - see [LICENSE](LICENSE) for details.
+

--- a/errors.go
+++ b/errors.go
@@ -9,18 +9,19 @@ import (
 
 // OAuth error codes as constants
 const (
-	ErrorCodeInvalidRequest       = "invalid_request"
-	ErrorCodeInvalidGrant         = "invalid_grant"
-	ErrorCodeInvalidClient        = "invalid_client"
-	ErrorCodeInvalidScope         = "invalid_scope"
-	ErrorCodeInvalidToken         = "invalid_token"
-	ErrorCodeInsufficientScope    = "insufficient_scope"
-	ErrorCodeUnauthorizedClient   = "unauthorized_client"
-	ErrorCodeUnsupportedGrantType = "unsupported_grant_type"
-	ErrorCodeServerError          = "server_error"
-	ErrorCodeAccessDenied         = "access_denied"
-	ErrorCodeInvalidRedirectURI   = "invalid_redirect_uri"
-	ErrorCodeRateLimitExceeded    = "rate_limit_exceeded"
+	ErrorCodeInvalidRequest          = "invalid_request"
+	ErrorCodeInvalidGrant            = "invalid_grant"
+	ErrorCodeInvalidClient           = "invalid_client"
+	ErrorCodeInvalidScope            = "invalid_scope"
+	ErrorCodeInvalidToken            = "invalid_token"
+	ErrorCodeInsufficientScope       = "insufficient_scope"
+	ErrorCodeUnauthorizedClient      = "unauthorized_client"
+	ErrorCodeUnsupportedGrantType    = "unsupported_grant_type"
+	ErrorCodeUnsupportedResponseType = "unsupported_response_type"
+	ErrorCodeServerError             = "server_error"
+	ErrorCodeAccessDenied            = "access_denied"
+	ErrorCodeInvalidRedirectURI      = "invalid_redirect_uri"
+	ErrorCodeRateLimitExceeded       = "rate_limit_exceeded"
 
 	// Silent authentication error codes (OIDC Core Section 3.1.2.6)
 	// These indicate the IdP requires user interaction and silent auth failed.

--- a/handler.go
+++ b/handler.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1145,7 +1146,7 @@ func (h *Handler) buildAuthServerMetadata() map[string]any {
 		"issuer":                                h.server.Config.Issuer,
 		"authorization_endpoint":                h.server.Config.AuthorizationEndpoint(),
 		"token_endpoint":                        h.server.Config.TokenEndpoint(),
-		"response_types_supported":              []string{"code"},
+		"response_types_supported":              DefaultResponseTypes,
 		"grant_types_supported":                 []string{"authorization_code", "refresh_token"},
 		"code_challenge_methods_supported":      []string{PKCEMethodS256},
 		"token_endpoint_auth_methods_supported": SupportedTokenAuthMethods,
@@ -1305,11 +1306,11 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Authoritativeness gate: client + redirect_uri must be registered before
-	// any subsequent error branch is allowed to redirect to redirectURI. Per
-	// RFC 6749 §4.1.2.1 + §3.1.2.4 errors are returned to redirect_uri only
-	// when that URI is the client's registered value.
-	if err := h.server.ValidateRedirectURIForAuthorization(r.Context(), clientID, redirectURI); err != nil {
+	// RFC 6749 §4.1.2.1 + §3.1.2.4: redirect_uri must be registered for the
+	// client before any error branch may redirect to it. The canonical URI
+	// returned is the redirect target.
+	canonicalRedirectURI, err := h.server.ValidateRedirectURIForAuthorization(r.Context(), clientID, redirectURI)
+	if err != nil {
 		h.logger.Info("Authorization request rejected: invalid client or redirect_uri", "client_id", clientID, "error", err)
 		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
 		instrumentation.SetSpanError(span, "invalid client or redirect_uri")
@@ -1323,7 +1324,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	if state == "" && !h.server.Config.AllowNoStateParameter {
 		h.logger.Info("Authorization request rejected: state parameter missing", "client_id", clientID)
 		h.respondAuthorizationError(w, r, authorizationError{
-			redirectURI: redirectURI,
+			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeInvalidRequest,
 			description: "state parameter is required for CSRF protection",
@@ -1336,7 +1337,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	if state != "" && len(state) < MinStateLength && !h.server.Config.AllowNoStateParameter {
 		h.logger.Warn("Authorization request rejected: state parameter too short", "state_length", len(state), "min_required", MinStateLength, "client_id", clientID)
 		h.respondAuthorizationError(w, r, authorizationError{
-			redirectURI: redirectURI,
+			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeInvalidRequest,
 			description: fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength),
@@ -1347,13 +1348,13 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if responseType != "code" {
+	if !slices.Contains(DefaultResponseTypes, responseType) {
 		h.logger.Info("Authorization request rejected: unsupported response_type", "response_type", responseType, "client_id", clientID)
 		h.respondAuthorizationError(w, r, authorizationError{
-			redirectURI: redirectURI,
+			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeUnsupportedResponseType,
-			description: `response_type must be "code"`,
+			description: fmt.Sprintf("response_type must be one of %v", DefaultResponseTypes),
 			startTime:   startTime,
 			span:        span,
 			spanError:   "unsupported response_type",
@@ -1376,7 +1377,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		h.logger.Error("Failed to start authorization flow", "error", err)
 		instrumentation.RecordError(span, err)
 		h.respondAuthorizationError(w, r, authorizationError{
-			redirectURI: redirectURI,
+			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeServerError,
 			description: "Failed to start authorization flow",
@@ -1400,7 +1401,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	if err != nil || (parsedAuthURL.Scheme != "https" && parsedAuthURL.Scheme != "http") {
 		h.logger.Error("Provider returned invalid authorization URL", "error", err)
 		h.respondAuthorizationError(w, r, authorizationError{
-			redirectURI: redirectURI,
+			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeServerError,
 			description: "Failed to start authorization flow",
@@ -2269,19 +2270,10 @@ type authorizationError struct {
 	spanError   string
 }
 
-// respondAuthorizationError redirects (302) to a registered http(s)
-// redirectURI with error / error_description / state per RFC 6749 §4.1.2.1.
-// Falls back to JSON 400 when redirectURI is not http(s).
-//
-// Callers MUST validate redirectURI against the client's registered URIs
-// before invoking this helper — see Server.ValidateRedirectURIForAuthorization.
-// The scheme gate is intentionally narrower than the authoritativeness check:
-// it accepts only http(s) so a misregistered registration can't be coaxed into
-// emitting a 302 with arbitrary scheme. Custom URL schemes admitted by
-// Config.AllowedCustomSchemes (RFC 8252 native apps) therefore receive a
-// JSON 400 here even though the success path issues an interstitial for them
-// — that gap matches the pre-PR error behaviour. A follow-up should mirror
-// serveSuccessInterstitial for the error path; not in scope for #303.
+// respondAuthorizationError redirects (302) to redirectURI with
+// error / error_description / state per RFC 6749 §4.1.2.1, or returns JSON 400
+// when redirectURI is not http(s). Custom URL schemes admitted by
+// Config.AllowedCustomSchemes (RFC 8252 native apps) fall back to JSON 400.
 func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Request, e authorizationError) {
 	instrumentation.SetSpanError(e.span, e.spanError)
 	instrumentation.SetSpanAttributes(
@@ -2307,9 +2299,6 @@ func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Reque
 
 	h.recordHTTPMetrics(r.Context(), endpointAuthorize, r.Method, http.StatusFound, e.startTime)
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
-	// #nosec G710 -- redirect target is the client's registered redirect_uri
-	// (authoritativeness verified by Server.ValidateRedirectURIForAuthorization
-	// before this helper is reached) and scheme-restricted to http(s).
 	http.Redirect(w, r, parsed.String(), http.StatusFound)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -1312,8 +1312,6 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// RFC 6749 §3.1.1: only "code" response_type is supported; AS metadata
-	// advertises response_types_supported: ["code"].
 	if responseType != "code" {
 		h.logger.Info("Authorization request rejected: unsupported response_type", "response_type", responseType, "client_id", clientID)
 		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeUnsupportedResponseType, "response_type must be \"code\"", startTime, span, "unsupported response_type")
@@ -2200,11 +2198,10 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 	})
 }
 
-// respondAuthorizationError handles RFC 6749 §4.1.2.1 error returns from the
-// authorization endpoint. When the redirect URI parses as an http(s) URL it
-// appends error / error_description / state and redirects (302); otherwise it
-// falls back to the JSON 400 path because the spec forbids redirecting to a
-// missing or non-http(s) redirect URI.
+// respondAuthorizationError redirects (302) to redirectURI with error /
+// error_description / state when the URI is a valid http(s) URL. When it is
+// missing or non-http(s) it falls back to a JSON 400 to avoid an open-redirect
+// gadget against an unvalidated URI.
 func (h *Handler) respondAuthorizationError(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -2237,9 +2234,8 @@ func (h *Handler) respondAuthorizationError(
 
 	h.recordHTTPMetrics(r.Context(), "authorization", http.MethodGet, http.StatusFound, startTime)
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
-	// #nosec G710 -- redirect target is the client-supplied redirect_uri parsed
-	// and scheme-checked above. RFC 6749 §4.1.2.1 mandates redirecting errors
-	// to redirect_uri so the client can correlate them with the request.
+	// #nosec G710 -- redirect target was parsed and scheme-restricted to http(s)
+	// above; not an open redirect.
 	http.Redirect(w, r, parsed.String(), http.StatusFound)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -1318,45 +1318,24 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// CRITICAL SECURITY: State parameter is required for CSRF protection
-	// Input validation at HTTP layer to return proper status codes
-	// Can be disabled for clients that don't support state (e.g., some MCP clients)
-	if state == "" && !h.server.Config.AllowNoStateParameter {
-		h.logger.Info("Authorization request rejected: state parameter missing", "client_id", clientID)
-		h.respondAuthorizationError(w, r, authorizationError{
+	if rejection := h.checkAuthorizationStateParam(state, clientID); rejection != nil {
+		h.respondAuthorizationError(w, r, span, startTime, authorizationError{
 			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeInvalidRequest,
-			description: "state parameter is required for CSRF protection",
-			startTime:   startTime,
-			span:        span,
-			spanError:   "state missing",
-		})
-		return
-	}
-	if state != "" && len(state) < MinStateLength && !h.server.Config.AllowNoStateParameter {
-		h.logger.Warn("Authorization request rejected: state parameter too short", "state_length", len(state), "min_required", MinStateLength, "client_id", clientID)
-		h.respondAuthorizationError(w, r, authorizationError{
-			redirectURI: canonicalRedirectURI,
-			state:       state,
-			code:        ErrorCodeInvalidRequest,
-			description: fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength),
-			startTime:   startTime,
-			span:        span,
-			spanError:   "state too short",
+			description: rejection.description,
+			spanError:   rejection.spanError,
 		})
 		return
 	}
 
 	if !slices.Contains(DefaultResponseTypes, responseType) {
 		h.logger.Info("Authorization request rejected: unsupported response_type", "response_type", responseType, "client_id", clientID)
-		h.respondAuthorizationError(w, r, authorizationError{
+		h.respondAuthorizationError(w, r, span, startTime, authorizationError{
 			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeUnsupportedResponseType,
-			description: fmt.Sprintf("response_type must be one of %v", DefaultResponseTypes),
-			startTime:   startTime,
-			span:        span,
+			description: fmt.Sprintf("response_type must be one of [%s]", strings.Join(DefaultResponseTypes, ", ")),
 			spanError:   "unsupported response_type",
 		})
 		return
@@ -1376,13 +1355,11 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.logger.Error("Failed to start authorization flow", "error", err)
 		instrumentation.RecordError(span, err)
-		h.respondAuthorizationError(w, r, authorizationError{
+		h.respondAuthorizationError(w, r, span, startTime, authorizationError{
 			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeServerError,
 			description: "Failed to start authorization flow",
-			startTime:   startTime,
-			span:        span,
 			spanError:   "authorization flow failed",
 		})
 		return
@@ -1400,13 +1377,11 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	parsedAuthURL, err := url.Parse(authURL)
 	if err != nil || (parsedAuthURL.Scheme != "https" && parsedAuthURL.Scheme != "http") {
 		h.logger.Error("Provider returned invalid authorization URL", "error", err)
-		h.respondAuthorizationError(w, r, authorizationError{
+		h.respondAuthorizationError(w, r, span, startTime, authorizationError{
 			redirectURI: canonicalRedirectURI,
 			state:       state,
 			code:        ErrorCodeServerError,
 			description: "Failed to start authorization flow",
-			startTime:   startTime,
-			span:        span,
 			spanError:   "invalid authorization URL",
 		})
 		return
@@ -2258,48 +2233,80 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 	})
 }
 
-// authorizationError carries the parameters for an RFC 6749 §4.1.2.1 error
-// returned by the /authorize endpoint.
+// authorizationError carries the OAuth error fields for an RFC 6749 §4.1.2.1
+// error returned by the /authorize endpoint. redirectURI is the canonical
+// allowlisted target from ValidateRedirectURIForAuthorization. spanError is
+// the short reason recorded on the tracing span.
 type authorizationError struct {
-	redirectURI string
+	redirectURI *url.URL
 	state       string
 	code        string
 	description string
-	startTime   time.Time
-	span        trace.Span
 	spanError   string
 }
 
 // respondAuthorizationError redirects (302) to redirectURI with
-// error / error_description / state per RFC 6749 §4.1.2.1, or returns JSON 400
-// when redirectURI is not http(s). Custom URL schemes admitted by
-// Config.AllowedCustomSchemes (RFC 8252 native apps) fall back to JSON 400.
-func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Request, e authorizationError) {
-	instrumentation.SetSpanError(e.span, e.spanError)
+// error / error_description / state per RFC 6749 §4.1.2.1. When redirectURI
+// is nil or uses a custom scheme admitted by Config.AllowedCustomSchemes
+// (RFC 8252 native apps), it falls back to JSON 400 because the spec only
+// requires redirect for http(s) targets.
+func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Request, span trace.Span, startTime time.Time, e authorizationError) {
+	instrumentation.SetSpanError(span, e.spanError)
 	instrumentation.SetSpanAttributes(
-		e.span,
+		span,
 		attribute.String(instrumentation.AttrError, e.code),
 		attribute.String(instrumentation.AttrErrorDescription, e.description),
 	)
 
-	parsed, err := url.Parse(e.redirectURI)
-	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") {
-		h.recordHTTPMetrics(r.Context(), endpointAuthorize, r.Method, http.StatusBadRequest, e.startTime)
+	if e.redirectURI == nil || (e.redirectURI.Scheme != "https" && e.redirectURI.Scheme != "http") {
+		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
 		h.writeError(w, e.code, e.description, http.StatusBadRequest)
 		return
 	}
 
-	q := parsed.Query()
+	redirect := *e.redirectURI
+	q := redirect.Query()
 	q.Set("error", e.code)
 	q.Set("error_description", e.description)
 	if e.state != "" {
 		q.Set("state", e.state)
 	}
-	parsed.RawQuery = q.Encode()
+	redirect.RawQuery = q.Encode()
 
-	h.recordHTTPMetrics(r.Context(), endpointAuthorize, r.Method, http.StatusFound, e.startTime)
+	h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusFound, startTime)
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
-	http.Redirect(w, r, parsed.String(), http.StatusFound)
+	http.Redirect(w, r, redirect.String(), http.StatusFound)
+}
+
+// authorizationStateRejection describes a state-parameter failure suitable
+// for the /authorize redirect error response.
+type authorizationStateRejection struct {
+	description string
+	spanError   string
+}
+
+// checkAuthorizationStateParam enforces the CSRF state-parameter rule at the
+// HTTP layer. Returns nil when state is acceptable (or when
+// AllowNoStateParameter is set for clients that cannot send state).
+func (h *Handler) checkAuthorizationStateParam(state, clientID string) *authorizationStateRejection {
+	if h.server.Config.AllowNoStateParameter {
+		return nil
+	}
+	if state == "" {
+		h.logger.Info("Authorization request rejected: state parameter missing", "client_id", clientID)
+		return &authorizationStateRejection{
+			description: "state parameter is required for CSRF protection",
+			spanError:   "state missing",
+		}
+	}
+	if len(state) < MinStateLength {
+		h.logger.Warn("Authorization request rejected: state parameter too short", "state_length", len(state), "min_required", MinStateLength, "client_id", clientID)
+		return &authorizationStateRejection{
+			description: fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength),
+			spanError:   "state too short",
+		}
+	}
+	return nil
 }
 
 // writeUnauthorizedError writes a 401 Unauthorized response with endpoint-specific scope guidance.

--- a/handler.go
+++ b/handler.go
@@ -1293,7 +1293,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	// Extract OIDC parameters for upstream IdP forwarding
 	authOpts, err := parseOIDCOptions(r.URL.Query())
 	if err != nil {
-		h.recordHTTPMetrics(r.Context(), "authorization", http.MethodGet, http.StatusBadRequest, startTime)
+		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
 		instrumentation.SetSpanError(span, "invalid OIDC parameter")
 		h.writeError(w, ErrorCodeInvalidRequest, err.Error(), http.StatusBadRequest)
 		return

--- a/handler.go
+++ b/handler.go
@@ -1298,23 +1298,59 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Authoritativeness gate: client + redirect_uri must be registered before
+	// any subsequent error branch is allowed to redirect to redirectURI. Per
+	// RFC 6749 §4.1.2.1 + §3.1.2.4 errors are returned to redirect_uri only
+	// when that URI is the client's registered value.
+	if err := h.server.ValidateRedirectURIForAuthorization(r.Context(), clientID, redirectURI); err != nil {
+		h.logger.Info("Authorization request rejected: invalid client or redirect_uri", "client_id", clientID, "error", err)
+		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "invalid client or redirect_uri")
+		h.writeError(w, ErrorCodeInvalidRequest, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	// CRITICAL SECURITY: State parameter is required for CSRF protection
 	// Input validation at HTTP layer to return proper status codes
 	// Can be disabled for clients that don't support state (e.g., some MCP clients)
 	if state == "" && !h.server.Config.AllowNoStateParameter {
 		h.logger.Info("Authorization request rejected: state parameter missing", "client_id", clientID)
-		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeInvalidRequest, "state parameter is required for CSRF protection", startTime, span, "state missing")
+		h.respondAuthorizationError(w, r, authorizationError{
+			redirectURI: redirectURI,
+			state:       state,
+			code:        ErrorCodeInvalidRequest,
+			description: "state parameter is required for CSRF protection",
+			startTime:   startTime,
+			span:        span,
+			spanError:   "state missing",
+		})
 		return
 	}
 	if state != "" && len(state) < MinStateLength && !h.server.Config.AllowNoStateParameter {
 		h.logger.Warn("Authorization request rejected: state parameter too short", "state_length", len(state), "min_required", MinStateLength, "client_id", clientID)
-		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeInvalidRequest, fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength), startTime, span, "state too short")
+		h.respondAuthorizationError(w, r, authorizationError{
+			redirectURI: redirectURI,
+			state:       state,
+			code:        ErrorCodeInvalidRequest,
+			description: fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength),
+			startTime:   startTime,
+			span:        span,
+			spanError:   "state too short",
+		})
 		return
 	}
 
 	if responseType != "code" {
 		h.logger.Info("Authorization request rejected: unsupported response_type", "response_type", responseType, "client_id", clientID)
-		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeUnsupportedResponseType, "response_type must be \"code\"", startTime, span, "unsupported response_type")
+		h.respondAuthorizationError(w, r, authorizationError{
+			redirectURI: redirectURI,
+			state:       state,
+			code:        ErrorCodeUnsupportedResponseType,
+			description: `response_type must be "code"`,
+			startTime:   startTime,
+			span:        span,
+			spanError:   "unsupported response_type",
+		})
 		return
 	}
 
@@ -1332,7 +1368,15 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.logger.Error("Failed to start authorization flow", "error", err)
 		instrumentation.RecordError(span, err)
-		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeServerError, "Failed to start authorization flow", startTime, span, "authorization flow failed")
+		h.respondAuthorizationError(w, r, authorizationError{
+			redirectURI: redirectURI,
+			state:       state,
+			code:        ErrorCodeServerError,
+			description: "Failed to start authorization flow",
+			startTime:   startTime,
+			span:        span,
+			spanError:   "authorization flow failed",
+		})
 		return
 	}
 
@@ -1348,7 +1392,15 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	parsedAuthURL, err := url.Parse(authURL)
 	if err != nil || (parsedAuthURL.Scheme != "https" && parsedAuthURL.Scheme != "http") {
 		h.logger.Error("Provider returned invalid authorization URL", "error", err)
-		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeServerError, "Failed to start authorization flow", startTime, span, "invalid authorization URL")
+		h.respondAuthorizationError(w, r, authorizationError{
+			redirectURI: redirectURI,
+			state:       state,
+			code:        ErrorCodeServerError,
+			description: "Failed to start authorization flow",
+			startTime:   startTime,
+			span:        span,
+			spanError:   "invalid authorization URL",
+		})
 		return
 	}
 	// #nosec G710 -- authURL is built by the configured provider's
@@ -2198,44 +2250,54 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 	})
 }
 
-// respondAuthorizationError redirects (302) to redirectURI with error /
-// error_description / state when the URI is a valid http(s) URL. When it is
-// missing or non-http(s) it falls back to a JSON 400 to avoid an open-redirect
-// gadget against an unvalidated URI.
-func (h *Handler) respondAuthorizationError(
-	w http.ResponseWriter,
-	r *http.Request,
-	redirectURI, state, code, description string,
-	startTime time.Time,
-	span trace.Span,
-	spanError string,
-) {
-	instrumentation.SetSpanError(span, spanError)
+// authorizationError carries the parameters for an RFC 6749 §4.1.2.1 error
+// returned by the /authorize endpoint.
+type authorizationError struct {
+	redirectURI string
+	state       string
+	code        string
+	description string
+	startTime   time.Time
+	span        trace.Span
+	spanError   string
+}
+
+// respondAuthorizationError redirects (302) to a registered http(s)
+// redirectURI with error / error_description / state per RFC 6749 §4.1.2.1.
+// Falls back to JSON 400 when redirectURI is not http(s).
+//
+// Callers MUST validate redirectURI against the client's registered URIs
+// before invoking this helper — see Server.ValidateRedirectURIForAuthorization.
+// The scheme gate below is defence-in-depth, not the primary authoritativeness
+// check.
+func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Request, e authorizationError) {
+	instrumentation.SetSpanError(e.span, e.spanError)
 	instrumentation.SetSpanAttributes(
-		span,
-		attribute.String(instrumentation.AttrError, code),
-		attribute.String(instrumentation.AttrErrorDescription, description),
+		e.span,
+		attribute.String(instrumentation.AttrError, e.code),
+		attribute.String(instrumentation.AttrErrorDescription, e.description),
 	)
 
-	parsed, err := url.Parse(redirectURI)
-	if err != nil || redirectURI == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
-		h.recordHTTPMetrics(r.Context(), "authorization", http.MethodGet, http.StatusBadRequest, startTime)
-		h.writeError(w, code, description, http.StatusBadRequest)
+	parsed, err := url.Parse(e.redirectURI)
+	if err != nil || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		h.recordHTTPMetrics(r.Context(), endpointAuthorize, r.Method, http.StatusBadRequest, e.startTime)
+		h.writeError(w, e.code, e.description, http.StatusBadRequest)
 		return
 	}
 
 	q := parsed.Query()
-	q.Set("error", code)
-	q.Set("error_description", description)
-	if state != "" {
-		q.Set("state", state)
+	q.Set("error", e.code)
+	q.Set("error_description", e.description)
+	if e.state != "" {
+		q.Set("state", e.state)
 	}
 	parsed.RawQuery = q.Encode()
 
-	h.recordHTTPMetrics(r.Context(), "authorization", http.MethodGet, http.StatusFound, startTime)
+	h.recordHTTPMetrics(r.Context(), endpointAuthorize, r.Method, http.StatusFound, e.startTime)
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
-	// #nosec G710 -- redirect target was parsed and scheme-restricted to http(s)
-	// above; not an open redirect.
+	// #nosec G710 -- redirect target is the client's registered redirect_uri
+	// (authoritativeness verified by Server.ValidateRedirectURIForAuthorization
+	// before this helper is reached) and scheme-restricted to http(s).
 	http.Redirect(w, r, parsed.String(), http.StatusFound)
 }
 

--- a/handler.go
+++ b/handler.go
@@ -2268,8 +2268,13 @@ type authorizationError struct {
 //
 // Callers MUST validate redirectURI against the client's registered URIs
 // before invoking this helper — see Server.ValidateRedirectURIForAuthorization.
-// The scheme gate below is defence-in-depth, not the primary authoritativeness
-// check.
+// The scheme gate is intentionally narrower than the authoritativeness check:
+// it accepts only http(s) so a misregistered registration can't be coaxed into
+// emitting a 302 with arbitrary scheme. Custom URL schemes admitted by
+// Config.AllowedCustomSchemes (RFC 8252 native apps) therefore receive a
+// JSON 400 here even though the success path issues an interstitial for them
+// — that gap matches the pre-PR error behaviour. A follow-up should mirror
+// serveSuccessInterstitial for the error path; not in scope for #303.
 func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Request, e authorizationError) {
 	instrumentation.SetSpanError(e.span, e.spanError)
 	instrumentation.SetSpanAttributes(

--- a/handler.go
+++ b/handler.go
@@ -1286,6 +1286,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	state := r.URL.Query().Get("state")
 	codeChallenge := r.URL.Query().Get("code_challenge")
 	codeChallengeMethod := r.URL.Query().Get("code_challenge_method")
+	responseType := r.URL.Query().Get("response_type")
 
 	// Extract OIDC parameters for upstream IdP forwarding
 	authOpts := parseOIDCOptions(r.URL.Query())
@@ -1302,20 +1303,22 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	// Can be disabled for clients that don't support state (e.g., some MCP clients)
 	if state == "" && !h.server.Config.AllowNoStateParameter {
 		h.logger.Info("Authorization request rejected: state parameter missing", "client_id", clientID)
-		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
-		instrumentation.SetSpanError(span, "state missing")
-		h.writeError(w, ErrorCodeInvalidRequest, "state parameter is required for CSRF protection", http.StatusBadRequest)
+		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeInvalidRequest, "state parameter is required for CSRF protection", startTime, span, "state missing")
 		return
 	}
 	if state != "" && len(state) < MinStateLength && !h.server.Config.AllowNoStateParameter {
 		h.logger.Warn("Authorization request rejected: state parameter too short", "state_length", len(state), "min_required", MinStateLength, "client_id", clientID)
-		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
-		instrumentation.SetSpanError(span, "state too short")
-		h.writeError(w, ErrorCodeInvalidRequest, fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength), http.StatusBadRequest)
+		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeInvalidRequest, fmt.Sprintf("state parameter must be at least %d characters for security", MinStateLength), startTime, span, "state too short")
 		return
 	}
 
-	responseType := r.URL.Query().Get("response_type")
+	// RFC 6749 §3.1.1: only "code" response_type is supported; AS metadata
+	// advertises response_types_supported: ["code"].
+	if responseType != "code" {
+		h.logger.Info("Authorization request rejected: unsupported response_type", "response_type", responseType, "client_id", clientID)
+		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeUnsupportedResponseType, "response_type must be \"code\"", startTime, span, "unsupported response_type")
+		return
+	}
 
 	// Add attributes to span
 	instrumentation.SetSpanAttributes(
@@ -1330,10 +1333,8 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	authURL, err := h.server.StartAuthorizationFlow(r.Context(), clientID, redirectURI, scope, resource, codeChallenge, codeChallengeMethod, state, authOpts)
 	if err != nil {
 		h.logger.Error("Failed to start authorization flow", "error", err)
-		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusInternalServerError, startTime)
 		instrumentation.RecordError(span, err)
-		instrumentation.SetSpanError(span, "authorization flow failed")
-		h.writeError(w, ErrorCodeServerError, "Failed to start authorization flow", http.StatusInternalServerError)
+		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeServerError, "Failed to start authorization flow", startTime, span, "authorization flow failed")
 		return
 	}
 
@@ -1349,9 +1350,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	parsedAuthURL, err := url.Parse(authURL)
 	if err != nil || (parsedAuthURL.Scheme != "https" && parsedAuthURL.Scheme != "http") {
 		h.logger.Error("Provider returned invalid authorization URL", "error", err)
-		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusInternalServerError, startTime)
-		instrumentation.SetSpanError(span, "invalid authorization URL")
-		h.writeError(w, ErrorCodeServerError, "Failed to start authorization flow", http.StatusInternalServerError)
+		h.respondAuthorizationError(w, r, redirectURI, state, ErrorCodeServerError, "Failed to start authorization flow", startTime, span, "invalid authorization URL")
 		return
 	}
 	// #nosec G710 -- authURL is built by the configured provider's
@@ -2199,6 +2198,49 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 		"error":             code,
 		"error_description": description,
 	})
+}
+
+// respondAuthorizationError handles RFC 6749 §4.1.2.1 error returns from the
+// authorization endpoint. When the redirect URI parses as an http(s) URL it
+// appends error / error_description / state and redirects (302); otherwise it
+// falls back to the JSON 400 path because the spec forbids redirecting to a
+// missing or non-http(s) redirect URI.
+func (h *Handler) respondAuthorizationError(
+	w http.ResponseWriter,
+	r *http.Request,
+	redirectURI, state, code, description string,
+	startTime time.Time,
+	span trace.Span,
+	spanError string,
+) {
+	instrumentation.SetSpanError(span, spanError)
+	instrumentation.SetSpanAttributes(
+		span,
+		attribute.String(instrumentation.AttrError, code),
+		attribute.String(instrumentation.AttrErrorDescription, description),
+	)
+
+	parsed, err := url.Parse(redirectURI)
+	if err != nil || redirectURI == "" || (parsed.Scheme != "https" && parsed.Scheme != "http") {
+		h.recordHTTPMetrics(r.Context(), "authorization", http.MethodGet, http.StatusBadRequest, startTime)
+		h.writeError(w, code, description, http.StatusBadRequest)
+		return
+	}
+
+	q := parsed.Query()
+	q.Set("error", code)
+	q.Set("error_description", description)
+	if state != "" {
+		q.Set("state", state)
+	}
+	parsed.RawQuery = q.Encode()
+
+	h.recordHTTPMetrics(r.Context(), "authorization", http.MethodGet, http.StatusFound, startTime)
+	security.SetSecurityHeaders(w, h.server.Config.Issuer)
+	// #nosec G710 -- redirect target is the client-supplied redirect_uri parsed
+	// and scheme-checked above. RFC 6749 §4.1.2.1 mandates redirecting errors
+	// to redirect_uri so the client can correlate them with the request.
+	http.Redirect(w, r, parsed.String(), http.StatusFound)
 }
 
 // writeUnauthorizedError writes a 401 Unauthorized response with endpoint-specific scope guidance.

--- a/handler_test.go
+++ b/handler_test.go
@@ -2735,8 +2735,6 @@ func TestHandler_ServeAuthorization_ShortStateWithAllowNoState(t *testing.T) {
 	}
 }
 
-// assertAuthorizationErrorRedirect asserts a 302 redirect to expectedRedirect
-// with error, error_description, and state query parameters.
 func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder, expectedRedirect, expectedErrorCode, expectedState string) {
 	t.Helper()
 
@@ -2777,7 +2775,7 @@ func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder
 	}
 }
 
-func TestServeAuthorization_NoResponseType_Rejected(t *testing.T) {
+func TestHandler_ServeAuthorization_NoResponseType_Rejected(t *testing.T) {
 	ctx := context.Background()
 	handler, store := setupTestHandler(t)
 	defer store.Stop()
@@ -2830,7 +2828,7 @@ func TestServeAuthorization_NoResponseType_Rejected(t *testing.T) {
 	}
 }
 
-func TestServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) {
+func TestHandler_ServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) {
 	ctx := context.Background()
 	handler, store := setupTestHandler(t)
 	defer store.Stop()
@@ -2850,22 +2848,19 @@ func TestServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) 
 	}
 
 	tests := []struct {
-		name        string
-		state       string
-		wantState   string // empty when the client did not send a state parameter
-		description string
+		name      string
+		state     string
+		wantState string // empty when the client did not send a state parameter
 	}{
 		{
-			name:        "state missing",
-			state:       "",
-			wantState:   "",
-			description: "missing state must redirect with invalid_request",
+			name:      "state missing",
+			state:     "",
+			wantState: "",
 		},
 		{
-			name:        "state too short",
-			state:       "short",
-			wantState:   "short",
-			description: "state below MinStateLength must redirect with invalid_request and echo the client state",
+			name:      "state too short",
+			state:     "short",
+			wantState: "short",
 		},
 	}
 
@@ -2926,6 +2921,37 @@ func TestServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) 
 
 		if w.Code != http.StatusBadRequest {
 			t.Errorf("status = %d, want %d (non-http redirect_uri must JSON-error)", w.Code, http.StatusBadRequest)
+		}
+	})
+
+	// Scheme-valid http(s) URL not registered for the client: must JSON-error,
+	// not redirect — otherwise /authorize error branches become an open-redirect
+	// gadget under RFC 6749 §4.1.2.1 + §3.1.2.4.
+	t.Run("scheme-valid but unregistered redirect_uri must JSON-error", func(t *testing.T) {
+		reqURL := "/authorize?client_id=" + client.ClientID +
+			"&redirect_uri=" + url.QueryEscape("https://attacker.example/landing") +
+			"&response_type=xxx" + // would otherwise hit the response_type branch
+			"&scope=openid" +
+			"&state=" + testutil.GenerateRandomString(43) +
+			"&code_challenge=test-challenge" +
+			"&code_challenge_method=S256"
+
+		req := httptest.NewRequest(http.MethodGet, reqURL, nil)
+		w := httptest.NewRecorder()
+		handler.ServeAuthorization(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+		}
+		if loc := w.Header().Get("Location"); loc != "" {
+			t.Errorf("Location header set to %q; unregistered redirect_uri must not redirect", loc)
+		}
+		var body map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("response body is not JSON: %v", err)
+		}
+		if body["error"] != ErrorCodeInvalidRequest {
+			t.Errorf("error = %q, want %q", body["error"], ErrorCodeInvalidRequest)
 		}
 	})
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -2556,46 +2556,44 @@ func TestHandler_ServeAuthorization_StateLength(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		state      string
-		wantStatus int
-		wantError  bool
+		name           string
+		state          string
+		wantStatus     int
+		wantErrorParam string // expected OAuth error code in redirect query (empty when expecting success or non-redirect)
 	}{
 		{
-			name:       "state too short (1 char)",
-			state:      "x",
-			wantStatus: http.StatusBadRequest,
-			wantError:  true,
+			name:           "state too short (1 char)",
+			state:          "x",
+			wantStatus:     http.StatusFound,
+			wantErrorParam: ErrorCodeInvalidRequest,
 		},
 		{
-			name:       "state too short (10 chars)",
-			state:      "0123456789",
-			wantStatus: http.StatusBadRequest,
-			wantError:  true,
+			name:           "state too short (10 chars)",
+			state:          "0123456789",
+			wantStatus:     http.StatusFound,
+			wantErrorParam: ErrorCodeInvalidRequest,
 		},
 		{
-			name:       "state too short (23 chars, just under minimum)",
-			state:      "01234567890123456789012",
-			wantStatus: http.StatusBadRequest,
-			wantError:  true,
+			name:           "state too short (23 chars, just under minimum)",
+			state:          "01234567890123456789012",
+			wantStatus:     http.StatusFound,
+			wantErrorParam: ErrorCodeInvalidRequest,
 		},
 		{
 			name:       "state exactly minimum length (24 chars)",
 			state:      "012345678901234567890123",
 			wantStatus: http.StatusFound,
-			wantError:  false,
 		},
 		{
 			name:       "state above minimum length (64 chars)",
 			state:      "0123456789012345678901234567890123456789012345678901234567890123",
 			wantStatus: http.StatusFound,
-			wantError:  false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := fmt.Sprintf("/authorize?client_id=%s&redirect_uri=https://example.com/callback&scope=openid&state=%s&code_challenge=test-challenge&code_challenge_method=S256",
+			url := fmt.Sprintf("/authorize?client_id=%s&redirect_uri=https://example.com/callback&response_type=code&scope=openid&state=%s&code_challenge=test-challenge&code_challenge_method=S256",
 				client.ClientID, tt.state)
 			req := httptest.NewRequest(http.MethodGet, url, nil)
 			w := httptest.NewRecorder()
@@ -2604,6 +2602,10 @@ func TestHandler_ServeAuthorization_StateLength(t *testing.T) {
 
 			if w.Code != tt.wantStatus {
 				t.Errorf("status = %d, want %d", w.Code, tt.wantStatus)
+			}
+
+			if tt.wantErrorParam != "" {
+				assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", tt.wantErrorParam, tt.state)
 			}
 		})
 	}
@@ -2719,7 +2721,7 @@ func TestHandler_ServeAuthorization_ShortStateWithAllowNoState(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			url := fmt.Sprintf("/authorize?client_id=%s&redirect_uri=https://example.com/callback&scope=openid&state=%s&code_challenge=test-challenge&code_challenge_method=S256",
+			url := fmt.Sprintf("/authorize?client_id=%s&redirect_uri=https://example.com/callback&response_type=code&scope=openid&state=%s&code_challenge=test-challenge&code_challenge_method=S256",
 				client.ClientID, tt.state)
 			req := httptest.NewRequest(http.MethodGet, url, nil)
 			w := httptest.NewRecorder()
@@ -2731,6 +2733,202 @@ func TestHandler_ServeAuthorization_ShortStateWithAllowNoState(t *testing.T) {
 			}
 		})
 	}
+}
+
+// assertAuthorizationErrorRedirect verifies that w is a 302 redirect back to
+// expectedRedirect carrying the OAuth error / error_description / state query
+// parameters mandated by RFC 6749 §4.1.2.1.
+func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder, expectedRedirect, expectedErrorCode, expectedState string) {
+	t.Helper()
+
+	if w.Code != http.StatusFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusFound)
+		return
+	}
+
+	location := w.Header().Get("Location")
+	if location == "" {
+		t.Fatal("Location header missing on error redirect")
+	}
+
+	parsed, err := url.Parse(location)
+	if err != nil {
+		t.Fatalf("Location header is not a valid URL: %v", err)
+	}
+
+	expected, err := url.Parse(expectedRedirect)
+	if err != nil {
+		t.Fatalf("expectedRedirect not parseable: %v", err)
+	}
+	if parsed.Scheme != expected.Scheme || parsed.Host != expected.Host || parsed.Path != expected.Path {
+		t.Errorf("redirect target = %s://%s%s, want %s://%s%s",
+			parsed.Scheme, parsed.Host, parsed.Path,
+			expected.Scheme, expected.Host, expected.Path)
+	}
+
+	q := parsed.Query()
+	if got := q.Get("error"); got != expectedErrorCode {
+		t.Errorf("error query param = %q, want %q", got, expectedErrorCode)
+	}
+	if q.Get("error_description") == "" {
+		t.Errorf("error_description query param missing")
+	}
+	if got := q.Get("state"); got != expectedState {
+		t.Errorf("state query param = %q, want %q", got, expectedState)
+	}
+}
+
+func TestServeAuthorization_NoResponseType_Rejected(t *testing.T) {
+	ctx := context.Background()
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	client, _, err := handler.server.RegisterClient(
+		ctx,
+		"Test Client",
+		"confidential",
+		"",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.168.1.100",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("RegisterClient() error = %v", err)
+	}
+
+	validState := testutil.GenerateRandomString(43)
+
+	tests := []struct {
+		name         string
+		responseType string
+	}{
+		{name: "response_type missing", responseType: ""},
+		{name: "response_type=token (implicit flow rejected)", responseType: "token"},
+		{name: "response_type=id_token (OIDC implicit rejected)", responseType: "id_token"},
+		{name: "response_type=code id_token (hybrid rejected)", responseType: "code id_token"},
+		{name: "response_type=unknown", responseType: "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqURL := "/authorize?client_id=" + client.ClientID +
+				"&redirect_uri=https://example.com/callback" +
+				"&scope=openid" +
+				"&state=" + validState +
+				"&code_challenge=test-challenge" +
+				"&code_challenge_method=S256"
+			if tt.responseType != "" {
+				reqURL += "&response_type=" + url.QueryEscape(tt.responseType)
+			}
+
+			req := httptest.NewRequest(http.MethodGet, reqURL, nil)
+			w := httptest.NewRecorder()
+			handler.ServeAuthorization(w, req)
+
+			assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", ErrorCodeUnsupportedResponseType, validState)
+		})
+	}
+}
+
+func TestServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) {
+	ctx := context.Background()
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	client, _, err := handler.server.RegisterClient(
+		ctx,
+		"Test Client",
+		"confidential",
+		"",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.168.1.100",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("RegisterClient() error = %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		state       string
+		wantState   string // state expected in the redirect query (empty for missing-state case)
+		description string
+	}{
+		{
+			name:        "state missing",
+			state:       "",
+			wantState:   "",
+			description: "missing state must redirect with invalid_request",
+		},
+		{
+			name:        "state too short",
+			state:       "short",
+			wantState:   "short",
+			description: "state below MinStateLength must redirect with invalid_request and echo the client state",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reqURL := "/authorize?client_id=" + client.ClientID +
+				"&redirect_uri=https://example.com/callback" +
+				"&response_type=code" +
+				"&scope=openid" +
+				"&code_challenge=test-challenge" +
+				"&code_challenge_method=S256"
+			if tt.state != "" {
+				reqURL += "&state=" + tt.state
+			}
+
+			req := httptest.NewRequest(http.MethodGet, reqURL, nil)
+			w := httptest.NewRecorder()
+			handler.ServeAuthorization(w, req)
+
+			assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", ErrorCodeInvalidRequest, tt.wantState)
+		})
+	}
+
+	t.Run("missing redirect_uri falls back to JSON 400", func(t *testing.T) {
+		reqURL := "/authorize?client_id=" + client.ClientID +
+			"&response_type=code" +
+			"&scope=openid" +
+			"&code_challenge=test-challenge" +
+			"&code_challenge_method=S256"
+
+		req := httptest.NewRequest(http.MethodGet, reqURL, nil)
+		w := httptest.NewRecorder()
+		handler.ServeAuthorization(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d (no parseable redirect_uri must JSON-error)", w.Code, http.StatusBadRequest)
+		}
+		var body map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+			t.Fatalf("response body is not JSON: %v", err)
+		}
+		if body["error"] != ErrorCodeInvalidRequest {
+			t.Errorf("error = %q, want %q", body["error"], ErrorCodeInvalidRequest)
+		}
+	})
+
+	t.Run("non-http redirect_uri falls back to JSON 400", func(t *testing.T) {
+		reqURL := "/authorize?client_id=" + client.ClientID +
+			"&redirect_uri=" + url.QueryEscape("javascript:alert(1)") +
+			"&response_type=code" +
+			"&scope=openid" +
+			"&code_challenge=test-challenge" +
+			"&code_challenge_method=S256"
+
+		req := httptest.NewRequest(http.MethodGet, reqURL, nil)
+		w := httptest.NewRecorder()
+		handler.ServeAuthorization(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("status = %d, want %d (non-http redirect_uri must JSON-error)", w.Code, http.StatusBadRequest)
+		}
+	})
 }
 
 func TestHandler_ServeCallback_ShortProviderStateAlwaysRejected(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -2559,7 +2559,7 @@ func TestHandler_ServeAuthorization_StateLength(t *testing.T) {
 		name           string
 		state          string
 		wantStatus     int
-		wantErrorParam string // expected OAuth error code in redirect query (empty when expecting success or non-redirect)
+		wantErrorParam string // empty when the request is expected to succeed
 	}{
 		{
 			name:           "state too short (1 char)",
@@ -2735,9 +2735,8 @@ func TestHandler_ServeAuthorization_ShortStateWithAllowNoState(t *testing.T) {
 	}
 }
 
-// assertAuthorizationErrorRedirect verifies that w is a 302 redirect back to
-// expectedRedirect carrying the OAuth error / error_description / state query
-// parameters mandated by RFC 6749 §4.1.2.1.
+// assertAuthorizationErrorRedirect asserts a 302 redirect to expectedRedirect
+// with error, error_description, and state query parameters.
 func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder, expectedRedirect, expectedErrorCode, expectedState string) {
 	t.Helper()
 
@@ -2853,7 +2852,7 @@ func TestServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) 
 	tests := []struct {
 		name        string
 		state       string
-		wantState   string // state expected in the redirect query (empty for missing-state case)
+		wantState   string // empty when the client did not send a state parameter
 		description string
 	}{
 		{

--- a/handler_test.go
+++ b/handler_test.go
@@ -2824,8 +2824,6 @@ func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder
 	}
 }
 
-// Regression test for #303: /authorize must enforce response_type=code and
-// reject anything else with unsupported_response_type via the redirect path.
 func TestHandler_ServeAuthorization_NoResponseType_Rejected(t *testing.T) {
 	ctx := context.Background()
 	handler, store := setupTestHandler(t)
@@ -2879,10 +2877,6 @@ func TestHandler_ServeAuthorization_NoResponseType_Rejected(t *testing.T) {
 	}
 }
 
-// Regression test for #303: state-parameter failures redirect to the
-// registered redirect_uri per RFC 6749 §4.1.2.1, but unregistered or
-// non-http(s) redirect_uri values must JSON-error so the error path cannot
-// become an open-redirect gadget (RFC 6749 §3.1.2.4).
 func TestHandler_ServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) {
 	ctx := context.Background()
 	handler, store := setupTestHandler(t)

--- a/handler_test.go
+++ b/handler_test.go
@@ -2652,7 +2652,7 @@ func TestHandler_ServeAuthorization_StateLength(t *testing.T) {
 			}
 
 			if tt.wantErrorParam != "" {
-				assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", tt.wantErrorParam, tt.state)
+				assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", tt.wantErrorParam, "state parameter", tt.state)
 			}
 		})
 	}
@@ -2782,7 +2782,7 @@ func TestHandler_ServeAuthorization_ShortStateWithAllowNoState(t *testing.T) {
 	}
 }
 
-func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder, expectedRedirect, expectedErrorCode, expectedState string) {
+func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder, expectedRedirect, expectedErrorCode, expectedErrorDescriptionSubstr, expectedState string) {
 	t.Helper()
 
 	if w.Code != http.StatusFound {
@@ -2814,14 +2814,18 @@ func assertAuthorizationErrorRedirect(t *testing.T, w *httptest.ResponseRecorder
 	if got := q.Get("error"); got != expectedErrorCode {
 		t.Errorf("error query param = %q, want %q", got, expectedErrorCode)
 	}
-	if q.Get("error_description") == "" {
+	if got := q.Get("error_description"); got == "" {
 		t.Errorf("error_description query param missing")
+	} else if expectedErrorDescriptionSubstr != "" && !strings.Contains(got, expectedErrorDescriptionSubstr) {
+		t.Errorf("error_description = %q, want substring %q", got, expectedErrorDescriptionSubstr)
 	}
 	if got := q.Get("state"); got != expectedState {
 		t.Errorf("state query param = %q, want %q", got, expectedState)
 	}
 }
 
+// Regression test for #303: /authorize must enforce response_type=code and
+// reject anything else with unsupported_response_type via the redirect path.
 func TestHandler_ServeAuthorization_NoResponseType_Rejected(t *testing.T) {
 	ctx := context.Background()
 	handler, store := setupTestHandler(t)
@@ -2870,11 +2874,15 @@ func TestHandler_ServeAuthorization_NoResponseType_Rejected(t *testing.T) {
 			w := httptest.NewRecorder()
 			handler.ServeAuthorization(w, req)
 
-			assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", ErrorCodeUnsupportedResponseType, validState)
+			assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", ErrorCodeUnsupportedResponseType, "response_type must be one of [code]", validState)
 		})
 	}
 }
 
+// Regression test for #303: state-parameter failures redirect to the
+// registered redirect_uri per RFC 6749 §4.1.2.1, but unregistered or
+// non-http(s) redirect_uri values must JSON-error so the error path cannot
+// become an open-redirect gadget (RFC 6749 §3.1.2.4).
 func TestHandler_ServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *testing.T) {
 	ctx := context.Background()
 	handler, store := setupTestHandler(t)
@@ -2927,7 +2935,7 @@ func TestHandler_ServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *tes
 			w := httptest.NewRecorder()
 			handler.ServeAuthorization(w, req)
 
-			assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", ErrorCodeInvalidRequest, tt.wantState)
+			assertAuthorizationErrorRedirect(t, w, "https://example.com/callback", ErrorCodeInvalidRequest, "state parameter", tt.wantState)
 		})
 	}
 
@@ -3001,6 +3009,58 @@ func TestHandler_ServeAuthorization_InvalidRequest_RedirectsToRedirectURI(t *tes
 			t.Errorf("error = %q, want %q", body["error"], ErrorCodeInvalidRequest)
 		}
 	})
+}
+
+// Native-app custom-scheme redirect URIs (RFC 8252 §7.1) cannot carry an HTTP
+// 302 redirect; respondAuthorizationError must fall back to JSON 400 for
+// those clients rather than attempt a Location redirect.
+func TestHandler_ServeAuthorization_CustomSchemeRedirectURI_FallsBackToJSON(t *testing.T) {
+	ctx := context.Background()
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	handler.server.Config.AllowedCustomSchemes = []string{"^myapp$"}
+
+	client, _, err := handler.server.RegisterClient(
+		ctx,
+		"Native App",
+		"public",
+		"",
+		[]string{"myapp://callback"},
+		[]string{"openid"},
+		"192.168.1.100",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("RegisterClient() error = %v", err)
+	}
+
+	validState := testutil.GenerateRandomString(43)
+	reqURL := "/authorize?client_id=" + client.ClientID +
+		"&redirect_uri=" + url.QueryEscape("myapp://callback") +
+		"&response_type=token" +
+		"&scope=openid" +
+		"&state=" + validState +
+		"&code_challenge=test-challenge" +
+		"&code_challenge_method=S256"
+
+	req := httptest.NewRequest(http.MethodGet, reqURL, nil)
+	w := httptest.NewRecorder()
+	handler.ServeAuthorization(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d (custom-scheme redirect_uri must JSON-error)", w.Code, http.StatusBadRequest)
+	}
+	if loc := w.Header().Get("Location"); loc != "" {
+		t.Errorf("Location header set to %q; custom-scheme redirect must not 302", loc)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("response body is not JSON: %v", err)
+	}
+	if body["error"] != ErrorCodeUnsupportedResponseType {
+		t.Errorf("error = %q, want %q", body["error"], ErrorCodeUnsupportedResponseType)
+	}
 }
 
 func TestHandler_ServeCallback_ShortProviderStateAlwaysRejected(t *testing.T) {

--- a/server/flows.go
+++ b/server/flows.go
@@ -836,21 +836,23 @@ func (s *Server) rotateRefreshToken(ctx context.Context, oldRefreshToken, userID
 // resource is the target resource server identifier per RFC 8707 (optional for backward compatibility)
 // authOpts contains optional OIDC parameters (prompt, login_hint, id_token_hint) for upstream IdP forwarding
 // ValidateRedirectURIForAuthorization runs the client lookup and registered
-// redirect-URI check that StartAuthorizationFlow performs. Handlers must
-// invoke it before redirecting any /authorize error to redirectURI: until
-// both checks pass redirectURI is attacker-controllable and a redirect would
-// be an open-redirect gadget under RFC 6749 §4.1.2.1 + §3.1.2.4.
-func (s *Server) ValidateRedirectURIForAuthorization(ctx context.Context, clientID, redirectURI string) error {
+// redirect-URI check that StartAuthorizationFlow performs. Returns the
+// canonical URI from client.RedirectURIs on success; the handler MUST use
+// that value as the redirect target so open-redirect static analysis can see
+// the allowlist match. RFC 6749 §4.1.2.1 + §3.1.2.4: until both checks pass
+// the request URI is attacker-controllable.
+func (s *Server) ValidateRedirectURIForAuthorization(ctx context.Context, clientID, redirectURI string) (string, error) {
 	client, err := s.getOrFetchClient(ctx, clientID)
 	if err != nil {
 		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidClient)
-		return fmt.Errorf("%s: %w", ErrorCodeInvalidClient, err)
+		return "", fmt.Errorf("%s: %w", ErrorCodeInvalidClient, err)
 	}
-	if err := s.validateRedirectURI(client, redirectURI); err != nil {
+	canonical, err := s.resolveRegisteredRedirectURI(client, redirectURI)
+	if err != nil {
 		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidRedirectURI)
-		return fmt.Errorf("%s: %w", ErrorCodeInvalidRedirectURI, err)
+		return "", fmt.Errorf("%s: %w", ErrorCodeInvalidRedirectURI, err)
 	}
-	return nil
+	return canonical, nil
 }
 
 func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectURI, scope, resource, codeChallenge, codeChallengeMethod, clientState string, authOpts *providers.AuthorizationURLOptions) (string, error) {

--- a/server/flows.go
+++ b/server/flows.go
@@ -835,6 +835,24 @@ func (s *Server) rotateRefreshToken(ctx context.Context, oldRefreshToken, userID
 // clientState is the state parameter from the client (REQUIRED for CSRF protection)
 // resource is the target resource server identifier per RFC 8707 (optional for backward compatibility)
 // authOpts contains optional OIDC parameters (prompt, login_hint, id_token_hint) for upstream IdP forwarding
+// ValidateRedirectURIForAuthorization runs the client lookup and registered
+// redirect-URI check that StartAuthorizationFlow performs. Handlers must
+// invoke it before redirecting any /authorize error to redirectURI: until
+// both checks pass redirectURI is attacker-controllable and a redirect would
+// be an open-redirect gadget under RFC 6749 §4.1.2.1 + §3.1.2.4.
+func (s *Server) ValidateRedirectURIForAuthorization(ctx context.Context, clientID, redirectURI string) error {
+	client, err := s.getOrFetchClient(ctx, clientID)
+	if err != nil {
+		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidClient)
+		return fmt.Errorf("%s: %w", ErrorCodeInvalidClient, err)
+	}
+	if err := s.validateRedirectURI(client, redirectURI); err != nil {
+		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidRedirectURI)
+		return fmt.Errorf("%s: %w", ErrorCodeInvalidRedirectURI, err)
+	}
+	return nil
+}
+
 func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectURI, scope, resource, codeChallenge, codeChallengeMethod, clientState string, authOpts *providers.AuthorizationURLOptions) (string, error) {
 	// CRITICAL SECURITY: Validate state parameter from client for CSRF protection
 	if err := s.validateClientStateParameter(clientState); err != nil {

--- a/server/flows.go
+++ b/server/flows.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"fmt"
 	"math"
+	"net/url"
 	"strings"
 	"time"
 
@@ -831,30 +832,33 @@ func (s *Server) rotateRefreshToken(ctx context.Context, oldRefreshToken, userID
 	return newRefreshToken, familyID, true
 }
 
-// StartAuthorizationFlow starts a new OAuth authorization flow
-// clientState is the state parameter from the client (REQUIRED for CSRF protection)
-// resource is the target resource server identifier per RFC 8707 (optional for backward compatibility)
-// authOpts contains optional OIDC parameters (prompt, login_hint, id_token_hint) for upstream IdP forwarding
-// ValidateRedirectURIForAuthorization runs the client lookup and registered
-// redirect-URI check that StartAuthorizationFlow performs. Returns the
-// canonical URI from client.RedirectURIs on success; the handler MUST use
-// that value as the redirect target so open-redirect static analysis can see
-// the allowlist match. RFC 6749 §4.1.2.1 + §3.1.2.4: until both checks pass
-// the request URI is attacker-controllable.
-func (s *Server) ValidateRedirectURIForAuthorization(ctx context.Context, clientID, redirectURI string) (string, error) {
+// ValidateRedirectURIForAuthorization resolves the redirect URI to its
+// canonical, registered form for the client. Callers redirecting /authorize
+// protocol errors back to the client MUST use this return value as the
+// redirect target — it provably originates from server-side storage, not from
+// the request, satisfying RFC 6749 §3.1.2.4.
+func (s *Server) ValidateRedirectURIForAuthorization(ctx context.Context, clientID, redirectURI string) (*url.URL, error) {
 	client, err := s.getOrFetchClient(ctx, clientID)
 	if err != nil {
 		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidClient)
-		return "", fmt.Errorf("%s: %w", ErrorCodeInvalidClient, err)
+		return nil, fmt.Errorf("%s: %w", ErrorCodeInvalidClient, err)
 	}
 	canonical, err := s.resolveRegisteredRedirectURI(client, redirectURI)
 	if err != nil {
 		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidRedirectURI)
-		return "", fmt.Errorf("%s: %w", ErrorCodeInvalidRedirectURI, err)
+		return nil, fmt.Errorf("%s: %w", ErrorCodeInvalidRedirectURI, err)
 	}
-	return canonical, nil
+	parsed, err := url.Parse(canonical)
+	if err != nil {
+		return nil, fmt.Errorf("%s: canonical redirect URI is not a valid URL: %w", ErrorCodeInvalidRedirectURI, err)
+	}
+	return parsed, nil
 }
 
+// StartAuthorizationFlow starts a new OAuth authorization flow.
+// clientState is the state parameter from the client (REQUIRED for CSRF protection).
+// resource is the target resource server identifier per RFC 8707 (optional for backward compatibility).
+// authOpts contains optional OIDC parameters (prompt, login_hint, id_token_hint) for upstream IdP forwarding.
 func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectURI, scope, resource, codeChallenge, codeChallengeMethod, clientState string, authOpts *providers.AuthorizationURLOptions) (string, error) {
 	// CRITICAL SECURITY: Validate state parameter from client for CSRF protection
 	if err := s.validateClientStateParameter(clientState); err != nil {

--- a/server/flows_redirect_uri_test.go
+++ b/server/flows_redirect_uri_test.go
@@ -1,0 +1,118 @@
+package server
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestServer_ValidateRedirectURIForAuthorization(t *testing.T) {
+	ctx := context.Background()
+	srv, _, _ := setupFlowTestServer(t)
+	srv.Config.AllowLocalhostRedirectURIs = true
+
+	client, _, err := srv.RegisterClient(
+		ctx,
+		"client",
+		ClientTypePublic,
+		"",
+		[]string{"http://localhost/callback"},
+		[]string{"openid"},
+		"192.168.1.100",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("RegisterClient() error = %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		clientID    string
+		redirectURI string
+		want        string // expected canonical URI string; empty if error expected
+		errContains string // expected substring of err.Error(); empty if success
+	}{
+		{
+			name:        "exact match returns canonical URI",
+			clientID:    client.ClientID,
+			redirectURI: "http://localhost/callback",
+			want:        "http://localhost/callback",
+		},
+		{
+			name:        "unknown client_id yields invalid_client",
+			clientID:    "does-not-exist",
+			redirectURI: "http://localhost/callback",
+			errContains: ErrorCodeInvalidClient,
+		},
+		{
+			name:        "empty client_id yields invalid_client",
+			clientID:    "",
+			redirectURI: "http://localhost/callback",
+			errContains: ErrorCodeInvalidClient,
+		},
+		{
+			name:        "unregistered redirect_uri yields invalid_redirect_uri",
+			clientID:    client.ClientID,
+			redirectURI: "http://localhost/elsewhere",
+			errContains: ErrorCodeInvalidRedirectURI,
+		},
+		{
+			name:        "empty redirect_uri yields invalid_redirect_uri",
+			clientID:    client.ClientID,
+			redirectURI: "",
+			errContains: ErrorCodeInvalidRedirectURI,
+		},
+		{
+			name:        "scheme mismatch yields invalid_redirect_uri",
+			clientID:    client.ClientID,
+			redirectURI: "https://localhost/callback",
+			errContains: ErrorCodeInvalidRedirectURI,
+		},
+		{
+			name:        "loopback port-agnostic match preserves request port (RFC 8252 §7.3)",
+			clientID:    client.ClientID,
+			redirectURI: "http://localhost:54123/callback",
+			want:        "http://localhost:54123/callback",
+		},
+		{
+			name:        "loopback path mismatch yields invalid_redirect_uri",
+			clientID:    client.ClientID,
+			redirectURI: "http://localhost:54123/other",
+			errContains: ErrorCodeInvalidRedirectURI,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := srv.ValidateRedirectURIForAuthorization(ctx, tt.clientID, tt.redirectURI)
+
+			if tt.errContains != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil (canonical=%v)", tt.errContains, got)
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tt.errContains)
+				}
+				if got != nil {
+					t.Errorf("expected nil canonical URL on error, got %v", got)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error = %v", err)
+			}
+			if got == nil {
+				t.Fatal("expected non-nil canonical URL on success")
+			}
+			wantURL, parseErr := url.Parse(tt.want)
+			if parseErr != nil {
+				t.Fatalf("test wantURL not parseable: %v", parseErr)
+			}
+			if got.String() != wantURL.String() {
+				t.Errorf("canonical = %q, want %q", got.String(), wantURL.String())
+			}
+		})
+	}
+}

--- a/server/validation.go
+++ b/server/validation.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -175,29 +176,40 @@ func isLocalhostHostname(hostname string) bool {
 //
 // For all other URIs, exact string matching is used per OAuth 2.1.
 func (s *Server) validateRedirectURI(client *storage.Client, redirectURI string) error {
-	// First check if URI is registered
-	found := false
+	_, err := s.resolveRegisteredRedirectURI(client, redirectURI)
+	return err
+}
+
+// resolveRegisteredRedirectURI returns the canonical URI from
+// client.RedirectURIs that matches redirectURI under the same rules as
+// validateRedirectURI: exact match by default, plus optional RFC 8252 §7.3
+// port-agnostic loopback match when AllowLocalhostRedirectURIs is set. For
+// loopback the canonical URI substitutes the request's port into the
+// registered scheme/host/path so the bound native-app port survives the
+// round-trip; for non-loopback the canonical URI is the registered element
+// verbatim. Callers writing the URI back into a redirect Location header
+// should pass the canonical value so the redirect target provably originates
+// from server-controlled storage.
+func (s *Server) resolveRegisteredRedirectURI(client *storage.Client, redirectURI string) (string, error) {
 	for _, uri := range client.RedirectURIs {
 		if uri == redirectURI {
-			found = true
-			break
+			if err := validateRedirectURISecurityEnhanced(uri, s.Config.Issuer, s.Config.AllowedCustomSchemes); err != nil {
+				return "", err
+			}
+			return uri, nil
 		}
 	}
 
-	// If exact match failed and localhost redirect URIs are allowed,
-	// try RFC 8252 port-agnostic matching for loopback addresses
-	if !found && s.Config.AllowLocalhostRedirectURIs {
-		if matchesLoopbackRedirectURI(redirectURI, client.RedirectURIs) {
-			found = true
+	if s.Config.AllowLocalhostRedirectURIs {
+		if canonical, ok := canonicalLoopbackRedirectURI(redirectURI, client.RedirectURIs); ok {
+			if err := validateRedirectURISecurityEnhanced(canonical, s.Config.Issuer, s.Config.AllowedCustomSchemes); err != nil {
+				return "", err
+			}
+			return canonical, nil
 		}
 	}
 
-	if !found {
-		return fmt.Errorf("redirect URI not registered for client")
-	}
-
-	// Perform security validation on the URI with custom scheme support
-	return validateRedirectURISecurityEnhanced(redirectURI, s.Config.Issuer, s.Config.AllowedCustomSchemes)
+	return "", fmt.Errorf("redirect URI not registered for client")
 }
 
 // matchesLoopbackRedirectURI checks if a redirect URI matches any registered URI
@@ -216,43 +228,52 @@ func (s *Server) validateRedirectURI(client *storage.Client, redirectURI string)
 // targets a loopback address (localhost, 127.0.0.0/8, ::1). Non-loopback URIs are
 // never matched by this function — they require exact string matching.
 func matchesLoopbackRedirectURI(requestedURI string, registeredURIs []string) bool {
+	_, ok := canonicalLoopbackRedirectURI(requestedURI, registeredURIs)
+	return ok
+}
+
+// canonicalLoopbackRedirectURI returns the canonical URI for a loopback
+// port-agnostic match (RFC 8252 §7.3 + §8.3). Scheme, host, and path are
+// taken from the matched registered URI; only the port is taken from the
+// request (the native app binds an ephemeral port, so RFC 8252 mandates the
+// request port wins on the redirect leg). Returns ok=false when no registered
+// loopback URI matches.
+func canonicalLoopbackRedirectURI(requestedURI string, registeredURIs []string) (string, bool) {
 	parsed, err := url.Parse(requestedURI)
 	if err != nil {
-		return false
+		return "", false
 	}
-
-	// Only apply port-agnostic matching for loopback addresses
 	hostname := parsed.Hostname()
 	if !isLoopbackAddress(hostname) {
-		return false
+		return "", false
 	}
 
 	requestedScheme := strings.ToLower(parsed.Scheme)
 	requestedHost := strings.ToLower(hostname)
 	requestedPath := parsed.Path
+	requestedPort := parsed.Port()
 
 	for _, registered := range registeredURIs {
 		registeredParsed, err := url.Parse(registered)
 		if err != nil {
 			continue
 		}
-
 		registeredHost := registeredParsed.Hostname()
-
-		// Only match against registered URIs that are also loopback
 		if !isLoopbackAddress(registeredHost) {
 			continue
 		}
-
-		// Compare scheme, host, and path — exclude port (RFC 8252 Section 8.3)
-		if strings.ToLower(registeredParsed.Scheme) == requestedScheme &&
-			strings.ToLower(registeredHost) == requestedHost &&
-			registeredParsed.Path == requestedPath {
-			return true
+		if strings.ToLower(registeredParsed.Scheme) != requestedScheme ||
+			strings.ToLower(registeredHost) != requestedHost ||
+			registeredParsed.Path != requestedPath {
+			continue
 		}
+		canonical := *registeredParsed
+		if requestedPort != "" {
+			canonical.Host = net.JoinHostPort(registeredHost, requestedPort)
+		}
+		return canonical.String(), true
 	}
-
-	return false
+	return "", false
 }
 
 // validateScopes validates that requested scopes are allowed

--- a/server/validation.go
+++ b/server/validation.go
@@ -212,26 +212,6 @@ func (s *Server) resolveRegisteredRedirectURI(client *storage.Client, redirectUR
 	return "", fmt.Errorf("redirect URI not registered for client")
 }
 
-// matchesLoopbackRedirectURI checks if a redirect URI matches any registered URI
-// using RFC 8252 Section 7.3 port-agnostic matching for loopback addresses.
-//
-// Per RFC 8252:
-//   - Section 7.3: "The authorization server MUST allow any port to be specified at
-//     the time of the request for loopback IP redirect URIs, to accommodate clients
-//     that obtain an available ephemeral port from the operating system at the time
-//     of the request."
-//   - Section 8.3: "The redirect URI MUST NOT be compared against pre-registered
-//     URIs using simple string matching [...] the comparison MUST be done by comparing
-//     scheme, host, and path."
-//
-// This function only applies port-agnostic matching when the requested redirect URI
-// targets a loopback address (localhost, 127.0.0.0/8, ::1). Non-loopback URIs are
-// never matched by this function — they require exact string matching.
-func matchesLoopbackRedirectURI(requestedURI string, registeredURIs []string) bool {
-	_, ok := canonicalLoopbackRedirectURI(requestedURI, registeredURIs)
-	return ok
-}
-
 // canonicalLoopbackRedirectURI returns the canonical URI for a loopback
 // port-agnostic match (RFC 8252 §7.3 + §8.3). Scheme, host, and path are
 // taken from the matched registered URI; only the port is taken from the

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -957,9 +957,9 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	})
 }
 
-// TestMatchesLoopbackRedirectURI tests RFC 8252 Section 7.3 port-agnostic
+// TestCanonicalLoopbackRedirectURI_Match tests RFC 8252 §7.3 port-agnostic
 // matching for loopback redirect URIs.
-func TestMatchesLoopbackRedirectURI(t *testing.T) {
+func TestCanonicalLoopbackRedirectURI_Match(t *testing.T) {
 	tests := []struct {
 		name           string
 		requestedURI   string
@@ -1071,9 +1071,9 @@ func TestMatchesLoopbackRedirectURI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := matchesLoopbackRedirectURI(tt.requestedURI, tt.registeredURIs)
+			_, got := canonicalLoopbackRedirectURI(tt.requestedURI, tt.registeredURIs)
 			if got != tt.want {
-				t.Errorf("matchesLoopbackRedirectURI(%q, %v) = %v, want %v",
+				t.Errorf("canonicalLoopbackRedirectURI(%q, %v) match = %v, want %v",
 					tt.requestedURI, tt.registeredURIs, got, tt.want)
 			}
 		})


### PR DESCRIPTION
Closes #303. Follow-up: #328 (consolidate redirect-URI validation paths).

## Summary

- `/authorize` now reads `response_type` and rejects missing or non-`code` values with `unsupported_response_type`, matching the AS metadata's `response_types_supported: ["code"]`.
- New `Server.ValidateRedirectURIForAuthorization(ctx, clientID, redirectURI) (*url.URL, error)` performs the client lookup and registered-URI check and returns the canonical `*url.URL` from server-side storage; `ServeAuthorization` runs this gate before any error branch may redirect (RFC 6749 §3.1.2.4).
- New private helper `respondAuthorizationError` redirects (302) to the canonical URI with `error` / `error_description` / `state` per RFC 6749 §4.1.2.1, or falls back to JSON 400 when the canonical target is `nil` or a custom scheme (RFC 8252 native apps).
- New private helper `checkAuthorizationStateParam` extracts the CSRF-state-parameter check so `ServeAuthorization` stays under the gocyclo budget.
- `invalid_client` (missing or unregistered `client_id`) and `invalid_redirect_uri` (missing, non-`http(s)`, or not registered for the client) continue to return JSON `400`, per RFC 6749 §3.1.2.4 which forbids redirecting to an unvalidated URI.
- New `ErrorCodeUnsupportedResponseType` constant.
- New tests: `TestHandler_ServeAuthorization_NoResponseType_Rejected`, `TestHandler_ServeAuthorization_InvalidRequest_RedirectsToRedirectURI` (incl. open-redirect-surface assertion for unregistered `redirect_uri`), `TestHandler_ServeAuthorization_CustomSchemeRedirectURI_FallsBackToJSON`. `TestHandler_ServeAuthorization_StateLength` updated to assert the new redirect contract. Test helper `assertAuthorizationErrorRedirect` pins `error_description` substring.
- Removed the dead `matchesLoopbackRedirectURI` wrapper; its sole test now exercises `canonicalLoopbackRedirectURI` directly.

## Compatibility

Wire-visible behaviour change. Clients that today receive JSON `400` / `500` from `/authorize` for state / response_type / server failures will now receive a `302` redirect to `redirect_uri` with OAuth error query parameters. Conforming OAuth 2.0 / 2.1 clients already handle this — it's the spec-mandated path. Clients that omit `response_type` will now fail (with a redirect to their `redirect_uri` carrying `error=unsupported_response_type`); they must send `response_type=code` to succeed. `client_id` and `redirect_uri` errors are unchanged — both still return JSON `400`. Native-app clients using custom URI schemes registered via `AllowedCustomSchemes` continue to receive JSON `400` for `/authorize` protocol errors; redirecting custom schemes is out of scope for this fix.