### PR TITLE
fix(introspect): RFC 7662 §2.2 response shape + cross-client gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Token introspection (`/oauth/introspect`) now enforces a cross-client gate (#306)**
   - **Breaking**: a client introspecting a token bound to a different client receives `{"active": false}` per RFC 7662 §2.2 with no other claims populated.
   - New `Config.IntrospectionResourceServers []string` allowlists resource servers permitted to introspect tokens they do not own. Empty entries are rejected at startup; same-client introspection is always allowed.
-  - Cross-client denials emit `security.EventIntrospectionRequesterDenied` (severity `medium`, `reason` ∈ `{empty_client_id, cross_client_probe}`).
+  - Cross-client denials emit `security.EventIntrospectionRequesterDenied` (severity `medium`, `reason` ∈ `{empty_requester, empty_token_bound_client, cross_client_probe}`).
   - User attributes (`email`, `email_verified`, `name`, `sub`) flow only on the authorized path.
 - **`security.Auditor` methods take `context.Context`**
   - `LogEvent` and the 11 typed helpers (`LogTokenIssued`, `LogTokenRefreshed`, `LogTokenRevoked`, `LogAuthFailure`, `LogRateLimitExceeded`, `LogClientRegistrationRateLimitExceeded`, `LogClientRegistered`, `LogInvalidPKCE`, `LogTokenReuse`, `LogSuspiciousActivity`, `LogInvalidRedirect`) now take `ctx context.Context` as the first argument. The ctx is forwarded to the underlying `slog.Handler.Handle`, so otelslog-style handlers attach trace/span IDs to audit records.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Token introspection (`/oauth/introspect`) now enforces a cross-client gate (#306)**
-  - **Breaking**: a client introspecting a token bound to a different client now receives `{"active": false}` per RFC 7662 §2.2 with no other claims populated. Previously any authenticated client could probe any token in the store and learn its active state plus user attributes.
-  - Migration: enroll resource servers that need to validate access tokens issued to user-agent clients in `Config.IntrospectionResourceServers []string` (new field). Same-client introspection is always allowed; cross-client requires explicit allowlisting.
-  - The `email` / `email_verified` / `name` / `sub` user attributes only flow on the authorized path, so a denied probe cannot enumerate users.
+  - **Breaking**: a client introspecting a token bound to a different client receives `{"active": false}` per RFC 7662 §2.2 with no other claims populated.
+  - New `Config.IntrospectionResourceServers []string` allowlists resource servers permitted to introspect tokens they do not own. Empty entries are rejected at startup; same-client introspection is always allowed.
+  - Cross-client denials emit `security.EventIntrospectionRequesterDenied` (severity `medium`, `reason` ∈ `{empty_client_id, cross_client_probe}`).
+  - User attributes (`email`, `email_verified`, `name`, `sub`) flow only on the authorized path.
 - **`security.Auditor` methods take `context.Context`**
   - `LogEvent` and the 11 typed helpers (`LogTokenIssued`, `LogTokenRefreshed`, `LogTokenRevoked`, `LogAuthFailure`, `LogRateLimitExceeded`, `LogClientRegistrationRateLimitExceeded`, `LogClientRegistered`, `LogInvalidPKCE`, `LogTokenReuse`, `LogSuspiciousActivity`, `LogInvalidRedirect`) now take `ctx context.Context` as the first argument. The ctx is forwarded to the underlying `slog.Handler.Handle`, so otelslog-style handlers attach trace/span IDs to audit records.
   - **Breaking**: prepend `ctx` at every call site (`r.Context()` for HTTP-driven flows, `context.Background()` for background emissions).
@@ -139,9 +140,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`/oauth/introspect` response shape (RFC 7662 §2.2) (#306)**
-  - `client_id` now reflects the client the token was issued to, taken from stored token metadata (opaque) or the verified JWT `client_id` claim (JWT mode). Previously the field echoed back the requesting client, which is misleading and arguably spec-violating.
-  - `exp`, `iat`, `aud`, `iss`, `scope`, `sub`, `token_type` are populated from token metadata / JWT claims (opaque tokens read expiry from the stored provider token, `iat` from the metadata write time). `nbf` is included for JWT tokens that carry the claim; omitted otherwise per RFC 7662 §2.2 ("OPTIONAL").
-  - JWT access tokens (`AccessTokenFormatJWT`) project verified claims directly into the response — no metadata round-trip.
+  - `client_id` reflects the client the token was issued to (from stored token metadata for opaque tokens, from the verified `client_id` JWT claim in JWT mode).
+  - `exp`, `iat`, `aud`, `iss`, `scope`, `sub`, `token_type` are populated from token metadata or verified JWT claims. `nbf` is included only when the JWT carries it.
+  - `Cache-Control: no-store` + `Pragma: no-cache` are now set on the success path.
+  - JWT-mode introspection consumes the verified claim map returned by `validateSelfIssuedJWT` in a single pass (no re-parse, no drift between the two verification paths).
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**
   - `isMandatoryScope()` now returns true for `email`, `profile`, `groups`, and `offline_access` in addition to `openid` and cross-client audience scopes.
   - When an MCP client sends only custom scopes (e.g., `claudeai`), identity-critical scopes from the provider's defaults are now force-merged into the authorization request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Token introspection (`/oauth/introspect`) now enforces a cross-client gate (#306)**
+  - **Breaking**: a client introspecting a token bound to a different client now receives `{"active": false}` per RFC 7662 §2.2 with no other claims populated. Previously any authenticated client could probe any token in the store and learn its active state plus user attributes.
+  - Migration: enroll resource servers that need to validate access tokens issued to user-agent clients in `Config.IntrospectionResourceServers []string` (new field). Same-client introspection is always allowed; cross-client requires explicit allowlisting.
+  - The `email` / `email_verified` / `name` / `sub` user attributes only flow on the authorized path, so a denied probe cannot enumerate users.
 - **`security.Auditor` methods take `context.Context`**
   - `LogEvent` and the 11 typed helpers (`LogTokenIssued`, `LogTokenRefreshed`, `LogTokenRevoked`, `LogAuthFailure`, `LogRateLimitExceeded`, `LogClientRegistrationRateLimitExceeded`, `LogClientRegistered`, `LogInvalidPKCE`, `LogTokenReuse`, `LogSuspiciousActivity`, `LogInvalidRedirect`) now take `ctx context.Context` as the first argument. The ctx is forwarded to the underlying `slog.Handler.Handle`, so otelslog-style handlers attach trace/span IDs to audit records.
   - **Breaking**: prepend `ctx` at every call site (`r.Context()` for HTTP-driven flows, `context.Background()` for background emissions).
@@ -134,6 +138,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`/oauth/introspect` response shape (RFC 7662 §2.2) (#306)**
+  - `client_id` now reflects the client the token was issued to, taken from stored token metadata (opaque) or the verified JWT `client_id` claim (JWT mode). Previously the field echoed back the requesting client, which is misleading and arguably spec-violating.
+  - `exp`, `iat`, `aud`, `iss`, `scope`, `sub`, `token_type` are populated from token metadata / JWT claims (opaque tokens read expiry from the stored provider token, `iat` from the metadata write time). `nbf` is included for JWT tokens that carry the claim; omitted otherwise per RFC 7662 §2.2 ("OPTIONAL").
+  - JWT access tokens (`AccessTokenFormatJWT`) project verified claims directly into the response — no metadata round-trip.
 - **Treat email, profile, groups, offline_access as mandatory scopes (#252)**
   - `isMandatoryScope()` now returns true for `email`, `profile`, `groups`, and `offline_access` in addition to `openid` and cross-client audience scopes.
   - When an MCP client sends only custom scopes (e.g., `claudeai`), identity-critical scopes from the provider's defaults are now force-merged into the authorization request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,9 +87,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Token introspection (`/oauth/introspect`) now enforces a cross-client gate (#306)**
   - **Breaking**: a client introspecting a token bound to a different client receives `{"active": false}` per RFC 7662 §2.2 with no other claims populated.
-  - New `Config.IntrospectionResourceServers []string` allowlists resource servers permitted to introspect tokens they do not own. Empty entries are rejected at startup; same-client introspection is always allowed.
+  - New `Config.IntrospectionResourceServers []string` allowlists resource servers permitted to introspect tokens they do not own. Empty entries are rejected at `Config.Validate`; entries not resolving to a registered client are rejected at `Server.New`; same-client introspection is always allowed.
   - Cross-client denials emit `security.EventIntrospectionRequesterDenied` (severity `medium`, `reason` ∈ `{empty_requester, empty_token_bound_client, cross_client_probe}`).
   - User attributes (`email`, `email_verified`, `name`, `sub`) flow only on the authorized path.
+- **RFC 9068 access tokens (JWT mode) now carry `email_verified` and `name` claims**
+  - `AccessTokenClaims.EmailVerified` and `AccessTokenClaims.Name` are populated from `providers.UserInfo` during issuance.
+  - Brings JWT-mode introspection into parity with opaque-mode introspection on identity attributes.
 - **`security.Auditor` methods take `context.Context`**
   - `LogEvent` and the 11 typed helpers (`LogTokenIssued`, `LogTokenRefreshed`, `LogTokenRevoked`, `LogAuthFailure`, `LogRateLimitExceeded`, `LogClientRegistrationRateLimitExceeded`, `LogClientRegistered`, `LogInvalidPKCE`, `LogTokenReuse`, `LogSuspiciousActivity`, `LogInvalidRedirect`) now take `ctx context.Context` as the first argument. The ctx is forwarded to the underlying `slog.Handler.Handle`, so otelslog-style handlers attach trace/span IDs to audit records.
   - **Breaking**: prepend `ctx` at every call site (`r.Context()` for HTTP-driven flows, `context.Background()` for background emissions).

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -219,7 +219,7 @@ analyze-all: fmt-check vet lint gosec quality-check deps-check doc-check ## Run 
 ##@ Verification
 
 .PHONY: verify ci check-security
-verify: init-examples fmt-all analyze-all test-coverage ## Run all verification steps
+verify: init-examples analyze-all test-coverage ## Run all verification steps (read-only; use `fmt-all` first locally to apply formatters)
 	@echo "====> $@"
 
 ci: verify ## Run CI checks (alias for verify)

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -219,7 +219,7 @@ analyze-all: fmt-check vet lint gosec quality-check deps-check doc-check ## Run 
 ##@ Verification
 
 .PHONY: verify ci check-security
-verify: init-examples analyze-all fmt-all test-coverage ## Run all verification steps
+verify: init-examples fmt-all analyze-all test-coverage ## Run all verification steps
 	@echo "====> $@"
 
 ci: verify ## Run CI checks (alias for verify)

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -219,7 +219,7 @@ analyze-all: fmt-check vet lint gosec quality-check deps-check doc-check ## Run 
 ##@ Verification
 
 .PHONY: verify ci check-security
-verify: init-examples analyze-all test-coverage ## Run all verification steps (read-only; use `fmt-all` first locally to apply formatters)
+verify: init-examples analyze-all fmt-all test-coverage ## Run all verification steps
 	@echo "====> $@"
 
 ci: verify ## Run CI checks (alias for verify)

--- a/docs/security.md
+++ b/docs/security.md
@@ -9,10 +9,11 @@ This guide covers security configuration for production deployments. For deep te
 3. [Token Encryption](#token-encryption)
 4. [Rate Limiting](#rate-limiting)
 5. [Audit Logging](#audit-logging)
-6. [Client Registration Protection](#client-registration-protection)
-7. [Redirect URI Security](#redirect-uri-security)
-8. [SSO Token Forwarding](#sso-token-forwarding)
-9. [Legacy Client Support](#legacy-client-support)
+6. [Token Introspection (RFC 7662)](#token-introspection-rfc-7662)
+7. [Client Registration Protection](#client-registration-protection)
+8. [Redirect URI Security](#redirect-uri-security)
+9. [SSO Token Forwarding](#sso-token-forwarding)
+10. [Legacy Client Support](#legacy-client-support)
 
 ## Secure Defaults
 
@@ -210,6 +211,7 @@ server.SetAuditor(auditor)
 | `token_reuse_detected` | Refresh token reuse (theft indicator) |
 | `invalid_pkce` | PKCE validation failure |
 | `client_registered` | New client registered |
+| `introspection_requester_denied` | Cross-client introspection probe (see [Token Introspection](#token-introspection-rfc-7662)) |
 
 ### Monitoring Recommendations
 
@@ -218,6 +220,35 @@ Set up alerts for:
 - `token_reuse_detected` - Possible token theft
 - `rate_limit_exceeded` - Possible abuse
 - Spikes in `auth_failure` - Brute force attempt
+- Spikes in `introspection_requester_denied` with `reason=cross_client_probe` - DCR client enumerating tokens it does not own
+
+## Token Introspection (RFC 7662)
+
+`/oauth/introspect` is opt-in via `Config.EnableIntrospectionEndpoint`. When enabled, the endpoint enforces a **cross-client gate**: a client receives the RFC 7662 §2.2 response only for tokens it owns, or for tokens whose `client_id` it is enrolled for via `Config.IntrospectionResourceServers`. Every other probe returns `{"active": false}` with no other claims — byte-identical to an unknown-token response.
+
+### Why the gate
+
+Without it, any DCR-registered client could introspect any token in the store and learn (a) whether it is active and (b) the bound user's `sub` / `email` / `email_verified` / `name`. That is a passive token / user enumeration channel. The gate closes the channel while preserving introspection's legitimate use case (resource servers validating tokens issued to their own clients).
+
+### Configuration
+
+```go
+srvCfg.EnableIntrospectionEndpoint = true
+srvCfg.IntrospectionResourceServers = []string{
+    "rs-billing-api",   // resource server allowed to introspect tokens
+    "rs-files-api",     // …issued to any DCR client targeting this RS
+}
+```
+
+Empty entries are rejected at `Config.Validate`. Unregistered client IDs are rejected at `Server.New`. Same-client probes are always allowed and do not require enrolment.
+
+### Response shape
+
+`client_id` reflects the **token-bound** client, not the requester. `exp`, `iat`, `aud`, `iss`, `scope`, `sub`, `token_type` are projected from token metadata (opaque mode) or the verified JWT claims (JWT mode). `nbf` is projected when the JWT carries it. User attributes (`email`, `email_verified`, `name`) are projected on the authorized path only.
+
+### Auditing
+
+Cross-client denials emit `introspection_requester_denied` (severity `medium`) with `reason ∈ {empty_requester, empty_token_bound_client, cross_client_probe}`. The wire response hides the denial from the caller; the audit record preserves it for SIEM ingestion.
 
 ## Client Registration Protection
 

--- a/handler.go
+++ b/handler.go
@@ -2412,11 +2412,6 @@ func (h *Handler) ServeTokenIntrospection(w http.ResponseWriter, r *http.Request
 
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	w.Header().Set("Content-Type", "application/json")
-	// RFC 7662 §2.2: introspection responses MUST NOT be cached by
-	// intermediaries because the activity / claims they reflect can change
-	// out-of-band (token revocation, family expiry).
-	w.Header().Set("Cache-Control", "no-store")
-	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(response)
 	h.recordHTTPMetrics(r.Context(), endpointIntrospect, http.MethodPost, http.StatusOK, startTime)

--- a/handler.go
+++ b/handler.go
@@ -2405,6 +2405,11 @@ func (h *Handler) ServeTokenIntrospection(w http.ResponseWriter, r *http.Request
 
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	w.Header().Set("Content-Type", "application/json")
+	// RFC 7662 §2.2: introspection responses MUST NOT be cached by
+	// intermediaries because the activity / claims they reflect can change
+	// out-of-band (token revocation, family expiry).
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(response)
 	h.recordHTTPMetrics(r.Context(), endpointIntrospect, http.MethodPost, http.StatusOK, startTime)

--- a/handler.go
+++ b/handler.go
@@ -2398,8 +2398,10 @@ func (h *Handler) ServeTokenIntrospection(w http.ResponseWriter, r *http.Request
 		instrumentation.SetSpanAttributes(span, attribute.String(instrumentation.AttrClientID, clientID))
 	}
 
-	// Validate the token and build response
-	response := h.buildIntrospectionResponse(r.Context(), token, clientID, clientIP)
+	response := h.server.IntrospectToken(r.Context(), token, clientID)
+	if active, _ := response["active"].(bool); !active {
+		h.logger.Debug("Token introspection inactive", "ip", clientIP, "client_id", clientID)
+	}
 
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	w.Header().Set("Content-Type", "application/json")
@@ -2441,35 +2443,6 @@ func (h *Handler) authenticateIntrospectionClient(r *http.Request, clientIP stri
 		h.server.Auditor.LogAuthFailure(ctx, "", clientID, clientIP, "introspection_missing_credentials")
 	}
 	return "", fmt.Errorf("client authentication required for token introspection")
-}
-
-// buildIntrospectionResponse creates the RFC 7662 introspection response.
-func (h *Handler) buildIntrospectionResponse(ctx context.Context, token, clientID, clientIP string) map[string]interface{} {
-	userInfo, err := h.server.ValidateToken(ctx, token)
-
-	response := map[string]interface{}{
-		"active": false,
-	}
-
-	if err != nil || userInfo == nil {
-		h.logger.Debug("Token introspection failed", "error", err, "ip", clientIP)
-		return response
-	}
-
-	response["active"] = true
-	response["sub"] = userInfo.ID
-	response["email"] = userInfo.Email
-	response["email_verified"] = userInfo.EmailVerified
-	response["token_type"] = "Bearer"
-
-	if userInfo.Name != "" {
-		response["name"] = userInfo.Name
-	}
-	if clientID != "" {
-		response["client_id"] = clientID
-	}
-
-	return response
 }
 
 // Context key for user info

--- a/handler_test.go
+++ b/handler_test.go
@@ -3796,9 +3796,6 @@ func TestHandler_ServeTokenIntrospection(t *testing.T) {
 	}
 }
 
-// seedOpaqueIntrospectionToken seeds an opaque access token in the store with
-// matching TokenMetadata, returning the bearer string and the recorded
-// IssuedAt for the test to compare against the introspection response.
 func seedOpaqueIntrospectionToken(t *testing.T, store *memory.Store, accessToken, userID, clientID, audience string, scopes []string, expiresAt time.Time) time.Time {
 	t.Helper()
 	ctx := context.Background()
@@ -3826,9 +3823,6 @@ func seedOpaqueIntrospectionToken(t *testing.T, store *memory.Store, accessToken
 	return meta.IssuedAt
 }
 
-// TestIntrospect_CrossClient_ReturnsInactive verifies that a client introspecting
-// a token bound to a different client receives only {"active": false}, with no
-// claims or user attributes leaking through (RFC 7662 §2.2 + §2.1 gating).
 func TestIntrospect_CrossClient_ReturnsInactive(t *testing.T) {
 	ctx := context.Background()
 
@@ -3876,10 +3870,6 @@ func TestIntrospect_CrossClient_ReturnsInactive(t *testing.T) {
 	}
 }
 
-// TestIntrospect_AllowlistedResourceServer_Succeeds verifies that a client
-// listed in Config.IntrospectionResourceServers can introspect tokens it
-// does not own, and that the response carries the token's bound client_id
-// (not the requester's).
 func TestIntrospect_AllowlistedResourceServer_Succeeds(t *testing.T) {
 	ctx := context.Background()
 
@@ -3927,9 +3917,6 @@ func TestIntrospect_AllowlistedResourceServer_Succeeds(t *testing.T) {
 	}
 }
 
-// TestIntrospect_ResponseFields_Complete verifies the full RFC 7662 §2.2
-// response shape: active, sub, client_id, token_type, scope, aud, iss, exp,
-// iat are all populated from token metadata.
 func TestIntrospect_ResponseFields_Complete(t *testing.T) {
 	ctx := context.Background()
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -3796,6 +3796,211 @@ func TestHandler_ServeTokenIntrospection(t *testing.T) {
 	}
 }
 
+// seedOpaqueIntrospectionToken seeds an opaque access token in the store with
+// matching TokenMetadata, returning the bearer string and the recorded
+// IssuedAt for the test to compare against the introspection response.
+func seedOpaqueIntrospectionToken(t *testing.T, store *memory.Store, accessToken, userID, clientID, audience string, scopes []string, expiresAt time.Time) time.Time {
+	t.Helper()
+	ctx := context.Background()
+	providerToken := &oauth2.Token{
+		AccessToken: accessToken,
+		TokenType:   "Bearer",
+		Expiry:      expiresAt,
+	}
+	if err := store.SaveToken(ctx, accessToken, providerToken); err != nil {
+		t.Fatalf("SaveToken() error = %v", err)
+	}
+	if err := store.SaveTokenMetadata(ctx, accessToken, storage.TokenMetadata{
+		UserID:    userID,
+		ClientID:  clientID,
+		TokenType: "access",
+		Audience:  audience,
+		Scopes:    scopes,
+	}); err != nil {
+		t.Fatalf("SaveTokenMetadata() error = %v", err)
+	}
+	meta, err := store.GetTokenMetadata(accessToken)
+	if err != nil {
+		t.Fatalf("GetTokenMetadata() error = %v", err)
+	}
+	return meta.IssuedAt
+}
+
+// TestIntrospect_CrossClient_ReturnsInactive verifies that a client introspecting
+// a token bound to a different client receives only {"active": false}, with no
+// claims or user attributes leaking through (RFC 7662 §2.2 + §2.1 gating).
+func TestIntrospect_CrossClient_ReturnsInactive(t *testing.T) {
+	ctx := context.Background()
+
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	tokenOwner, _, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
+	if err != nil {
+		t.Fatalf("RegisterClient(owner) error = %v", err)
+	}
+	probingClient, probingSecret, err := handler.server.RegisterClient(ctx, "Probing Client", "confidential", "", []string{"https://example.com/cb-probe"}, []string{"openid"}, "192.168.1.2", 10)
+	if err != nil {
+		t.Fatalf("RegisterClient(probe) error = %v", err)
+	}
+
+	const accessToken = "opaque-access-token-cross-client"
+	seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, "https://auth.example.com", []string{"openid", "email"}, time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("token", accessToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(probingClient.ClientID, probingSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeTokenIntrospection(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if active, _ := response["active"].(bool); active {
+		t.Fatalf("active = true, want false for cross-client introspection (response=%v)", response)
+	}
+	for _, leaked := range []string{"sub", "email", "email_verified", "name", "client_id", "scope", "aud", "iss", "exp", "iat", "token_type"} {
+		if _, present := response[leaked]; present {
+			t.Errorf("cross-client probe leaked %q in response: %v", leaked, response)
+		}
+	}
+}
+
+// TestIntrospect_AllowlistedResourceServer_Succeeds verifies that a client
+// listed in Config.IntrospectionResourceServers can introspect tokens it
+// does not own, and that the response carries the token's bound client_id
+// (not the requester's).
+func TestIntrospect_AllowlistedResourceServer_Succeeds(t *testing.T) {
+	ctx := context.Background()
+
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	tokenOwner, _, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
+	if err != nil {
+		t.Fatalf("RegisterClient(owner) error = %v", err)
+	}
+	resourceServer, resourceSecret, err := handler.server.RegisterClient(ctx, "Resource Server", "confidential", "", []string{"https://example.com/cb-rs"}, []string{"openid"}, "192.168.1.3", 10)
+	if err != nil {
+		t.Fatalf("RegisterClient(rs) error = %v", err)
+	}
+
+	handler.server.Config.IntrospectionResourceServers = []string{resourceServer.ClientID}
+
+	const accessToken = "opaque-access-token-allowlist"
+	seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, "https://auth.example.com", []string{"openid", "email"}, time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("token", accessToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(resourceServer.ClientID, resourceSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeTokenIntrospection(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if active, _ := response["active"].(bool); !active {
+		t.Fatalf("active = false, want true (response=%v)", response)
+	}
+	if got, _ := response["client_id"].(string); got != tokenOwner.ClientID {
+		t.Errorf("client_id = %q, want %q (token-bound, not requester)", got, tokenOwner.ClientID)
+	}
+}
+
+// TestIntrospect_ResponseFields_Complete verifies the full RFC 7662 §2.2
+// response shape: active, sub, client_id, token_type, scope, aud, iss, exp,
+// iat are all populated from token metadata.
+func TestIntrospect_ResponseFields_Complete(t *testing.T) {
+	ctx := context.Background()
+
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	tokenOwner, ownerSecret, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
+	if err != nil {
+		t.Fatalf("RegisterClient(owner) error = %v", err)
+	}
+
+	const accessToken = "opaque-access-token-fields"
+	expiry := time.Now().Add(45 * time.Minute).Truncate(time.Second)
+	audience := testIssuer
+	scopes := []string{"openid", "email", "profile"}
+	issuedAt := seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, audience, scopes, expiry)
+
+	form := url.Values{}
+	form.Set("token", accessToken)
+
+	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(tokenOwner.ClientID, ownerSecret)
+	w := httptest.NewRecorder()
+
+	handler.ServeTokenIntrospection(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var response map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if active, _ := response["active"].(bool); !active {
+		t.Fatalf("active = false, want true (response=%v)", response)
+	}
+	if got, _ := response["client_id"].(string); got != tokenOwner.ClientID {
+		t.Errorf("client_id = %q, want %q", got, tokenOwner.ClientID)
+	}
+	if got, _ := response["sub"].(string); got == "" {
+		t.Errorf("sub missing or empty (response=%v)", response)
+	}
+	if got, _ := response["token_type"].(string); got != "Bearer" {
+		t.Errorf("token_type = %q, want Bearer", got)
+	}
+	if got, _ := response["scope"].(string); got != helpers.JoinScopes(scopes) {
+		t.Errorf("scope = %q, want %q", got, helpers.JoinScopes(scopes))
+	}
+	if got, _ := response["aud"].(string); got != audience {
+		t.Errorf("aud = %q, want %q", got, audience)
+	}
+	if got, _ := response["iss"].(string); got != testIssuer {
+		t.Errorf("iss = %q, want %q", got, testIssuer)
+	}
+	expVal, ok := response["exp"].(float64)
+	if !ok {
+		t.Errorf("exp missing or not a number (response=%v)", response)
+	} else if int64(expVal) != expiry.Unix() {
+		t.Errorf("exp = %d, want %d", int64(expVal), expiry.Unix())
+	}
+	iatVal, ok := response["iat"].(float64)
+	if !ok {
+		t.Errorf("iat missing or not a number (response=%v)", response)
+	} else if int64(iatVal) != issuedAt.Unix() {
+		t.Errorf("iat = %d, want %d", int64(iatVal), issuedAt.Unix())
+	}
+}
+
 // CORS Tests
 
 func TestCORS_Disabled(t *testing.T) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
@@ -3823,168 +3824,115 @@ func seedOpaqueIntrospectionToken(t *testing.T, store *memory.Store, accessToken
 	return meta.IssuedAt
 }
 
-func TestIntrospect_CrossClient_ReturnsInactive(t *testing.T) {
+func TestHandler_ServeTokenIntrospection_OpaquePath(t *testing.T) {
 	ctx := context.Background()
 
-	handler, store := setupTestHandler(t)
-	defer store.Stop()
-
-	tokenOwner, _, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
-	if err != nil {
-		t.Fatalf("RegisterClient(owner) error = %v", err)
-	}
-	probingClient, probingSecret, err := handler.server.RegisterClient(ctx, "Probing Client", "confidential", "", []string{"https://example.com/cb-probe"}, []string{"openid"}, "192.168.1.2", 10)
-	if err != nil {
-		t.Fatalf("RegisterClient(probe) error = %v", err)
-	}
-
-	const accessToken = "opaque-access-token-cross-client"
-	seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, "https://auth.example.com", []string{"openid", "email"}, time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("token", accessToken)
-
-	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(probingClient.ClientID, probingSecret)
-	w := httptest.NewRecorder()
-
-	handler.ServeTokenIntrospection(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
-	}
-
-	var response map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
+	tests := []struct {
+		name                  string
+		requester             string // "owner", "probe", "rs" — picks which client makes the request
+		allowlistResourceSrv  bool   // wire IntrospectionResourceServers with the rs client
+		wantActive            bool
+		wantFieldsPresent     []string // beyond "active"
+		wantFieldsAbsent      []string
+		wantClientIDIsTokenRS bool // when active, assert client_id is the token's owner not requester
+	}{
+		{
+			name:              "token owner sees full RFC 7662 §2.2 projection",
+			requester:         "owner",
+			wantActive:        true,
+			wantFieldsPresent: []string{"client_id", "sub", "token_type", "scope", "aud", "iss", "exp", "iat"},
+		},
+		{
+			name:              "cross-client probe denied — no field leakage",
+			requester:         "probe",
+			wantActive:        false,
+			wantFieldsAbsent:  []string{"sub", "email", "email_verified", "name", "client_id", "scope", "aud", "iss", "exp", "iat", "token_type"},
+		},
+		{
+			name:                  "allowlisted resource server sees token-owner client_id",
+			requester:             "rs",
+			allowlistResourceSrv:  true,
+			wantActive:            true,
+			wantFieldsPresent:     []string{"client_id", "sub"},
+			wantClientIDIsTokenRS: true,
+		},
 	}
 
-	if active, _ := response["active"].(bool); active {
-		t.Fatalf("active = true, want false for cross-client introspection (response=%v)", response)
-	}
-	for _, leaked := range []string{"sub", "email", "email_verified", "name", "client_id", "scope", "aud", "iss", "exp", "iat", "token_type"} {
-		if _, present := response[leaked]; present {
-			t.Errorf("cross-client probe leaked %q in response: %v", leaked, response)
-		}
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, store := setupTestHandler(t)
+			defer store.Stop()
 
-func TestIntrospect_AllowlistedResourceServer_Succeeds(t *testing.T) {
-	ctx := context.Background()
+			tokenOwner, ownerSecret, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
+			require.NoError(t, err)
+			probingClient, probingSecret, err := handler.server.RegisterClient(ctx, "Probing Client", "confidential", "", []string{"https://example.com/cb-probe"}, []string{"openid"}, "192.168.1.2", 10)
+			require.NoError(t, err)
+			resourceServer, resourceSecret, err := handler.server.RegisterClient(ctx, "Resource Server", "confidential", "", []string{"https://example.com/cb-rs"}, []string{"openid"}, "192.168.1.3", 10)
+			require.NoError(t, err)
 
-	handler, store := setupTestHandler(t)
-	defer store.Stop()
+			if tt.allowlistResourceSrv {
+				handler.server.Config.IntrospectionResourceServers = []string{resourceServer.ClientID}
+			}
 
-	tokenOwner, _, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
-	if err != nil {
-		t.Fatalf("RegisterClient(owner) error = %v", err)
-	}
-	resourceServer, resourceSecret, err := handler.server.RegisterClient(ctx, "Resource Server", "confidential", "", []string{"https://example.com/cb-rs"}, []string{"openid"}, "192.168.1.3", 10)
-	if err != nil {
-		t.Fatalf("RegisterClient(rs) error = %v", err)
-	}
+			const accessToken = "opaque-access-token"
+			expiry := time.Now().Add(45 * time.Minute).Truncate(time.Second)
+			audience := testIssuer
+			scopes := []string{"openid", "email", "profile"}
+			issuedAt := seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, audience, scopes, expiry)
 
-	handler.server.Config.IntrospectionResourceServers = []string{resourceServer.ClientID}
+			form := url.Values{}
+			form.Set("token", accessToken)
+			req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	const accessToken = "opaque-access-token-allowlist"
-	seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, "https://auth.example.com", []string{"openid", "email"}, time.Now().Add(time.Hour))
+			switch tt.requester {
+			case "owner":
+				req.SetBasicAuth(tokenOwner.ClientID, ownerSecret)
+			case "probe":
+				req.SetBasicAuth(probingClient.ClientID, probingSecret)
+			case "rs":
+				req.SetBasicAuth(resourceServer.ClientID, resourceSecret)
+			}
 
-	form := url.Values{}
-	form.Set("token", accessToken)
+			w := httptest.NewRecorder()
+			handler.ServeTokenIntrospection(w, req)
 
-	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(resourceServer.ClientID, resourceSecret)
-	w := httptest.NewRecorder()
+			require.Equal(t, http.StatusOK, w.Code)
+			require.Equal(t, "no-store", w.Header().Get("Cache-Control"),
+				"RFC 7662 §2.2 requires Cache-Control: no-store on introspection responses")
 
-	handler.ServeTokenIntrospection(w, req)
+			var response map[string]any
+			require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
 
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
-	}
+			active, _ := response["active"].(bool)
+			require.Equal(t, tt.wantActive, active, "response: %v", response)
 
-	var response map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
+			for _, key := range tt.wantFieldsPresent {
+				require.Contains(t, response, key, "expected %q present (response=%v)", key, response)
+			}
+			for _, key := range tt.wantFieldsAbsent {
+				require.NotContains(t, response, key, "denied probe leaked %q (response=%v)", key, response)
+			}
 
-	if active, _ := response["active"].(bool); !active {
-		t.Fatalf("active = false, want true (response=%v)", response)
-	}
-	if got, _ := response["client_id"].(string); got != tokenOwner.ClientID {
-		t.Errorf("client_id = %q, want %q (token-bound, not requester)", got, tokenOwner.ClientID)
-	}
-}
-
-func TestIntrospect_ResponseFields_Complete(t *testing.T) {
-	ctx := context.Background()
-
-	handler, store := setupTestHandler(t)
-	defer store.Stop()
-
-	tokenOwner, ownerSecret, err := handler.server.RegisterClient(ctx, "Owner Client", "confidential", "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
-	if err != nil {
-		t.Fatalf("RegisterClient(owner) error = %v", err)
-	}
-
-	const accessToken = "opaque-access-token-fields"
-	expiry := time.Now().Add(45 * time.Minute).Truncate(time.Second)
-	audience := testIssuer
-	scopes := []string{"openid", "email", "profile"}
-	issuedAt := seedOpaqueIntrospectionToken(t, store, accessToken, "user-1", tokenOwner.ClientID, audience, scopes, expiry)
-
-	form := url.Values{}
-	form.Set("token", accessToken)
-
-	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(tokenOwner.ClientID, ownerSecret)
-	w := httptest.NewRecorder()
-
-	handler.ServeTokenIntrospection(w, req)
-
-	if w.Code != http.StatusOK {
-		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
-	}
-
-	var response map[string]any
-	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
-		t.Fatalf("decode response: %v", err)
-	}
-
-	if active, _ := response["active"].(bool); !active {
-		t.Fatalf("active = false, want true (response=%v)", response)
-	}
-	if got, _ := response["client_id"].(string); got != tokenOwner.ClientID {
-		t.Errorf("client_id = %q, want %q", got, tokenOwner.ClientID)
-	}
-	if got, _ := response["sub"].(string); got == "" {
-		t.Errorf("sub missing or empty (response=%v)", response)
-	}
-	if got, _ := response["token_type"].(string); got != "Bearer" {
-		t.Errorf("token_type = %q, want Bearer", got)
-	}
-	if got, _ := response["scope"].(string); got != helpers.JoinScopes(scopes) {
-		t.Errorf("scope = %q, want %q", got, helpers.JoinScopes(scopes))
-	}
-	if got, _ := response["aud"].(string); got != audience {
-		t.Errorf("aud = %q, want %q", got, audience)
-	}
-	if got, _ := response["iss"].(string); got != testIssuer {
-		t.Errorf("iss = %q, want %q", got, testIssuer)
-	}
-	expVal, ok := response["exp"].(float64)
-	if !ok {
-		t.Errorf("exp missing or not a number (response=%v)", response)
-	} else if int64(expVal) != expiry.Unix() {
-		t.Errorf("exp = %d, want %d", int64(expVal), expiry.Unix())
-	}
-	iatVal, ok := response["iat"].(float64)
-	if !ok {
-		t.Errorf("iat missing or not a number (response=%v)", response)
-	} else if int64(iatVal) != issuedAt.Unix() {
-		t.Errorf("iat = %d, want %d", int64(iatVal), issuedAt.Unix())
+			if tt.wantActive {
+				require.Equal(t, "Bearer", response["token_type"])
+				if tt.wantClientIDIsTokenRS {
+					require.Equal(t, tokenOwner.ClientID, response["client_id"],
+						"client_id must reflect the token's owner, not the introspecting RS")
+				}
+				if scope, ok := response["scope"].(string); ok {
+					require.Equal(t, helpers.JoinScopes(scopes), scope)
+				}
+				if exp, ok := response["exp"].(float64); ok {
+					require.Equal(t, expiry.Unix(), int64(exp))
+				}
+				if iat, ok := response["iat"].(float64); ok {
+					require.Equal(t, issuedAt.Unix(), int64(iat))
+				}
+				require.Equal(t, audience, response["aud"])
+				require.Equal(t, testIssuer, response["iss"])
+			}
+		})
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -3890,10 +3890,10 @@ func TestHandler_ServeTokenIntrospection_OpaquePath(t *testing.T) {
 			wantFieldsPresent: []string{"client_id", "sub", "token_type", "scope", "aud", "iss", "exp", "iat"},
 		},
 		{
-			name:              "cross-client probe denied — no field leakage",
-			requester:         "probe",
-			wantActive:        false,
-			wantFieldsAbsent:  []string{"sub", "email", "email_verified", "name", "client_id", "scope", "aud", "iss", "exp", "iat", "token_type"},
+			name:             "cross-client probe denied — no field leakage",
+			requester:        "probe",
+			wantActive:       false,
+			wantFieldsAbsent: []string{"sub", "email", "email_verified", "name", "client_id", "scope", "aud", "iss", "exp", "iat", "token_type"},
 		},
 		{
 			name:                  "allowlisted resource server sees token-owner client_id",
@@ -3945,8 +3945,10 @@ func TestHandler_ServeTokenIntrospection_OpaquePath(t *testing.T) {
 			handler.ServeTokenIntrospection(w, req)
 
 			require.Equal(t, http.StatusOK, w.Code)
-			require.Equal(t, "no-store", w.Header().Get("Cache-Control"),
+			require.Contains(t, w.Header().Get("Cache-Control"), "no-store",
 				"RFC 7662 §2.2 requires Cache-Control: no-store on introspection responses")
+			require.Equal(t, "no-cache", w.Header().Get("Pragma"),
+				"HTTP/1.0 intermediaries honour Pragma: no-cache")
 
 			var response map[string]any
 			require.NoError(t, json.NewDecoder(w.Body).Decode(&response))

--- a/instrumentation/tracing.go
+++ b/instrumentation/tracing.go
@@ -174,4 +174,3 @@ func AddSecurityAttributes(span trace.Span, clientIP string) {
 		SetSpanAttributes(span, attribute.String(AttrClientIP, clientIP))
 	}
 }
-

--- a/instrumentation/tracing_test.go
+++ b/instrumentation/tracing_test.go
@@ -433,4 +433,3 @@ func TestNilSafeHelpers_WithNilSpans(_ *testing.T) {
 
 	// Should not panic
 }
-

--- a/security/audit.go
+++ b/security/audit.go
@@ -55,8 +55,10 @@ func (a *Auditor) LogEvent(ctx context.Context, event Event) {
 
 	event.Timestamp = time.Now()
 
-	a.logger.LogAttrs(ctx, slog.LevelInfo, "security_audit",
-		slog.Group("audit",
+	a.logger.LogAttrs(
+		ctx, slog.LevelInfo, "security_audit",
+		slog.Group(
+			"audit",
 			slog.String("event_type", event.Type),
 			slog.String("user_id_hash", hashForLogging(event.UserID)),
 			slog.String("client_id", event.ClientID),

--- a/security/events.go
+++ b/security/events.go
@@ -131,6 +131,13 @@ const (
 	// self-issued JWT access token's jti in the RevokedTokenStore denylist.
 	EventSelfIssuedJWTRevoked = "self_issued_jwt_revoked"
 
+	// EventIntrospectionRequesterDenied is logged when /oauth/introspect is
+	// called by a client that is neither the token's client_id nor on the
+	// IntrospectionResourceServers allowlist. The endpoint returns
+	// {"active": false} per RFC 7662 §2.2 so the denial is invisible to the
+	// caller, but the audit record preserves the cross-client probe attempt.
+	EventIntrospectionRequesterDenied = "introspection_requester_denied"
+
 	// Provider-related events
 
 	// EventInvalidProviderCallback is logged when provider callback validation fails

--- a/server/access_token.go
+++ b/server/access_token.go
@@ -39,6 +39,16 @@ type AccessTokenClaims struct {
 	// logs without an extra IdP round-trip.
 	Email string
 
+	// EmailVerified mirrors providers.UserInfo.EmailVerified. Emitted as the
+	// email_verified claim only when Email is non-empty, so that introspection
+	// of a JWT access token (RFC 7662 §2.2) projects the same identity
+	// attributes as the opaque branch.
+	EmailVerified bool
+
+	// Name mirrors providers.UserInfo.Name. Emitted as the OIDC standard name
+	// claim when non-empty; same parity rationale as EmailVerified.
+	Name string
+
 	// Groups are the user's group memberships from the upstream provider.
 	// Included verbatim under the "groups" claim when non-empty.
 	Groups []string
@@ -142,11 +152,13 @@ const rfc9068TokenType = "at+jwt"
 type rfc9068Claims struct {
 	josejwt.Claims
 
-	ClientID string   `json:"client_id,omitempty"`
-	Scope    string   `json:"scope,omitempty"`
-	Email    string   `json:"email,omitempty"`
-	Groups   []string `json:"groups,omitempty"`
-	FamilyID string   `json:"family_id,omitempty"`
+	ClientID      string   `json:"client_id,omitempty"`
+	Scope         string   `json:"scope,omitempty"`
+	Email         string   `json:"email,omitempty"`
+	EmailVerified *bool    `json:"email_verified,omitempty"`
+	Name          string   `json:"name,omitempty"`
+	Groups        []string `json:"groups,omitempty"`
+	FamilyID      string   `json:"family_id,omitempty"`
 }
 
 // Issue signs an RFC 9068 access token. The header carries alg/kid/typ; the
@@ -176,8 +188,13 @@ func (j *jwtIssuer) Issue(_ context.Context, c AccessTokenClaims) (string, error
 		ClientID: c.ClientID,
 		Scope:    helpers.JoinScopes(c.Scopes),
 		Email:    c.Email,
+		Name:     c.Name,
 		Groups:   c.Groups,
 		FamilyID: c.FamilyID,
+	}
+	if c.Email != "" {
+		verified := c.EmailVerified
+		claims.EmailVerified = &verified
 	}
 
 	signed, err := josejwt.Signed(j.signer).Claims(claims).Serialize()

--- a/server/config.go
+++ b/server/config.go
@@ -792,6 +792,13 @@ type Config struct {
 
 	// IntrospectionResourceServers lists client IDs permitted to introspect
 	// tokens they do not own. Empty means strict same-client gating.
+	//
+	// SECURITY: an allowlisted resource server receives the full RFC 7662 §2.2
+	// projection for any token issued to in-scope clients — including `sub`,
+	// `email`, `name`, `scope`, and `aud`. Allowlist only services that are
+	// already authorized to learn those attributes; this knob is not a
+	// substitute for token-binding or DPoP if the goal is to gate on the
+	// presenter rather than on the token's recipient.
 	IntrospectionResourceServers []string
 
 	// ClientMetadataCacheTTL is how long to cache fetched client metadata

--- a/server/config.go
+++ b/server/config.go
@@ -1091,9 +1091,9 @@ func (c *Config) Validate() error {
 }
 
 // validateIntrospectionResourceServers rejects empty entries in the allowlist.
-// An empty string would never match a requesting client (introspectionRequester
-// Allowed bails when requestingClient == "") so it can only mask operator
-// intent — fail closed at startup.
+// An empty string would never match a requesting client (the requester gate
+// bails when requestingClient == ""), so an empty entry can only mask
+// operator intent — fail closed at startup.
 func (c *Config) validateIntrospectionResourceServers() error {
 	for i, entry := range c.IntrospectionResourceServers {
 		if entry == "" {

--- a/server/config.go
+++ b/server/config.go
@@ -790,6 +790,17 @@ type Config struct {
 	// Default: false (not yet implemented)
 	EnableIntrospectionEndpoint bool
 
+	// IntrospectionResourceServers lists client IDs permitted to introspect tokens
+	// they don't own. Typically resource servers that need to validate access tokens
+	// issued to user-agent clients (RFC 7662 §2.1 explicitly contemplates this).
+	//
+	// When the requesting client matches the token's bound client_id the request
+	// is always allowed; otherwise the requester must appear in this list or the
+	// response is {"active": false} per RFC 7662 §2.2 with no claim leakage.
+	//
+	// Default: nil (strict same-client gating).
+	IntrospectionResourceServers []string
+
 	// ClientMetadataCacheTTL is how long to cache fetched client metadata
 	// Caching reduces latency and prevents repeated fetches for the same client
 	// HTTP Cache-Control headers may override this value

--- a/server/config.go
+++ b/server/config.go
@@ -1038,6 +1038,10 @@ func (c *Config) IsJWTAccessTokenFormat() bool {
 // are validated at construction time via applySecureDefaults / the
 // dedicated validate* helpers.
 func (c *Config) Validate() error {
+	if err := c.validateIntrospectionResourceServers(); err != nil {
+		return err
+	}
+
 	if !c.IsJWTAccessTokenFormat() {
 		// AccessTokenFormatOpaque (or empty/unknown — treated as opaque).
 		// Reject anything that is not the explicit opaque value or empty so
@@ -1066,6 +1070,19 @@ func (c *Config) Validate() error {
 			c.AccessTokenSigningAlgorithm, supportedSigningAlgorithmsList())
 	}
 	return validateSigningKeyMatchesAlgorithm(c.AccessTokenSigningKey, c.AccessTokenSigningAlgorithm)
+}
+
+// validateIntrospectionResourceServers rejects empty entries in the allowlist.
+// An empty string would never match a requesting client (introspectionRequester
+// Allowed bails when requestingClient == "") so it can only mask operator
+// intent — fail closed at startup.
+func (c *Config) validateIntrospectionResourceServers() error {
+	for i, entry := range c.IntrospectionResourceServers {
+		if entry == "" {
+			return fmt.Errorf("IntrospectionResourceServers[%d] is empty", i)
+		}
+	}
+	return nil
 }
 
 // validateSigningKeyMatchesAlgorithm enforces that the configured private

--- a/server/config.go
+++ b/server/config.go
@@ -790,15 +790,8 @@ type Config struct {
 	// Default: false (not yet implemented)
 	EnableIntrospectionEndpoint bool
 
-	// IntrospectionResourceServers lists client IDs permitted to introspect tokens
-	// they don't own. Typically resource servers that need to validate access tokens
-	// issued to user-agent clients (RFC 7662 §2.1 explicitly contemplates this).
-	//
-	// When the requesting client matches the token's bound client_id the request
-	// is always allowed; otherwise the requester must appear in this list or the
-	// response is {"active": false} per RFC 7662 §2.2 with no claim leakage.
-	//
-	// Default: nil (strict same-client gating).
+	// IntrospectionResourceServers lists client IDs permitted to introspect
+	// tokens they do not own. Empty means strict same-client gating.
 	IntrospectionResourceServers []string
 
 	// ClientMetadataCacheTTL is how long to cache fetched client metadata

--- a/server/flows.go
+++ b/server/flows.go
@@ -1537,6 +1537,8 @@ func (s *Server) fillUserInfoClaims(ctx context.Context, userID string, c *Acces
 		return
 	}
 	c.Email = info.Email
+	c.EmailVerified = info.EmailVerified
+	c.Name = info.Name
 	c.Groups = info.Groups
 }
 

--- a/server/flows.go
+++ b/server/flows.go
@@ -273,7 +273,8 @@ func (s *Server) ValidateToken(ctx context.Context, accessToken string) (*provid
 	// our iss bypass JWT-mode security by tripping the opaque or
 	// forwarded-token path.
 	if s.Config.IsJWTAccessTokenFormat() && s.looksLikeSelfIssuedJWT(accessToken) {
-		return s.validateSelfIssuedJWT(ctx, accessToken)
+		userInfo, _, err := s.validateSelfIssuedJWT(ctx, accessToken)
+		return userInfo, err
 	}
 
 	// PRIORITY 2: Forwarded ID token (JWT) from a trusted upstream service.

--- a/server/flows_jwt.go
+++ b/server/flows_jwt.go
@@ -295,6 +295,12 @@ func userInfoFromJWTClaims(claims map[string]any) *providers.UserInfo {
 	if v, ok := claims["email"].(string); ok {
 		info.Email = v
 	}
+	if v, ok := claims["email_verified"].(bool); ok {
+		info.EmailVerified = v
+	}
+	if v, ok := claims["name"].(string); ok {
+		info.Name = v
+	}
 	switch g := claims["groups"].(type) {
 	case []string:
 		info.Groups = append(info.Groups, g...)

--- a/server/flows_jwt.go
+++ b/server/flows_jwt.go
@@ -65,36 +65,40 @@ func (s *Server) looksLikeSelfIssuedJWT(tokenString string) bool {
 // typ, signature mismatch). Returns the wrapped underlying error for hard
 // rejections (revoked, expired, audience mismatch). Callers treat the
 // former as "fall through" and the latter as "reject".
-func (s *Server) validateSelfIssuedJWT(ctx context.Context, tokenString string) (*providers.UserInfo, error) {
+//
+// Returns the verified claim map alongside the UserInfo so callers that
+// need claim-level access (introspection, audit) don't need to re-parse +
+// re-verify the token, which would risk drift between the two pipelines.
+func (s *Server) validateSelfIssuedJWT(ctx context.Context, tokenString string) (*providers.UserInfo, map[string]any, error) {
 	if !s.Config.IsJWTAccessTokenFormat() {
-		return nil, errBearerNotSelfIssuedJWT
+		return nil, nil, errBearerNotSelfIssuedJWT
 	}
 
 	header, claims, err := s.parseAndVerifyJWTSignature(tokenString)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if err := s.checkJWTHeaderAndIssuer(header, claims); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := s.checkJWTExpiration(ctx, claims, tokenString); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := s.checkJWTAudience(ctx, claims, tokenString); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	jti, _ := claims["jti"].(string)
 	if err := s.checkJWTRevocation(ctx, jti, tokenString); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := s.checkJWTFamily(ctx, claims, tokenString); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	userInfo := userInfoFromJWTClaims(claims)
 	s.logSelfIssuedJWTAccepted(ctx, tokenString, userInfo, jti)
-	return userInfo, nil
+	return userInfo, claims, nil
 }
 
 // parseAndVerifyJWTSignature parses the JWT and verifies the signature

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -14,6 +14,12 @@ import (
 // or {"active": false} when requestingClient is not authorized to learn it.
 // Denied probes return no other fields so the endpoint is not an oracle for
 // token or user enumeration.
+//
+// Callers MUST authenticate requestingClient before invoking this method.
+// The cross-client gate trusts that identifier as-is; passing an attacker-
+// supplied or unauthenticated value defeats the gate entirely. The in-tree
+// caller is [Handler.ServeTokenIntrospection], which runs
+// authenticateIntrospectionClient first.
 func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingClient string) map[string]any {
 	if s.Config.IsJWTAccessTokenFormat() && s.looksLikeSelfIssuedJWT(accessToken) {
 		return s.introspectSelfIssuedJWT(ctx, accessToken, requestingClient)

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -2,9 +2,11 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
 	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage"
 )
 
@@ -13,30 +15,32 @@ import (
 // Denied probes return no other fields so the endpoint is not an oracle for
 // token or user enumeration.
 func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingClient string) map[string]any {
-	inactive := map[string]any{"active": false}
-
 	if s.Config.IsJWTAccessTokenFormat() && s.looksLikeSelfIssuedJWT(accessToken) {
-		return s.introspectSelfIssuedJWT(ctx, accessToken, requestingClient, inactive)
+		return s.introspectSelfIssuedJWT(ctx, accessToken, requestingClient)
 	}
-	return s.introspectOpaqueToken(ctx, accessToken, requestingClient, inactive)
+	return s.introspectOpaqueToken(ctx, accessToken, requestingClient)
 }
 
-// introspectSelfIssuedJWT skips the metadata store: a verified self-issued JWT
-// already carries every RFC 7662 §2.2 claim signed by the AS.
-func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, requestingClient string, inactive map[string]any) map[string]any {
-	userInfo, err := s.validateSelfIssuedJWT(ctx, accessToken)
-	if err != nil || userInfo == nil {
-		return inactive
-	}
+// inactiveIntrospectionResponse is the RFC 7662 §2.2 response for any token
+// the requester is not authorized to introspect or that fails validation.
+// Constructed fresh per call so a caller mutating it cannot affect another.
+func inactiveIntrospectionResponse() map[string]any {
+	return map[string]any{"active": false}
+}
 
-	_, claims, err := s.parseAndVerifyJWTSignature(accessToken)
-	if err != nil {
-		return inactive
+// introspectSelfIssuedJWT runs the same verification pipeline as
+// [Server.validateSelfIssuedJWT] and projects the verified claim set into the
+// RFC 7662 §2.2 response — single pass, no re-verification, no drift between
+// the two paths.
+func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, requestingClient string) map[string]any {
+	userInfo, claims, err := s.validateSelfIssuedJWT(ctx, accessToken)
+	if err != nil || userInfo == nil {
+		return inactiveIntrospectionResponse()
 	}
 
 	tokenBoundClient, _ := claims["client_id"].(string)
-	if !s.introspectionRequesterAllowed(requestingClient, tokenBoundClient) {
-		return inactive
+	if !s.introspectionRequesterAllowed(ctx, requestingClient, tokenBoundClient) {
+		return inactiveIntrospectionResponse()
 	}
 
 	return introspectionResponseFromJWTClaims(claims, tokenBoundClient)
@@ -72,30 +76,38 @@ func copyClaimString(dst, claims map[string]any, key string) {
 }
 
 func copyClaimUnixTime(dst, claims map[string]any, key string) {
-	if v, ok := claims[key].(float64); ok {
+	switch v := claims[key].(type) {
+	case float64:
 		dst[key] = int64(v)
+	case json.Number:
+		// jose's Claims decoder uses float64 by default but the underlying
+		// json decoder can be configured for json.Number — accept both so a
+		// future decode-mode change does not silently drop exp/iat/nbf.
+		if n, err := v.Int64(); err == nil {
+			dst[key] = n
+		}
 	}
 }
 
 // introspectOpaqueToken gates on the requester before fetching userinfo, so a
 // denied probe never triggers a provider round-trip nor leaks user attributes.
-func (s *Server) introspectOpaqueToken(ctx context.Context, accessToken, requestingClient string, inactive map[string]any) map[string]any {
+func (s *Server) introspectOpaqueToken(ctx context.Context, accessToken, requestingClient string) map[string]any {
 	metaGetter, ok := s.tokenStore.(storage.TokenMetadataGetter)
 	if !ok {
-		return inactive
+		return inactiveIntrospectionResponse()
 	}
 	tokenMetadata, err := metaGetter.GetTokenMetadata(accessToken)
 	if err != nil || tokenMetadata == nil {
-		return inactive
+		return inactiveIntrospectionResponse()
 	}
 
-	if !s.introspectionRequesterAllowed(requestingClient, tokenMetadata.ClientID) {
-		return inactive
+	if !s.introspectionRequesterAllowed(ctx, requestingClient, tokenMetadata.ClientID) {
+		return inactiveIntrospectionResponse()
 	}
 
 	userInfo, err := s.ValidateToken(ctx, accessToken)
 	if err != nil || userInfo == nil {
-		return inactive
+		return inactiveIntrospectionResponse()
 	}
 
 	return s.introspectionResponseFromOpaqueToken(ctx, accessToken, tokenMetadata, userInfo)
@@ -131,10 +143,12 @@ func (s *Server) introspectionResponseFromOpaqueToken(ctx context.Context, acces
 	return response
 }
 
-// introspectionRequesterAllowed fails closed: an empty client ID on either
-// side denies, even though a well-formed token always carries one.
-func (s *Server) introspectionRequesterAllowed(requestingClient, tokenBoundClient string) bool {
+// introspectionRequesterAllowed fails closed. Denials emit
+// EventIntrospectionRequesterDenied so cross-client probes are visible in the
+// audit log even though the RFC 7662 §2.2 response hides them from the caller.
+func (s *Server) introspectionRequesterAllowed(ctx context.Context, requestingClient, tokenBoundClient string) bool {
 	if tokenBoundClient == "" || requestingClient == "" {
+		s.logIntrospectionRequesterDenied(ctx, requestingClient, tokenBoundClient, "empty_client_id")
 		return false
 	}
 	if requestingClient == tokenBoundClient {
@@ -145,5 +159,21 @@ func (s *Server) introspectionRequesterAllowed(requestingClient, tokenBoundClien
 			return true
 		}
 	}
+	s.logIntrospectionRequesterDenied(ctx, requestingClient, tokenBoundClient, "cross_client_probe")
 	return false
+}
+
+func (s *Server) logIntrospectionRequesterDenied(ctx context.Context, requestingClient, tokenBoundClient, reason string) {
+	if s.Auditor == nil {
+		return
+	}
+	s.Auditor.LogEvent(ctx, security.Event{
+		Type:     security.EventIntrospectionRequesterDenied,
+		ClientID: requestingClient,
+		Details: map[string]any{
+			"severity":           "medium",
+			"reason":             reason,
+			"token_bound_client": tokenBoundClient,
+		},
+	})
 }

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"context"
+
+	"github.com/giantswarm/mcp-oauth/internal/helpers"
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/storage"
+)
+
+// IntrospectToken returns the RFC 7662 token-introspection payload for the
+// given bearer when the requesting client is authorized to learn it.
+//
+// Authorization (RFC 7662 §2.1): the requester must either be the client the
+// token was issued to, or appear in Config.IntrospectionResourceServers.
+// Cross-client probes return {"active": false} with no other fields populated
+// so the endpoint cannot be used as an oracle for token / user enumeration.
+//
+// The response shape follows RFC 7662 §2.2: active, scope, client_id, sub,
+// token_type, exp, iat, aud, iss. Email-related extras (email, email_verified,
+// name) are included only on the authorized path so they do not leak through
+// the gate.
+func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingClient string) map[string]any {
+	inactive := map[string]any{"active": false}
+
+	if s.Config.IsJWTAccessTokenFormat() && s.looksLikeSelfIssuedJWT(accessToken) {
+		return s.introspectSelfIssuedJWT(ctx, accessToken, requestingClient, inactive)
+	}
+	return s.introspectOpaqueToken(ctx, accessToken, requestingClient, inactive)
+}
+
+// introspectSelfIssuedJWT validates a self-issued JWT and projects its claims
+// directly into the response. The metadata round-trip is skipped: the JWT
+// carries iss/exp/iat/aud/scope/sub/client_id already and they have just been
+// re-verified against the configured signing key.
+func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, requestingClient string, inactive map[string]any) map[string]any {
+	userInfo, err := s.validateSelfIssuedJWT(ctx, accessToken)
+	if err != nil || userInfo == nil {
+		return inactive
+	}
+
+	_, claims, err := s.parseAndVerifyJWTSignature(accessToken)
+	if err != nil {
+		return inactive
+	}
+
+	tokenBoundClient, _ := claims["client_id"].(string)
+	if !s.introspectionRequesterAllowed(requestingClient, tokenBoundClient) {
+		return inactive
+	}
+
+	return introspectionResponseFromJWTClaims(claims, tokenBoundClient)
+}
+
+// introspectionResponseFromJWTClaims projects the JWT claim map into an
+// RFC 7662 §2.2 response. Pulled out of introspectSelfIssuedJWT so the
+// per-claim copying does not push the parent over the cyclomatic-complexity
+// budget; the projection is mechanical and has no security state.
+func introspectionResponseFromJWTClaims(claims map[string]any, tokenBoundClient string) map[string]any {
+	response := map[string]any{
+		"active":     true,
+		"token_type": "Bearer",
+	}
+	if tokenBoundClient != "" {
+		response["client_id"] = tokenBoundClient
+	}
+	copyClaimString(response, claims, "sub")
+	copyClaimString(response, claims, "iss")
+	copyClaimString(response, claims, "scope")
+	copyClaimString(response, claims, "email")
+	copyClaimUnixTime(response, claims, "exp")
+	copyClaimUnixTime(response, claims, "iat")
+	copyClaimUnixTime(response, claims, "nbf")
+	if aud := audiencesFromClaim(claims["aud"]); len(aud) == 1 {
+		response["aud"] = aud[0]
+	} else if len(aud) > 1 {
+		response["aud"] = aud
+	}
+	return response
+}
+
+func copyClaimString(dst, claims map[string]any, key string) {
+	if v, ok := claims[key].(string); ok && v != "" {
+		dst[key] = v
+	}
+}
+
+func copyClaimUnixTime(dst, claims map[string]any, key string) {
+	if v, ok := claims[key].(float64); ok {
+		dst[key] = int64(v)
+	}
+}
+
+// introspectOpaqueToken resolves an opaque token by consulting the
+// TokenMetadata store for ownership / scope / audience / iat and the
+// TokenStore for expiry (the upstream-bound provider token shares its
+// expiry with the AS-issued bearer per capTokenExpiry). The cross-client
+// gate runs before the provider userinfo round-trip so a denied probe
+// reveals nothing — neither active state nor user attributes.
+func (s *Server) introspectOpaqueToken(ctx context.Context, accessToken, requestingClient string, inactive map[string]any) map[string]any {
+	metaGetter, ok := s.tokenStore.(storage.TokenMetadataGetter)
+	if !ok {
+		return inactive
+	}
+	tokenMetadata, err := metaGetter.GetTokenMetadata(accessToken)
+	if err != nil || tokenMetadata == nil {
+		return inactive
+	}
+
+	if !s.introspectionRequesterAllowed(requestingClient, tokenMetadata.ClientID) {
+		return inactive
+	}
+
+	userInfo, err := s.ValidateToken(ctx, accessToken)
+	if err != nil || userInfo == nil {
+		return inactive
+	}
+
+	return s.introspectionResponseFromOpaqueToken(ctx, accessToken, tokenMetadata, userInfo)
+}
+
+func (s *Server) introspectionResponseFromOpaqueToken(ctx context.Context, accessToken string, tokenMetadata *storage.TokenMetadata, userInfo *providers.UserInfo) map[string]any {
+	response := map[string]any{
+		"active":     true,
+		"token_type": "Bearer",
+		"client_id":  tokenMetadata.ClientID,
+		"sub":        userInfo.ID,
+		"iss":        s.Config.Issuer,
+	}
+	if userInfo.Email != "" {
+		response["email"] = userInfo.Email
+		response["email_verified"] = userInfo.EmailVerified
+	}
+	if userInfo.Name != "" {
+		response["name"] = userInfo.Name
+	}
+	if scope := helpers.JoinScopes(tokenMetadata.Scopes); scope != "" {
+		response["scope"] = scope
+	}
+	if tokenMetadata.Audience != "" {
+		response["aud"] = tokenMetadata.Audience
+	}
+	if !tokenMetadata.IssuedAt.IsZero() {
+		response["iat"] = tokenMetadata.IssuedAt.Unix()
+	}
+	if storedToken, err := s.tokenStore.GetToken(ctx, accessToken); err == nil && storedToken != nil && !storedToken.Expiry.IsZero() {
+		response["exp"] = storedToken.Expiry.Unix()
+	}
+	return response
+}
+
+// introspectionRequesterAllowed implements the RFC 7662 §2.1 authorization
+// gate: the requester is allowed when it owns the token or when it has been
+// enrolled in IntrospectionResourceServers. An empty tokenBoundClient (which
+// should not occur on a well-formed token) denies by default.
+func (s *Server) introspectionRequesterAllowed(requestingClient, tokenBoundClient string) bool {
+	if tokenBoundClient == "" || requestingClient == "" {
+		return false
+	}
+	if requestingClient == tokenBoundClient {
+		return true
+	}
+	for _, allowed := range s.Config.IntrospectionResourceServers {
+		if allowed == requestingClient {
+			return true
+		}
+	}
+	return false
+}

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -8,18 +8,10 @@ import (
 	"github.com/giantswarm/mcp-oauth/storage"
 )
 
-// IntrospectToken returns the RFC 7662 token-introspection payload for the
-// given bearer when the requesting client is authorized to learn it.
-//
-// Authorization (RFC 7662 §2.1): the requester must either be the client the
-// token was issued to, or appear in Config.IntrospectionResourceServers.
-// Cross-client probes return {"active": false} with no other fields populated
-// so the endpoint cannot be used as an oracle for token / user enumeration.
-//
-// The response shape follows RFC 7662 §2.2: active, scope, client_id, sub,
-// token_type, exp, iat, aud, iss. Email-related extras (email, email_verified,
-// name) are included only on the authorized path so they do not leak through
-// the gate.
+// IntrospectToken returns the RFC 7662 introspection payload for accessToken,
+// or {"active": false} when requestingClient is not authorized to learn it.
+// Denied probes return no other fields so the endpoint is not an oracle for
+// token or user enumeration.
 func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingClient string) map[string]any {
 	inactive := map[string]any{"active": false}
 
@@ -29,10 +21,8 @@ func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingCli
 	return s.introspectOpaqueToken(ctx, accessToken, requestingClient, inactive)
 }
 
-// introspectSelfIssuedJWT validates a self-issued JWT and projects its claims
-// directly into the response. The metadata round-trip is skipped: the JWT
-// carries iss/exp/iat/aud/scope/sub/client_id already and they have just been
-// re-verified against the configured signing key.
+// introspectSelfIssuedJWT skips the metadata store: a verified self-issued JWT
+// already carries every RFC 7662 §2.2 claim signed by the AS.
 func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, requestingClient string, inactive map[string]any) map[string]any {
 	userInfo, err := s.validateSelfIssuedJWT(ctx, accessToken)
 	if err != nil || userInfo == nil {
@@ -52,10 +42,6 @@ func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, reque
 	return introspectionResponseFromJWTClaims(claims, tokenBoundClient)
 }
 
-// introspectionResponseFromJWTClaims projects the JWT claim map into an
-// RFC 7662 §2.2 response. Pulled out of introspectSelfIssuedJWT so the
-// per-claim copying does not push the parent over the cyclomatic-complexity
-// budget; the projection is mechanical and has no security state.
 func introspectionResponseFromJWTClaims(claims map[string]any, tokenBoundClient string) map[string]any {
 	response := map[string]any{
 		"active":     true,
@@ -91,12 +77,8 @@ func copyClaimUnixTime(dst, claims map[string]any, key string) {
 	}
 }
 
-// introspectOpaqueToken resolves an opaque token by consulting the
-// TokenMetadata store for ownership / scope / audience / iat and the
-// TokenStore for expiry (the upstream-bound provider token shares its
-// expiry with the AS-issued bearer per capTokenExpiry). The cross-client
-// gate runs before the provider userinfo round-trip so a denied probe
-// reveals nothing — neither active state nor user attributes.
+// introspectOpaqueToken gates on the requester before fetching userinfo, so a
+// denied probe never triggers a provider round-trip nor leaks user attributes.
 func (s *Server) introspectOpaqueToken(ctx context.Context, accessToken, requestingClient string, inactive map[string]any) map[string]any {
 	metaGetter, ok := s.tokenStore.(storage.TokenMetadataGetter)
 	if !ok {
@@ -149,10 +131,8 @@ func (s *Server) introspectionResponseFromOpaqueToken(ctx context.Context, acces
 	return response
 }
 
-// introspectionRequesterAllowed implements the RFC 7662 §2.1 authorization
-// gate: the requester is allowed when it owns the token or when it has been
-// enrolled in IntrospectionResourceServers. An empty tokenBoundClient (which
-// should not occur on a well-formed token) denies by default.
+// introspectionRequesterAllowed fails closed: an empty client ID on either
+// side denies, even though a well-formed token always carries one.
 func (s *Server) introspectionRequesterAllowed(requestingClient, tokenBoundClient string) bool {
 	if tokenBoundClient == "" || requestingClient == "" {
 		return false

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"context"
-	"encoding/json"
+	"slices"
 
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
 	"github.com/giantswarm/mcp-oauth/providers"
@@ -82,16 +82,8 @@ func copyClaimString(dst, claims map[string]any, key string) {
 }
 
 func copyClaimUnixTime(dst, claims map[string]any, key string) {
-	switch v := claims[key].(type) {
-	case float64:
+	if v, ok := claims[key].(float64); ok {
 		dst[key] = int64(v)
-	case json.Number:
-		// jose's Claims decoder uses float64 by default but the underlying
-		// json decoder can be configured for json.Number — accept both so a
-		// future decode-mode change does not silently drop exp/iat/nbf.
-		if n, err := v.Int64(); err == nil {
-			dst[key] = n
-		}
 	}
 }
 
@@ -153,17 +145,19 @@ func (s *Server) introspectionResponseFromOpaqueToken(ctx context.Context, acces
 // EventIntrospectionRequesterDenied so cross-client probes are visible in the
 // audit log even though the RFC 7662 §2.2 response hides them from the caller.
 func (s *Server) introspectionRequesterAllowed(ctx context.Context, requestingClient, tokenBoundClient string) bool {
-	if tokenBoundClient == "" || requestingClient == "" {
-		s.logIntrospectionRequesterDenied(ctx, requestingClient, tokenBoundClient, "empty_client_id")
+	if requestingClient == "" {
+		s.logIntrospectionRequesterDenied(ctx, requestingClient, tokenBoundClient, "empty_requester")
+		return false
+	}
+	if tokenBoundClient == "" {
+		s.logIntrospectionRequesterDenied(ctx, requestingClient, tokenBoundClient, "empty_token_bound_client")
 		return false
 	}
 	if requestingClient == tokenBoundClient {
 		return true
 	}
-	for _, allowed := range s.Config.IntrospectionResourceServers {
-		if allowed == requestingClient {
-			return true
-		}
+	if slices.Contains(s.Config.IntrospectionResourceServers, requestingClient) {
+		return true
 	}
 	s.logIntrospectionRequesterDenied(ctx, requestingClient, tokenBoundClient, "cross_client_probe")
 	return false

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -2,13 +2,36 @@ package server
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"slices"
 
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
 	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage"
 )
+
+// validateIntrospectionAllowlistRegistered verifies every entry in
+// Config.IntrospectionResourceServers resolves to a registered client. Catches
+// operator typos that would otherwise silently deny every probe.
+//
+// A backend that returns transient errors during startup is treated as fatal
+// here: bringing up a server with an unverifiable allowlist would leave the
+// gate's correctness in an unknown state.
+func (s *Server) validateIntrospectionAllowlistRegistered(ctx context.Context) error {
+	for i, clientID := range s.Config.IntrospectionResourceServers {
+		_, err := s.clientStore.GetClient(ctx, clientID)
+		if errors.Is(err, storage.ErrClientNotFound) {
+			return fmt.Errorf("IntrospectionResourceServers[%d] %q is not a registered client", i, clientID)
+		}
+		if err != nil {
+			return fmt.Errorf("IntrospectionResourceServers[%d] %q lookup failed: %w", i, clientID, err)
+		}
+	}
+	return nil
+}
 
 // IntrospectToken returns the RFC 7662 introspection payload for accessToken,
 // or {"active": false} when requestingClient is not authorized to learn it.
@@ -17,9 +40,7 @@ import (
 //
 // Callers MUST authenticate requestingClient before invoking this method.
 // The cross-client gate trusts that identifier as-is; passing an attacker-
-// supplied or unauthenticated value defeats the gate entirely. The in-tree
-// caller is [Handler.ServeTokenIntrospection], which runs
-// authenticateIntrospectionClient first.
+// supplied or unauthenticated value defeats the gate entirely.
 func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingClient string) map[string]any {
 	if s.Config.IsJWTAccessTokenFormat() && s.looksLikeSelfIssuedJWT(accessToken) {
 		return s.introspectSelfIssuedJWT(ctx, accessToken, requestingClient)
@@ -34,22 +55,50 @@ func inactiveIntrospectionResponse() map[string]any {
 	return map[string]any{"active": false}
 }
 
-// introspectSelfIssuedJWT runs the same verification pipeline as
-// [Server.validateSelfIssuedJWT] and projects the verified claim set into the
-// RFC 7662 §2.2 response — single pass, no re-verification, no drift between
-// the two paths.
+// introspectSelfIssuedJWT projects the verified claim set into the RFC 7662
+// §2.2 response.
+//
+// Gate ordering: the cross-client check runs against the UNVERIFIED client_id
+// claim first, so a probe for a JWT the requester does not own is rejected
+// before the heavy validation pipeline runs. The verified claim is re-checked
+// after validation; signature verification ensures an attacker cannot forge a
+// matching unverified client_id to bypass the gate (signature would fail and
+// the response stays inactive). This collapses the timing distinction between
+// "valid JWT I don't own" and "garbage JWT" — both return inactive after a
+// single unverified parse.
 func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, requestingClient string) map[string]any {
+	unverifiedBoundClient := unverifiedClientIDClaim(accessToken)
+	if !s.introspectionRequesterAllowed(ctx, requestingClient, unverifiedBoundClient) {
+		return inactiveIntrospectionResponse()
+	}
+
 	userInfo, claims, err := s.validateSelfIssuedJWT(ctx, accessToken)
 	if err != nil || userInfo == nil {
 		return inactiveIntrospectionResponse()
 	}
 
-	tokenBoundClient, _ := claims["client_id"].(string)
-	if !s.introspectionRequesterAllowed(ctx, requestingClient, tokenBoundClient) {
+	verifiedBoundClient, _ := claims["client_id"].(string)
+	if verifiedBoundClient != unverifiedBoundClient &&
+		!s.introspectionRequesterAllowed(ctx, requestingClient, verifiedBoundClient) {
 		return inactiveIntrospectionResponse()
 	}
 
-	return introspectionResponseFromJWTClaims(claims, tokenBoundClient)
+	return introspectionResponseFromJWTClaims(claims, verifiedBoundClient)
+}
+
+// unverifiedClientIDClaim returns the client_id claim from accessToken without
+// verifying the signature. Used only for the introspection gate's early
+// reject path; the verified claim is re-checked after full validation.
+func unverifiedClientIDClaim(accessToken string) string {
+	if !oidc.IsJWT(accessToken) {
+		return ""
+	}
+	claims, err := oidc.ParseUnverifiedClaims(accessToken)
+	if err != nil {
+		return ""
+	}
+	v, _ := claims["client_id"].(string)
+	return v
 }
 
 func introspectionResponseFromJWTClaims(claims map[string]any, tokenBoundClient string) map[string]any {
@@ -64,19 +113,25 @@ func introspectionResponseFromJWTClaims(claims map[string]any, tokenBoundClient 
 	copyClaimString(response, claims, "iss")
 	copyClaimString(response, claims, "scope")
 	copyClaimString(response, claims, "email")
+	copyClaimString(response, claims, "name")
+	copyClaimBool(response, claims, "email_verified")
 	copyClaimUnixTime(response, claims, "exp")
 	copyClaimUnixTime(response, claims, "iat")
 	copyClaimUnixTime(response, claims, "nbf")
 	if aud := audiencesFromClaim(claims["aud"]); len(aud) == 1 {
 		response["aud"] = aud[0]
-	} else if len(aud) > 1 {
-		response["aud"] = aud
 	}
 	return response
 }
 
 func copyClaimString(dst, claims map[string]any, key string) {
 	if v, ok := claims[key].(string); ok && v != "" {
+		dst[key] = v
+	}
+}
+
+func copyClaimBool(dst, claims map[string]any, key string) {
+	if v, ok := claims[key].(bool); ok {
 		dst[key] = v
 	}
 }

--- a/server/introspect_test.go
+++ b/server/introspect_test.go
@@ -1,15 +1,53 @@
 package server
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/storage"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
+
+// auditRecord is the shape of one slog record emitted by [security.Auditor]
+// after JSON-encoding via [slog.NewJSONHandler]. Only the audit group is
+// exercised in tests; top-level slog fields (time, level, msg) are ignored.
+type auditRecord struct {
+	EventType string         `json:"event_type"`
+	ClientID  string         `json:"client_id"`
+	Details   map[string]any `json:"details"`
+}
+
+func decodeAuditRecords(t *testing.T, raw []byte) []auditRecord {
+	t.Helper()
+	var out []auditRecord
+	for _, line := range bytes.Split(bytes.TrimSpace(raw), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var envelope struct {
+			Audit auditRecord `json:"audit"`
+		}
+		require.NoError(t, json.Unmarshal(line, &envelope), "unmarshal %s", line)
+		if envelope.Audit.EventType != "" {
+			out = append(out, envelope.Audit)
+		}
+	}
+	return out
+}
+
+func newRecordingAuditor() (*security.Auditor, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(buf, nil))
+	return security.NewAuditor(logger, true), buf
+}
 
 // newJWTIntrospectionServer wires a JWT-mode server, an opaque-mode mock
 // provider, and three registered clients (token owner, probing client,
@@ -46,13 +84,15 @@ func newJWTIntrospectionServer(t *testing.T) (srv *Server, accessToken, ownerCli
 	issuer, err := newJWTIssuer(cfg)
 	require.NoError(t, err)
 	token, err := issuer.Issue(context.Background(), AccessTokenClaims{
-		Subject:   "user-42",
-		ClientID:  owner.ClientID,
-		Audience:  cfg.GetResourceIdentifier(),
-		Scopes:    []string{"openid", "email"},
-		Email:     "user@example.com",
-		IssuedAt:  now,
-		ExpiresAt: now.Add(15 * time.Minute),
+		Subject:       "user-42",
+		ClientID:      owner.ClientID,
+		Audience:      cfg.GetResourceIdentifier(),
+		Scopes:        []string{"openid", "email"},
+		Email:         "user@example.com",
+		EmailVerified: true,
+		Name:          "User Forty-Two",
+		IssuedAt:      now,
+		ExpiresAt:     now.Add(15 * time.Minute),
 	})
 	require.NoError(t, err)
 
@@ -71,10 +111,11 @@ func TestServer_IntrospectToken_JWTPath_OwnerSeesProjection(t *testing.T) {
 	require.Equal(t, "https://auth.example.com", response["iss"])
 	require.Equal(t, "openid email", response["scope"])
 	require.Equal(t, "user@example.com", response["email"])
+	require.Equal(t, true, response["email_verified"], "JWT mode must project email_verified for parity with opaque mode")
+	require.Equal(t, "User Forty-Two", response["name"], "JWT mode must project name for parity with opaque mode")
 	require.Equal(t, srv.Config.GetResourceIdentifier(), response["aud"])
 	require.Contains(t, response, "exp")
 	require.Contains(t, response, "iat")
-	// exp / iat must be int64 — copyClaimUnixTime converts the float64 claim.
 	_, expIsInt := response["exp"].(int64)
 	require.True(t, expIsInt, "exp should be int64 after projection (got %T)", response["exp"])
 }
@@ -108,4 +149,97 @@ func TestServer_Config_Validate_EmptyIntrospectionResourceServerEntryFailsClosed
 	err := cfg.Validate()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "IntrospectionResourceServers[1] is empty")
+}
+
+// TestServer_IntrospectToken_JWTPath_GarbageToken_RejectedBeforeValidation
+// pins the timing-oracle defence: a forged JWT with client_id == requester
+// must still return inactive (signature verify rejects it). Both the "valid
+// JWT I don't own" and "garbage JWT" paths return identical responses; the
+// only timing artefact is the unverified parse + one gate evaluation.
+func TestServer_IntrospectToken_JWTPath_GarbageToken_RejectedBeforeValidation(t *testing.T) {
+	srv, _, owner, _, _ := newJWTIntrospectionServer(t)
+
+	// A garbage JWT whose unverified client_id claim matches the requester:
+	// the gate would let it through, but signature verification rejects it.
+	garbage := "eyJhbGciOiJSUzI1NiIsImtpZCI6ImtpZC1pbnRyb3NwZWN0IiwidHlwIjoiYXQrand0In0." +
+		"eyJpc3MiOiJodHRwczovL2F1dGguZXhhbXBsZS5jb20iLCJjbGllbnRfaWQiOiIiLCJzdWIiOiJ4In0." +
+		"aW52YWxpZF9zaWduYXR1cmU"
+
+	response := srv.IntrospectToken(context.Background(), garbage, owner)
+	require.Equal(t, false, response["active"])
+	require.Len(t, response, 1, "garbage JWT must return only {active: false}")
+}
+
+func TestServer_IntrospectToken_JWTPath_CrossClientDenied_EmitsAuditEvent(t *testing.T) {
+	srv, token, _, probe, _ := newJWTIntrospectionServer(t)
+	auditor, buf := newRecordingAuditor()
+	srv.Auditor = auditor
+
+	response := srv.IntrospectToken(context.Background(), token, probe)
+	require.Equal(t, false, response["active"])
+
+	records := decodeAuditRecords(t, buf.Bytes())
+	require.Len(t, records, 1)
+	require.Equal(t, security.EventIntrospectionRequesterDenied, records[0].EventType)
+	require.Equal(t, probe, records[0].ClientID)
+	require.Equal(t, "medium", records[0].Details["severity"])
+	require.Equal(t, "cross_client_probe", records[0].Details["reason"])
+}
+
+func TestServer_IntrospectToken_OpaquePath_CrossClientDenied_EmitsAuditEvent(t *testing.T) {
+	ctx := context.Background()
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	cfg := &Config{
+		Issuer:            "https://auth.example.com",
+		AccessTokenFormat: AccessTokenFormatOpaque,
+	}
+	require.NoError(t, cfg.Validate())
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, nil)
+	require.NoError(t, err)
+
+	owner, _, err := srv.RegisterClient(ctx, "Owner", ClientTypeConfidential, "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
+	require.NoError(t, err)
+	probe, _, err := srv.RegisterClient(ctx, "Probe", ClientTypeConfidential, "", []string{"https://example.com/cb-probe"}, []string{"openid"}, "192.168.1.2", 10)
+	require.NoError(t, err)
+
+	auditor, buf := newRecordingAuditor()
+	srv.Auditor = auditor
+
+	const accessToken = "opaque-audit-token"
+	require.NoError(t, store.SaveTokenMetadata(ctx, accessToken, storage.TokenMetadata{
+		UserID:    "user-1",
+		ClientID:  owner.ClientID,
+		TokenType: "access",
+		Audience:  cfg.GetResourceIdentifier(),
+		Scopes:    []string{"openid"},
+	}))
+
+	response := srv.IntrospectToken(ctx, accessToken, probe.ClientID)
+	require.Equal(t, false, response["active"])
+
+	records := decodeAuditRecords(t, buf.Bytes())
+	require.Len(t, records, 1)
+	require.Equal(t, security.EventIntrospectionRequesterDenied, records[0].EventType)
+	require.Equal(t, probe.ClientID, records[0].ClientID)
+	require.Equal(t, "medium", records[0].Details["severity"])
+	require.Equal(t, "cross_client_probe", records[0].Details["reason"])
+	require.Equal(t, owner.ClientID, records[0].Details["token_bound_client"])
+}
+
+func TestNew_RejectsUnregisteredIntrospectionResourceServer(t *testing.T) {
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	cfg := &Config{
+		Issuer:                       "https://auth.example.com",
+		AccessTokenFormat:            AccessTokenFormatOpaque,
+		IntrospectionResourceServers: []string{"not-registered"},
+	}
+
+	_, err := New(mock.NewProvider(), store, store, store, cfg, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "IntrospectionResourceServers[0] \"not-registered\" is not a registered client")
 }

--- a/server/introspect_test.go
+++ b/server/introspect_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// newJWTIntrospectionServer wires a JWT-mode server, an opaque-mode mock
+// provider, and three registered clients (token owner, probing client,
+// allowlisted resource server). It returns the server and the issued JWT
+// access token.
+func newJWTIntrospectionServer(t *testing.T) (srv *Server, accessToken, ownerClientID, probingClientID, resourceServerID string) {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	cfg := &Config{
+		Issuer:                      "https://auth.example.com",
+		AccessTokenFormat:           AccessTokenFormatJWT,
+		AccessTokenSigningKey:       generateRSAKey(t),
+		AccessTokenSigningKeyID:     "kid-introspect",
+		AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
+		AccessTokenTTL:              3600,
+		ClockSkewGracePeriod:        5,
+	}
+	require.NoError(t, cfg.Validate())
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, nil)
+	require.NoError(t, err)
+
+	owner, _, err := srv.RegisterClient(context.Background(), "Owner", ClientTypeConfidential, "", []string{"https://example.com/cb-owner"}, []string{"openid"}, "192.168.1.1", 10)
+	require.NoError(t, err)
+	probe, _, err := srv.RegisterClient(context.Background(), "Probe", ClientTypeConfidential, "", []string{"https://example.com/cb-probe"}, []string{"openid"}, "192.168.1.2", 10)
+	require.NoError(t, err)
+	rs, _, err := srv.RegisterClient(context.Background(), "Resource Server", ClientTypeConfidential, "", []string{"https://example.com/cb-rs"}, []string{"openid"}, "192.168.1.3", 10)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	issuer, err := newJWTIssuer(cfg)
+	require.NoError(t, err)
+	token, err := issuer.Issue(context.Background(), AccessTokenClaims{
+		Subject:   "user-42",
+		ClientID:  owner.ClientID,
+		Audience:  cfg.GetResourceIdentifier(),
+		Scopes:    []string{"openid", "email"},
+		Email:     "user@example.com",
+		IssuedAt:  now,
+		ExpiresAt: now.Add(15 * time.Minute),
+	})
+	require.NoError(t, err)
+
+	return srv, token, owner.ClientID, probe.ClientID, rs.ClientID
+}
+
+func TestServer_IntrospectToken_JWTPath_OwnerSeesProjection(t *testing.T) {
+	srv, token, owner, _, _ := newJWTIntrospectionServer(t)
+
+	response := srv.IntrospectToken(context.Background(), token, owner)
+
+	require.Equal(t, true, response["active"])
+	require.Equal(t, "Bearer", response["token_type"])
+	require.Equal(t, owner, response["client_id"])
+	require.Equal(t, "user-42", response["sub"])
+	require.Equal(t, "https://auth.example.com", response["iss"])
+	require.Equal(t, "openid email", response["scope"])
+	require.Equal(t, "user@example.com", response["email"])
+	require.Equal(t, srv.Config.GetResourceIdentifier(), response["aud"])
+	require.Contains(t, response, "exp")
+	require.Contains(t, response, "iat")
+	// exp / iat must be int64 — copyClaimUnixTime converts the float64 claim.
+	_, expIsInt := response["exp"].(int64)
+	require.True(t, expIsInt, "exp should be int64 after projection (got %T)", response["exp"])
+}
+
+func TestServer_IntrospectToken_JWTPath_CrossClientDenied(t *testing.T) {
+	srv, token, _, probe, _ := newJWTIntrospectionServer(t)
+
+	response := srv.IntrospectToken(context.Background(), token, probe)
+
+	require.Equal(t, false, response["active"])
+	for _, leaked := range []string{"sub", "email", "client_id", "scope", "aud", "iss", "exp", "iat", "token_type"} {
+		require.NotContains(t, response, leaked, "cross-client JWT probe leaked %q", leaked)
+	}
+}
+
+func TestServer_IntrospectToken_JWTPath_AllowlistedResourceServer(t *testing.T) {
+	srv, token, owner, _, rs := newJWTIntrospectionServer(t)
+	srv.Config.IntrospectionResourceServers = []string{rs}
+
+	response := srv.IntrospectToken(context.Background(), token, rs)
+
+	require.Equal(t, true, response["active"])
+	require.Equal(t, owner, response["client_id"], "client_id must reflect the token's owner, not the introspecting RS")
+}
+
+func TestServer_Config_Validate_EmptyIntrospectionResourceServerEntryFailsClosed(t *testing.T) {
+	cfg := &Config{
+		Issuer:                       "https://auth.example.com",
+		IntrospectionResourceServers: []string{"valid-client", ""},
+	}
+	err := cfg.Validate()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "IntrospectionResourceServers[1] is empty")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -165,6 +165,10 @@ func New(
 		return nil, fmt.Errorf("invalid server config: %w", err)
 	}
 
+	if err := srv.validateIntrospectionAllowlistRegistered(cleanupCtx); err != nil {
+		return nil, fmt.Errorf("invalid server config: %w", err)
+	}
+
 	if err := srv.initializeAccessTokenIssuer(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #306.

## Summary

- `client_id` in the `/oauth/introspect` response reflects the client the token was issued to (from `storage.TokenMetadata` for opaque, JWT `client_id` claim for `AccessTokenFormatJWT`), not the requester.
- `exp`, `iat`, `aud`, `iss`, `scope`, `sub`, `token_type` (RFC 7662 §2.2) populated; `nbf` included on JWT tokens that carry it; `email`, `email_verified`, `name` flow only on the authorized path.
- New cross-client gate: a client may introspect only tokens it owns, or tokens whose `client_id` it is enrolled for via `Config.IntrospectionResourceServers []string`. On denial the response is `{"active": false}` with no other fields — no oracle.
- JWT mode now carries `email_verified` and `name` in the access token (RFC 9068 + OIDC standard claims) so introspection has parity with opaque mode on identity attributes.
- Gate runs on the **unverified** `client_id` claim of a JWT before full signature/audience/revocation validation, then re-runs on the verified claim post-validation. Collapses the timing distinction between "valid JWT I don't own" and "garbage JWT".
- Allowlist validation: empty entries rejected at `Config.Validate`; entries that do not resolve to a registered client rejected at `Server.New`.
- Cross-client denials emit `security.EventIntrospectionRequesterDenied` (severity `medium`, reason ∈ `{empty_requester, empty_token_bound_client, cross_client_probe}`).

## Compatibility

**Breaking**: cross-client introspection now returns `{"active": false}` by default. Resource servers that previously introspected tokens issued to user-agent clients will start receiving `active: false` until they are enrolled.

Migration:

```go
srvCfg.IntrospectionResourceServers = []string{
    "rs-client-id-1",
    "rs-client-id-2",
}
```

The token's bound client always retains introspection rights for its own tokens — same-client probes are unaffected.

## Threat model

Pre-PR, any DCR-registered client could introspect any token in the store and learn (a) whether it was active and (b) `email` / `sub` / `email_verified` / `name`. That's a passive token / user enumeration channel: poll with random or guessed token strings, harvest the inactive-vs-active oracle, and on hits exfiltrate the bound user attributes. The gate closes the channel — denied probes are byte-identical regardless of token validity, and the JWT path no longer leaks a "this is a valid JWT" timing signal.

## Docs

`docs/security.md` gains a "Token Introspection (RFC 7662)" section covering the gate rationale, configuration knob, response shape, and audit event. `introspection_requester_denied` is in the Logged Events table and the Monitoring Recommendations list.

## Follow-up

#329 tracks folding `ExpiresAt` into `storage.TokenMetadata` so the opaque-path introspection drops the second backend read. Out of scope for #306 because it touches every storage backend.