### PR TITLE
fix(handler): reject Basic-Auth / form client_id mismatch + HTTP-level coverage for the refresh-token grant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Token, refresh, and revocation endpoints reject Basic-Auth / form `client_id` mismatch** (RFC 6749 §2.3.1) — when both an HTTP Basic Authorization header and a form `client_id` parameter are supplied and disagree, the request is rejected with `400 invalid_client` and the description `client_id in Basic Authorization header does not match form parameter`. Audited as `auth_failure` with `reason=client_id_mismatch_basic_vs_form`.
 - **`oauth_http_requests_total` now covers all `/token` and `ValidateToken` middleware paths**
   - The HTTP counter previously skipped `/token`'s `405` and unsupported-`grant_type` `400` responses, and the `ValidateToken` middleware's rate-limit `429`s. Dashboards summing by `endpoint` (new label `validate_token`) now see those.
 - **`oauth_http_requests_total` now records the 429 on `/register`'s IP-rate path**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Token, refresh, and revocation endpoints reject Basic-Auth / form `client_id` mismatch** (RFC 6749 §2.3.1) — when both an HTTP Basic Authorization header and a form `client_id` parameter are supplied and disagree, the request is rejected with `400 invalid_client` and the description `client_id in Basic Authorization header does not match form parameter`. Audited as `auth_failure` with `reason=client_id_mismatch_basic_vs_form`.
+- **All four authenticated endpoints reject Basic-Auth / form `client_id` mismatch** (RFC 6749 §2.3.1) — `/token` (authorization_code, refresh_token grants), `/revoke`, and `/introspect` return `400 invalid_client` with the description `client_id in Basic Authorization header does not match form parameter` when the Basic Authorization identity disagrees with the form `client_id`. Audited as `auth_failure` (reason `client_id_mismatch_basic_vs_form`); the audit record pins the Basic-Auth identity. `handleAuthorizationCodeGrant` now reads `oauthErr.Status` before recording the HTTP metric so a 400 is not relabelled as 401.
+- **`parseBasicAuth` rejects malformed `Authorization: Basic` headers** — the `ok` flag from `r.BasicAuth()` is now honoured, so an undecodable payload or missing colon is treated as "no credentials" rather than a silent client_id of garbage.
 - **`oauth_http_requests_total` now covers all `/token` and `ValidateToken` middleware paths**
   - The HTTP counter previously skipped `/token`'s `405` and unsupported-`grant_type` `400` responses, and the `ValidateToken` middleware's rate-limit `429`s. Dashboards summing by `endpoint` (new label `validate_token`) now see those.
 - **`oauth_http_requests_total` now records the 429 on `/register`'s IP-rate path**
@@ -45,7 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Entries are validated at startup: HTTPS only, no fragment / userinfo, no loopback / private / link-local / unspecified IP literal hosts. Invalid entries are dropped.
   - New audit event `client_registered_via_trusted_redirect_uri` (`security.EventClientRegisteredViaTrustedRedirectURI`) carries the matched URI.
   - Env loader: `OAUTH_TRUSTED_REDIRECT_URIS` (comma-separated).
-- **HTTP-level test coverage for the refresh-token grant** — `TestHandler_ServeToken_RefreshGrant_*` exercises `handleRefreshTokenGrant` and `authenticateRefreshTokenClient` end-to-end (0% → 100%), pinning the OAuth 2.1 Section 6 client-binding, client-authentication, reuse-detection, and expired-token branches against regressions.
 - **`LogValue()` on `Server`, `storage/memory.Store`, and `storage/valkey.Store`** (slog.LogValuer)
   - Callers can attach a one-shot structured snapshot of the server / store posture to any log line: `logger.Info("oauth ready", "server", srv, "store", store)`. The library no longer emits this state on its own.
   - `Server.LogValue()` exposes `issuer`, `production_mode`, `access_token_format`, `encryption_at_rest`, `instrumentation_on`, a `redirect_uri_policy` group (`dns_validation`, `dns_validation_strict`, `authorization_time_validation`, `dns_timeout`, `allow_localhost`, `allow_private_ip`, `allow_link_local`), and `session_id_hmac_key_fingerprint` (sha256[:8] hex, omitted when unconfigured).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Entries are validated at startup: HTTPS only, no fragment / userinfo, no loopback / private / link-local / unspecified IP literal hosts. Invalid entries are dropped.
   - New audit event `client_registered_via_trusted_redirect_uri` (`security.EventClientRegisteredViaTrustedRedirectURI`) carries the matched URI.
   - Env loader: `OAUTH_TRUSTED_REDIRECT_URIS` (comma-separated).
+- **HTTP-level test coverage for the refresh-token grant** — `TestHandler_ServeToken_RefreshGrant_*` exercises `handleRefreshTokenGrant` and `authenticateRefreshTokenClient` end-to-end (0% → 100%), pinning the OAuth 2.1 Section 6 client-binding, client-authentication, reuse-detection, and expired-token branches against regressions.
 - **`LogValue()` on `Server`, `storage/memory.Store`, and `storage/valkey.Store`** (slog.LogValuer)
   - Callers can attach a one-shot structured snapshot of the server / store posture to any log line: `logger.Info("oauth ready", "server", srv, "store", store)`. The library no longer emits this state on its own.
   - `Server.LogValue()` exposes `issuer`, `production_mode`, `access_token_format`, `encryption_at_rest`, `instrumentation_on`, a `redirect_uri_policy` group (`dns_validation`, `dns_validation_strict`, `authorization_time_validation`, `dns_timeout`, `allow_localhost`, `allow_private_ip`, `allow_link_local`), and `session_id_hmac_key_fingerprint` (sha256[:8] hex, omitted when unconfigured).

--- a/handler.go
+++ b/handler.go
@@ -1693,12 +1693,27 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 // Returns (clientID, clientAuthenticated, error).
 // If error is returned, the HTTP response has already been written.
 func (h *Handler) authenticateRefreshTokenClient(ctx context.Context, w http.ResponseWriter, r *http.Request, clientID, clientIP string, startTime time.Time, span trace.Span) (string, bool, error) {
-	authClientID, authClientSecret := h.parseBasicAuth(r)
+	basicClientID, basicClientSecret := h.parseBasicAuth(r)
+	formClientID := clientID
+
+	// RFC 6749 §2.3.1: if both Basic Auth and form client_id are supplied,
+	// they MUST identify the same client; reject silent override.
+	if basicClientID != "" && formClientID != "" && basicClientID != formClientID {
+		h.logger.Warn("client_id mismatch between Basic Authorization header and form parameter",
+			"basic_client_id", basicClientID, "form_client_id", formClientID, "ip", clientIP)
+		if h.server.Auditor != nil {
+			h.server.Auditor.LogAuthFailure(ctx, "", basicClientID, clientIP, "client_id_mismatch_basic_vs_form")
+		}
+		h.recordHTTPMetrics(r.Context(), "token", http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "client_id mismatch basic vs form")
+		h.writeError(w, ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)
+		return "", false, fmt.Errorf("client_id mismatch between Basic Authorization header and form parameter")
+	}
 
 	// Case 1: Basic Auth credentials provided - validate them
-	if authClientID != "" {
-		clientID = authClientID
-		if err := h.server.ValidateClientCredentials(ctx, clientID, authClientSecret); err != nil {
+	if basicClientID != "" {
+		clientID = basicClientID
+		if err := h.server.ValidateClientCredentials(ctx, clientID, basicClientSecret); err != nil {
 			h.logger.Warn("Client authentication failed", "client_id", clientID, "ip", clientIP, "error", err)
 			if h.server.Auditor != nil {
 				h.server.Auditor.LogAuthFailure(ctx, "", clientID, clientIP, "refresh_client_authentication_failed")
@@ -1811,12 +1826,27 @@ func (h *Handler) ServeTokenRevocation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get client credentials from Authorization header (if present)
+	basicClientID, basicClientSecret := h.parseBasicAuth(r)
+	formClientID := clientID
+
+	// RFC 6749 §2.3.1: if both Basic Auth and form client_id are supplied,
+	// they MUST identify the same client.
+	if basicClientID != "" && formClientID != "" && basicClientID != formClientID {
+		h.logger.Warn("client_id mismatch between Basic Authorization header and form parameter",
+			"basic_client_id", basicClientID, "form_client_id", formClientID, "ip", clientIP)
+		if h.server.Auditor != nil {
+			h.server.Auditor.LogAuthFailure(r.Context(), "", basicClientID, clientIP, "client_id_mismatch_basic_vs_form")
+		}
+		h.recordHTTPMetrics(r.Context(), endpointRevoke, http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "client_id mismatch basic vs form")
+		h.writeError(w, ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)
+		return
+	}
+
 	clientAuthenticated := false
-	if authClientID, authClientSecret := h.parseBasicAuth(r); authClientID != "" {
-		clientID = authClientID
-		// Validate client credentials
-		if err := h.server.ValidateClientCredentials(r.Context(), clientID, authClientSecret); err != nil {
+	if basicClientID != "" {
+		clientID = basicClientID
+		if err := h.server.ValidateClientCredentials(r.Context(), clientID, basicClientSecret); err != nil {
 			h.logger.Warn("Client authentication failed for revocation", "client_id", clientID, "ip", clientIP)
 			if h.server.Auditor != nil {
 				h.server.Auditor.LogAuthFailure(r.Context(), "", clientID, clientIP, "revocation_auth_failed")
@@ -2086,9 +2116,19 @@ func (h *Handler) parseBasicAuth(r *http.Request) (username, password string) {
 // authenticateClient validates client credentials from either Basic Auth or form parameters
 // Returns the validated client or an error with the OAuth error code
 func (h *Handler) authenticateClient(r *http.Request, clientID, clientIP string) (*storage.Client, error) {
-	authClientID, authClientSecret := h.parseBasicAuth(r)
-	if authClientID != "" {
-		clientID = authClientID
+	basicClientID, basicClientSecret := h.parseBasicAuth(r)
+	formClientID := clientID
+
+	// RFC 6749 §2.3.1: if both Basic Auth and form client_id are supplied,
+	// they MUST identify the same client; reject silent override.
+	if basicClientID != "" && formClientID != "" && basicClientID != formClientID {
+		h.logAuthFailure(r.Context(), basicClientID, clientIP, "client_id_mismatch_basic_vs_form", "client_id in Basic Authorization header does not match form parameter")
+		return nil, NewError(ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)
+	}
+
+	authClientSecret := basicClientSecret
+	if basicClientID != "" {
+		clientID = basicClientID
 	}
 
 	if clientID == "" {

--- a/handler.go
+++ b/handler.go
@@ -1778,6 +1778,37 @@ func (h *Handler) authenticateRefreshTokenClient(ctx context.Context, w http.Res
 	return clientID, false, nil
 }
 
+// authenticateRevocationClient resolves the client for /revoke. It enforces
+// the RFC 6749 §2.3.1 Basic / form client_id agreement, validates Basic-Auth
+// credentials when supplied, and returns (resolvedClientID, authenticated, ok).
+// ok=false means the HTTP response has already been written; the caller must
+// return immediately. RFC 7009 allows unauthenticated revocation for public
+// clients, so a missing Basic header is not itself an error.
+func (h *Handler) authenticateRevocationClient(w http.ResponseWriter, r *http.Request, formClientID, clientIP string, startTime time.Time, span trace.Span) (string, bool, bool) {
+	basicClientID, basicClientSecret := h.parseBasicAuth(r)
+
+	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, formClientID, clientIP, endpointRevoke, "", span, startTime) {
+		return "", false, false
+	}
+
+	if basicClientID == "" {
+		return formClientID, false, true
+	}
+
+	if err := h.server.ValidateClientCredentials(r.Context(), basicClientID, basicClientSecret); err != nil {
+		h.logger.Warn("Client authentication failed for revocation", "client_id", basicClientID, "ip", clientIP)
+		if h.server.Auditor != nil {
+			h.server.Auditor.LogAuthFailure(r.Context(), "", basicClientID, clientIP, "revocation_auth_failed")
+		}
+		h.recordHTTPMetrics(r.Context(), endpointRevoke, http.MethodPost, http.StatusUnauthorized, startTime)
+		instrumentation.RecordError(span, err)
+		instrumentation.SetSpanError(span, "client authentication failed")
+		h.writeError(w, ErrorCodeInvalidClient, "Client authentication failed", http.StatusUnauthorized)
+		return "", false, false
+	}
+	return basicClientID, true, true
+}
+
 // ServeTokenRevocation handles the RFC 7009 token revocation endpoint
 func (h *Handler) ServeTokenRevocation(w http.ResponseWriter, r *http.Request) {
 	startTime := time.Now()
@@ -1825,28 +1856,11 @@ func (h *Handler) ServeTokenRevocation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	basicClientID, basicClientSecret := h.parseBasicAuth(r)
-
-	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, clientID, clientIP, endpointRevoke, "", span, startTime) {
+	resolvedClientID, clientAuthenticated, ok := h.authenticateRevocationClient(w, r, clientID, clientIP, startTime, span)
+	if !ok {
 		return
 	}
-
-	clientAuthenticated := false
-	if basicClientID != "" {
-		clientID = basicClientID
-		if err := h.server.ValidateClientCredentials(r.Context(), clientID, basicClientSecret); err != nil {
-			h.logger.Warn("Client authentication failed for revocation", "client_id", clientID, "ip", clientIP)
-			if h.server.Auditor != nil {
-				h.server.Auditor.LogAuthFailure(r.Context(), "", clientID, clientIP, "revocation_auth_failed")
-			}
-			h.recordHTTPMetrics(r.Context(), endpointRevoke, http.MethodPost, http.StatusUnauthorized, startTime)
-			instrumentation.RecordError(span, err)
-			instrumentation.SetSpanError(span, "client authentication failed")
-			h.writeError(w, ErrorCodeInvalidClient, "Client authentication failed", http.StatusUnauthorized)
-			return
-		}
-		clientAuthenticated = true
-	}
+	clientID = resolvedClientID
 
 	instrumentation.SetSpanAttributes(span, attribute.String(instrumentation.AttrClientID, clientID))
 

--- a/handler.go
+++ b/handler.go
@@ -1560,15 +1560,18 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 	// Authenticate client
 	client, err := h.authenticateClient(r, clientID, clientIP)
 	if err != nil {
-		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusUnauthorized, startTime)
 		instrumentation.RecordError(span, err)
 		instrumentation.SetSpanError(span, "client authentication failed")
-		// authenticateClient returns Error, extract details
+		// authenticateClient returns *Error; read its Status before recording
+		// the HTTP metric so a 400 (client_id mismatch) is not mis-labelled as
+		// 401 (unauthorized) in dashboards.
 		if oauthErr, ok := err.(*Error); ok {
 			h.recordTokenFailure(r.Context(), "authorization_code", oauthErr.Code)
+			h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, oauthErr.Status, startTime)
 			h.writeError(w, oauthErr.Code, oauthErr.Description, oauthErr.Status)
 		} else {
 			h.recordTokenFailure(r.Context(), "authorization_code", ErrorCodeInvalidClient)
+			h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusUnauthorized, startTime)
 			h.writeError(w, ErrorCodeInvalidClient, "Client authentication failed", http.StatusUnauthorized)
 		}
 		return
@@ -1694,19 +1697,8 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 // If error is returned, the HTTP response has already been written.
 func (h *Handler) authenticateRefreshTokenClient(ctx context.Context, w http.ResponseWriter, r *http.Request, clientID, clientIP string, startTime time.Time, span trace.Span) (string, bool, error) {
 	basicClientID, basicClientSecret := h.parseBasicAuth(r)
-	formClientID := clientID
 
-	// RFC 6749 §2.3.1: if both Basic Auth and form client_id are supplied,
-	// they MUST identify the same client; reject silent override.
-	if basicClientID != "" && formClientID != "" && basicClientID != formClientID {
-		h.logger.Warn("client_id mismatch between Basic Authorization header and form parameter",
-			"basic_client_id", basicClientID, "form_client_id", formClientID, "ip", clientIP)
-		if h.server.Auditor != nil {
-			h.server.Auditor.LogAuthFailure(ctx, "", basicClientID, clientIP, "client_id_mismatch_basic_vs_form")
-		}
-		h.recordHTTPMetrics(r.Context(), "token", http.MethodPost, http.StatusBadRequest, startTime)
-		instrumentation.SetSpanError(span, "client_id mismatch basic vs form")
-		h.writeError(w, ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)
+	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, clientID, clientIP, endpointToken, "refresh_token", span, startTime) {
 		return "", false, fmt.Errorf("client_id mismatch between Basic Authorization header and form parameter")
 	}
 
@@ -1827,19 +1819,8 @@ func (h *Handler) ServeTokenRevocation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	basicClientID, basicClientSecret := h.parseBasicAuth(r)
-	formClientID := clientID
 
-	// RFC 6749 §2.3.1: if both Basic Auth and form client_id are supplied,
-	// they MUST identify the same client.
-	if basicClientID != "" && formClientID != "" && basicClientID != formClientID {
-		h.logger.Warn("client_id mismatch between Basic Authorization header and form parameter",
-			"basic_client_id", basicClientID, "form_client_id", formClientID, "ip", clientIP)
-		if h.server.Auditor != nil {
-			h.server.Auditor.LogAuthFailure(r.Context(), "", basicClientID, clientIP, "client_id_mismatch_basic_vs_form")
-		}
-		h.recordHTTPMetrics(r.Context(), endpointRevoke, http.MethodPost, http.StatusBadRequest, startTime)
-		instrumentation.SetSpanError(span, "client_id mismatch basic vs form")
-		h.writeError(w, ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)
+	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, clientID, clientIP, endpointRevoke, "", span, startTime) {
 		return
 	}
 
@@ -2108,9 +2089,51 @@ func (h *Handler) writeRegistrationResponse(w http.ResponseWriter, client *stora
 
 // Helper methods
 
+// parseBasicAuth returns the Basic Authorization credentials when the header
+// is well-formed. A malformed Basic header (missing `Basic ` prefix, undecodable
+// payload, missing colon) returns empty strings so the caller routes the
+// request to the unauthenticated path rather than treating garbage as a
+// silent client_id.
 func (h *Handler) parseBasicAuth(r *http.Request) (username, password string) {
-	username, password, _ = r.BasicAuth()
-	return
+	username, password, ok := r.BasicAuth()
+	if !ok {
+		return "", ""
+	}
+	return username, password
+}
+
+// rejectBasicFormClientIDMismatch enforces RFC 6749 §2.3.1: when both a Basic
+// Authorization header and a form `client_id` are supplied they MUST identify
+// the same client. On mismatch the response is written (400 invalid_client),
+// the audit event is emitted, and the HTTP metric / span are recorded — the
+// caller returns immediately on a true result. tokenFailureGrant is non-empty
+// for /token-grant sites so the per-grant failure counter increments alongside
+// the HTTP counter; /revoke and /introspect pass "".
+func (h *Handler) rejectBasicFormClientIDMismatch(
+	w http.ResponseWriter,
+	r *http.Request,
+	basicClientID, formClientID, clientIP, endpoint, tokenFailureGrant string,
+	span trace.Span,
+	startTime time.Time,
+) bool {
+	if basicClientID == "" || formClientID == "" || basicClientID == formClientID {
+		return false
+	}
+	h.logger.Warn("client_id mismatch between Basic Authorization header and form parameter",
+		"basic_client_id", basicClientID, "form_client_id", formClientID, "ip", clientIP, "endpoint", endpoint)
+	if h.server.Auditor != nil {
+		// Audit pins the Basic-Auth value: that is the authenticated identity
+		// the request claimed, and forensics care about who tried to authenticate
+		// rather than the form value the attacker may have synthesised.
+		h.server.Auditor.LogAuthFailure(r.Context(), "", basicClientID, clientIP, "client_id_mismatch_basic_vs_form")
+	}
+	if tokenFailureGrant != "" {
+		h.recordTokenFailure(r.Context(), tokenFailureGrant, ErrorCodeInvalidClient)
+	}
+	h.recordHTTPMetrics(r.Context(), endpoint, http.MethodPost, http.StatusBadRequest, startTime)
+	instrumentation.SetSpanError(span, "client_id mismatch basic vs form")
+	h.writeError(w, ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)
+	return true
 }
 
 // authenticateClient validates client credentials from either Basic Auth or form parameters
@@ -2425,6 +2448,15 @@ func (h *Handler) ServeTokenIntrospection(w http.ResponseWriter, r *http.Request
 	tokenType := r.Form.Get("token_type_hint")
 	if tokenType != "" && span != nil {
 		instrumentation.SetSpanAttributes(span, attribute.String(instrumentation.AttrTokenType, tokenType))
+	}
+
+	// RFC 6749 §2.3.1: enforce Basic / form client_id agreement before the
+	// per-endpoint authenticate function runs, so /introspect cannot become a
+	// silent-override bypass for the same rule the token / refresh / revoke
+	// paths enforce.
+	basicClientID, _ := h.parseBasicAuth(r)
+	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, r.Form.Get("client_id"), clientIP, endpointIntrospect, "", span, startTime) {
+		return
 	}
 
 	clientID, err := h.authenticateIntrospectionClient(r, clientIP)

--- a/handler.go
+++ b/handler.go
@@ -2143,7 +2143,7 @@ func (h *Handler) authenticateClient(r *http.Request, clientID, clientIP string)
 	formClientID := clientID
 
 	// RFC 6749 §2.3.1: if both Basic Auth and form client_id are supplied,
-	// they MUST identify the same client; reject silent override.
+	// they MUST identify the same client.
 	if basicClientID != "" && formClientID != "" && basicClientID != formClientID {
 		h.logAuthFailure(r.Context(), basicClientID, clientIP, "client_id_mismatch_basic_vs_form", "client_id in Basic Authorization header does not match form parameter")
 		return nil, NewError(ErrorCodeInvalidClient, "client_id in Basic Authorization header does not match form parameter", http.StatusBadRequest)

--- a/handler_refresh_token_test.go
+++ b/handler_refresh_token_test.go
@@ -136,16 +136,29 @@ func decodeErrorResponse(t *testing.T, recorder *httptest.ResponseRecorder) Erro
 	return response
 }
 
-func auditEventLogged(t *testing.T, auditBuf *bytes.Buffer, eventType string) bool {
+// scanAuditRecords decodes one JSON record per non-empty line in auditBuf.
+// Unparseable non-empty lines fail the test so a log-format regression
+// surfaces loudly instead of producing a silent false-negative from the
+// downstream auditEventLogged / auditAuthFailureWithReason helpers.
+func scanAuditRecords(t *testing.T, auditBuf *bytes.Buffer) []map[string]any {
 	t.Helper()
-	for _, line := range strings.Split(strings.TrimRight(auditBuf.String(), "\n"), "\n") {
+	out := make([]map[string]any, 0)
+	for i, line := range strings.Split(strings.TrimRight(auditBuf.String(), "\n"), "\n") {
 		if line == "" {
 			continue
 		}
 		var record map[string]any
 		if err := json.Unmarshal([]byte(line), &record); err != nil {
-			continue
+			t.Fatalf("audit log line %d is not JSON: %v\nline: %s", i, err, line)
 		}
+		out = append(out, record)
+	}
+	return out
+}
+
+func auditEventLogged(t *testing.T, auditBuf *bytes.Buffer, eventType string) bool {
+	t.Helper()
+	for _, record := range scanAuditRecords(t, auditBuf) {
 		audit, ok := record["audit"].(map[string]any)
 		if !ok {
 			continue
@@ -159,14 +172,7 @@ func auditEventLogged(t *testing.T, auditBuf *bytes.Buffer, eventType string) bo
 
 func auditAuthFailureWithReason(t *testing.T, auditBuf *bytes.Buffer, reason string) bool {
 	t.Helper()
-	for _, line := range strings.Split(strings.TrimRight(auditBuf.String(), "\n"), "\n") {
-		if line == "" {
-			continue
-		}
-		var record map[string]any
-		if err := json.Unmarshal([]byte(line), &record); err != nil {
-			continue
-		}
+	for _, record := range scanAuditRecords(t, auditBuf) {
 		audit, ok := record["audit"].(map[string]any)
 		if !ok {
 			continue
@@ -185,226 +191,246 @@ func auditAuthFailureWithReason(t *testing.T, auditBuf *bytes.Buffer, reason str
 	return false
 }
 
-func TestHandler_ServeToken_RefreshGrant_HappyPath_ConfidentialClient(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-confidential", "family-conf", time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-
-	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeTokenResponse(t, recorder)
-	require.NotEmpty(t, response.AccessToken)
-	require.NotEmpty(t, response.RefreshToken)
-	require.NotEqual(t, refreshToken, response.RefreshToken, "rotation must mint a new refresh token")
-	require.Equal(t, testTokenTypeBearer, response.TokenType)
-	require.True(t, auditEventLogged(t, env.auditBuf, security.EventTokenRefreshed))
+// refreshGrantInputs is what the per-case setup closure returns to the table
+// runner: the form body, the Basic Auth pair, and whether to issue a prior
+// successful refresh first (covers the reuse-detection case where the second
+// request must run after the token has already rotated).
+type refreshGrantInputs struct {
+	form               url.Values
+	basicAuth          [2]string
+	preRefreshFirstHit bool
 }
 
-func TestHandler_ServeToken_RefreshGrant_HappyPath_PublicClient(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, _ := env.registerClient(t, ClientTypePublic)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-public", "family-pub", time.Now().Add(time.Hour))
+func TestHandler_ServeToken_RefreshGrant(t *testing.T) {
+	tests := []struct {
+		name             string
+		setup            func(t *testing.T, env *refreshTestEnv) refreshGrantInputs
+		wantStatus       int
+		wantErrorCode    string // empty on success
+		wantErrorContain string // optional substring of error_description
+		wantAuditEvents  []string
+		wantAuditReasons []string
+		assertRotation   bool // happy path only: response.RefreshToken != seeded
+	}{
+		{
+			name: "happy path / confidential client / Basic Auth",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientID, "user-c", "family-c", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", rt),
+					basicAuth: [2]string{clientID, secret},
+				}
+			},
+			wantStatus:      http.StatusOK,
+			wantAuditEvents: []string{security.EventTokenRefreshed},
+			assertRotation:  true,
+		},
+		{
+			name: "happy path / public client / client_id only",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, _ := env.registerClient(t, ClientTypePublic)
+				rt := env.seedRefreshToken(t, clientID, "user-p", "family-p", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form: formWith("grant_type", "refresh_token", "refresh_token", rt, "client_id", clientID),
+				}
+			},
+			wantStatus:      http.StatusOK,
+			wantAuditEvents: []string{security.EventTokenRefreshed},
+			assertRotation:  true,
+		},
+		{
+			name: "confidential client without authentication is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, _ := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientID, "user-noauth", "family-noauth", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form: formWith("grant_type", "refresh_token", "refresh_token", rt, "client_id", clientID),
+				}
+			},
+			wantStatus:       http.StatusUnauthorized,
+			wantErrorCode:    ErrorCodeInvalidClient,
+			wantAuditReasons: []string{"confidential_client_refresh_missing_auth"},
+		},
+		{
+			name: "basic / form client_id mismatch is rejected (RFC 6749 §2.3.1)",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientID, "user-mm", "family-mm", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", rt, "client_id", "form-value-does-not-match"),
+					basicAuth: [2]string{clientID, secret},
+				}
+			},
+			wantStatus:       http.StatusBadRequest,
+			wantErrorCode:    ErrorCodeInvalidClient,
+			wantErrorContain: "does not match",
+			wantAuditReasons: []string{"client_id_mismatch_basic_vs_form"},
+		},
+		{
+			name: "basic + matching form client_id succeeds",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientID, "user-match", "family-match", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", rt, "client_id", clientID),
+					basicAuth: [2]string{clientID, secret},
+				}
+			},
+			wantStatus: http.StatusOK,
+		},
+		{
+			name: "cross-client refresh token binding is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientA, _ := env.registerClient(t, ClientTypeConfidential)
+				clientB, secretB := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientA, "user-x", "family-x", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", rt),
+					basicAuth: [2]string{clientB, secretB},
+				}
+			},
+			wantStatus:      http.StatusBadRequest,
+			wantErrorCode:   ErrorCodeInvalidGrant,
+			wantAuditEvents: []string{security.EventRefreshTokenClientBindingMismatch},
+		},
+		{
+			name: "reused refresh token is rejected on the second hit",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientID, "user-r", "family-r", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form:               formWith("grant_type", "refresh_token", "refresh_token", rt),
+					basicAuth:          [2]string{clientID, secret},
+					preRefreshFirstHit: true,
+				}
+			},
+			wantStatus:      http.StatusBadRequest,
+			wantErrorCode:   ErrorCodeInvalidGrant,
+			wantAuditEvents: []string{security.EventRefreshTokenReuseDetected},
+		},
+		{
+			name: "expired refresh token is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedRefreshToken(t, clientID, "user-e", "family-e", time.Now().Add(-time.Hour))
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", rt),
+					basicAuth: [2]string{clientID, secret},
+				}
+			},
+			wantStatus:    http.StatusBadRequest,
+			wantErrorCode: ErrorCodeInvalidGrant,
+		},
+		{
+			name: "legacy refresh token without client binding is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				rt := env.seedLegacyRefreshToken(t, "user-l", time.Now().Add(time.Hour))
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", rt),
+					basicAuth: [2]string{clientID, secret},
+				}
+			},
+			wantStatus:      http.StatusBadRequest,
+			wantErrorCode:   ErrorCodeInvalidGrant,
+			wantAuditEvents: []string{security.EventRefreshTokenMissingClientBinding},
+		},
+		{
+			name: "missing refresh_token parameter is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, secret := env.registerClient(t, ClientTypeConfidential)
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token"),
+					basicAuth: [2]string{clientID, secret},
+				}
+			},
+			wantStatus:    http.StatusBadRequest,
+			wantErrorCode: ErrorCodeInvalidRequest,
+		},
+		{
+			name: "missing client_id on a public-client refresh is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				return refreshGrantInputs{
+					form: formWith("grant_type", "refresh_token", "refresh_token", "any-refresh-token"),
+				}
+			},
+			wantStatus:    http.StatusBadRequest,
+			wantErrorCode: ErrorCodeInvalidRequest,
+		},
+		{
+			name: "unknown client is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				return refreshGrantInputs{
+					form: formWith("grant_type", "refresh_token", "refresh_token", "any-refresh-token", "client_id", "client-that-was-never-registered"),
+				}
+			},
+			wantStatus:    http.StatusUnauthorized,
+			wantErrorCode: ErrorCodeInvalidClient,
+		},
+		{
+			name: "bad client secret is rejected",
+			setup: func(t *testing.T, env *refreshTestEnv) refreshGrantInputs {
+				clientID, _ := env.registerClient(t, ClientTypeConfidential)
+				return refreshGrantInputs{
+					form:      formWith("grant_type", "refresh_token", "refresh_token", "any-refresh-token"),
+					basicAuth: [2]string{clientID, "wrong-secret"},
+				}
+			},
+			wantStatus:    http.StatusUnauthorized,
+			wantErrorCode: ErrorCodeInvalidClient,
+		},
+	}
 
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-	form.Set("client_id", clientID)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := newRefreshTestEnv(t)
+			inputs := tc.setup(t, env)
 
-	recorder := doRefreshRequest(env.handler, form, [2]string{})
+			if inputs.preRefreshFirstHit {
+				first := doRefreshRequest(env.handler, inputs.form, inputs.basicAuth)
+				require.Equal(t, http.StatusOK, first.Code, "first hit body: %s", first.Body.String())
+			}
 
-	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeTokenResponse(t, recorder)
-	require.NotEmpty(t, response.AccessToken)
-	require.NotEmpty(t, response.RefreshToken)
-	require.NotEqual(t, refreshToken, response.RefreshToken)
-	require.True(t, auditEventLogged(t, env.auditBuf, security.EventTokenRefreshed))
+			seededRefreshToken := inputs.form.Get("refresh_token")
+			recorder := doRefreshRequest(env.handler, inputs.form, inputs.basicAuth)
+			require.Equal(t, tc.wantStatus, recorder.Code, "body: %s", recorder.Body.String())
+
+			if tc.wantErrorCode != "" {
+				response := decodeErrorResponse(t, recorder)
+				require.Equal(t, tc.wantErrorCode, response.Error)
+				if tc.wantErrorContain != "" {
+					require.Contains(t, response.ErrorDescription, tc.wantErrorContain)
+				}
+			} else {
+				response := decodeTokenResponse(t, recorder)
+				require.NotEmpty(t, response.AccessToken)
+				require.NotEmpty(t, response.RefreshToken)
+				if tc.assertRotation && seededRefreshToken != "" {
+					require.NotEqual(t, seededRefreshToken, response.RefreshToken, "rotation must mint a new refresh token")
+				}
+				require.Equal(t, tokenTypeBearer, response.TokenType)
+			}
+
+			for _, event := range tc.wantAuditEvents {
+				require.True(t, auditEventLogged(t, env.auditBuf, event), "audit event %q not emitted", event)
+			}
+			for _, reason := range tc.wantAuditReasons {
+				require.True(t, auditAuthFailureWithReason(t, env.auditBuf, reason), "auth_failure with reason %q not emitted", reason)
+			}
+		})
+	}
 }
 
-func TestHandler_ServeToken_RefreshGrant_ConfidentialClient_NoAuth(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, _ := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-noauth", "family-noauth", time.Now().Add(time.Hour))
-
+// formWith builds a url.Values from a flat key,value,key,value,... slice. Panics
+// on an odd argument count — the test author controls the call site.
+func formWith(kv ...string) url.Values {
+	if len(kv)%2 != 0 {
+		panic("formWith: odd number of arguments")
+	}
 	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-	form.Set("client_id", clientID)
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{})
-
-	require.Equal(t, http.StatusUnauthorized, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidClient, response.Error)
-	require.True(t, auditAuthFailureWithReason(t, env.auditBuf, "confidential_client_refresh_missing_auth"))
-}
-
-func TestHandler_ServeToken_RefreshGrant_BasicAuthAndFormClientIDMismatch_Rejected(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-mismatch", "family-mismatch", time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-	form.Set("client_id", "form-value-does-not-match")
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidClient, response.Error)
-	require.Contains(t, response.ErrorDescription, "does not match")
-	require.True(t, auditAuthFailureWithReason(t, env.auditBuf, "client_id_mismatch_basic_vs_form"))
-}
-
-func TestHandler_ServeToken_RefreshGrant_BasicAuthAndMatchingFormClientID_OK(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-match", "family-match", time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-	form.Set("client_id", clientID)
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-
-	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeTokenResponse(t, recorder)
-	require.NotEmpty(t, response.AccessToken)
-	require.NotEmpty(t, response.RefreshToken)
-}
-
-func TestHandler_ServeToken_RefreshGrant_WrongClientBinding(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientA, _ := env.registerClient(t, ClientTypeConfidential)
-	clientB, secretB := env.registerClient(t, ClientTypeConfidential)
-
-	refreshToken := env.seedRefreshToken(t, clientA, "user-binding", "family-binding", time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientB, secretB})
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
-	require.True(t, auditEventLogged(t, env.auditBuf, security.EventRefreshTokenClientBindingMismatch))
-}
-
-func TestHandler_ServeToken_RefreshGrant_ReusedRefreshToken(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-reuse", "family-reuse", time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-
-	firstRecorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-	require.Equal(t, http.StatusOK, firstRecorder.Code, "first refresh body: %s", firstRecorder.Body.String())
-
-	secondRecorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-	require.Equal(t, http.StatusBadRequest, secondRecorder.Code, "second refresh body: %s", secondRecorder.Body.String())
-	response := decodeErrorResponse(t, secondRecorder)
-	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
-	require.True(t, auditEventLogged(t, env.auditBuf, security.EventRefreshTokenReuseDetected))
-}
-
-func TestHandler_ServeToken_RefreshGrant_ExpiredRefreshToken(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedRefreshToken(t, clientID, "user-expired", "family-expired", time.Now().Add(-time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
-}
-
-func TestHandler_ServeToken_RefreshGrant_LegacyRefreshTokenWithoutBinding(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-	refreshToken := env.seedLegacyRefreshToken(t, "user-legacy", time.Now().Add(time.Hour))
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", refreshToken)
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
-	require.True(t, auditEventLogged(t, env.auditBuf, security.EventRefreshTokenMissingClientBinding))
-}
-
-func TestHandler_ServeToken_RefreshGrant_MissingRefreshToken(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, secret := env.registerClient(t, ClientTypeConfidential)
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidRequest, response.Error)
-}
-
-func TestHandler_ServeToken_RefreshGrant_MissingClientID_PublicClient(t *testing.T) {
-	env := newRefreshTestEnv(t)
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", "any-refresh-token")
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{})
-
-	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidRequest, response.Error)
-}
-
-func TestHandler_ServeToken_RefreshGrant_UnknownClient(t *testing.T) {
-	env := newRefreshTestEnv(t)
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", "any-refresh-token")
-	form.Set("client_id", "client-that-was-never-registered")
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{})
-
-	require.Equal(t, http.StatusUnauthorized, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidClient, response.Error)
-}
-
-func TestHandler_ServeToken_RefreshGrant_BadClientSecret(t *testing.T) {
-	env := newRefreshTestEnv(t)
-	clientID, _ := env.registerClient(t, ClientTypeConfidential)
-
-	form := url.Values{}
-	form.Set("grant_type", "refresh_token")
-	form.Set("refresh_token", "any-refresh-token")
-
-	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, "wrong-secret"})
-
-	require.Equal(t, http.StatusUnauthorized, recorder.Code, "body: %s", recorder.Body.String())
-	response := decodeErrorResponse(t, recorder)
-	require.Equal(t, ErrorCodeInvalidClient, response.Error)
+	for i := 0; i < len(kv); i += 2 {
+		form.Set(kv[i], kv[i+1])
+	}
+	return form
 }

--- a/handler_refresh_token_test.go
+++ b/handler_refresh_token_test.go
@@ -95,7 +95,7 @@ func (e *refreshTestEnv) seedRefreshToken(t *testing.T, clientID, userID, family
 }
 
 // seedLegacyRefreshToken stores a refresh token without family metadata so the
-// stored client_id is empty — the legacy branch in validateRefreshTokenClientBinding.
+// stored client_id is empty.
 func (e *refreshTestEnv) seedLegacyRefreshToken(t *testing.T, userID string, expiresAt time.Time) string {
 	t.Helper()
 	refreshToken := "legacy-rt-" + userID
@@ -243,10 +243,7 @@ func TestHandler_ServeToken_RefreshGrant_ConfidentialClient_NoAuth(t *testing.T)
 	require.True(t, auditAuthFailureWithReason(t, env.auditBuf, "confidential_client_refresh_missing_auth"))
 }
 
-// Basic Auth client_id wins over the form client_id silently. A future change
-// that adds strict mismatch detection (returning invalid_client) breaks this
-// test by design.
-func TestHandler_ServeToken_RefreshGrant_BasicAuthOverridesFormClientID(t *testing.T) {
+func TestHandler_ServeToken_RefreshGrant_BasicAuthAndFormClientIDMismatch_Rejected(t *testing.T) {
 	env := newRefreshTestEnv(t)
 	clientID, secret := env.registerClient(t, ClientTypeConfidential)
 	refreshToken := env.seedRefreshToken(t, clientID, "user-mismatch", "family-mismatch", time.Now().Add(time.Hour))
@@ -255,6 +252,25 @@ func TestHandler_ServeToken_RefreshGrant_BasicAuthOverridesFormClientID(t *testi
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", refreshToken)
 	form.Set("client_id", "form-value-does-not-match")
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidClient, response.Error)
+	require.Contains(t, response.ErrorDescription, "does not match")
+	require.True(t, auditAuthFailureWithReason(t, env.auditBuf, "client_id_mismatch_basic_vs_form"))
+}
+
+func TestHandler_ServeToken_RefreshGrant_BasicAuthAndMatchingFormClientID_OK(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-match", "family-match", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", clientID)
 
 	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
 

--- a/handler_refresh_token_test.go
+++ b/handler_refresh_token_test.go
@@ -1,0 +1,394 @@
+package oauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/server"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+type refreshTestEnv struct {
+	handler  *Handler
+	store    *memory.Store
+	auditBuf *bytes.Buffer
+}
+
+func newRefreshTestEnv(t *testing.T) *refreshTestEnv {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	provider := mock.NewProvider()
+
+	auditBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(auditBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	config := &server.Config{
+		Issuer:                    testIssuer,
+		AllowRefreshTokenRotation: true,
+	}
+
+	auditor := security.NewAuditor(logger, true)
+
+	srv, err := server.New(provider, store, store, store, config, logger, server.WithAuditor(auditor))
+	require.NoError(t, err)
+
+	return &refreshTestEnv{
+		handler:  NewHandler(srv, logger),
+		store:    store,
+		auditBuf: auditBuf,
+	}
+}
+
+func (e *refreshTestEnv) registerClient(t *testing.T, clientType string) (string, string) {
+	t.Helper()
+	client, secret, err := e.handler.server.RegisterClient(
+		context.Background(),
+		"refresh-grant-test-client",
+		clientType,
+		"",
+		[]string{"https://example.com/callback"},
+		[]string{"openid", "email"},
+		"192.0.2.10",
+		10,
+	)
+	require.NoError(t, err)
+	return client.ClientID, secret
+}
+
+func (e *refreshTestEnv) seedRefreshToken(t *testing.T, clientID, userID, familyID string, expiresAt time.Time) string {
+	t.Helper()
+	refreshToken := "rt-" + clientID + "-" + familyID
+	err := e.store.SaveRefreshTokenWithFamily(
+		context.Background(),
+		refreshToken,
+		userID,
+		clientID,
+		familyID,
+		0,
+		expiresAt,
+	)
+	require.NoError(t, err)
+	err = e.store.SaveToken(context.Background(), refreshToken, &oauth2.Token{
+		AccessToken:  "provider-access-" + refreshToken,
+		RefreshToken: "provider-refresh-" + refreshToken,
+		Expiry:       time.Now().Add(time.Hour),
+		TokenType:    "Bearer",
+	})
+	require.NoError(t, err)
+	return refreshToken
+}
+
+// seedLegacyRefreshToken stores a refresh token without family metadata so the
+// stored client_id is empty — the legacy branch in validateRefreshTokenClientBinding.
+func (e *refreshTestEnv) seedLegacyRefreshToken(t *testing.T, userID string, expiresAt time.Time) string {
+	t.Helper()
+	refreshToken := "legacy-rt-" + userID
+	err := e.store.SaveRefreshToken(context.Background(), refreshToken, userID, expiresAt)
+	require.NoError(t, err)
+	err = e.store.SaveToken(context.Background(), refreshToken, &oauth2.Token{
+		AccessToken:  "provider-access-" + refreshToken,
+		RefreshToken: "provider-refresh-" + refreshToken,
+		Expiry:       time.Now().Add(time.Hour),
+		TokenType:    "Bearer",
+	})
+	require.NoError(t, err)
+	return refreshToken
+}
+
+func doRefreshRequest(handler *Handler, form url.Values, basicAuth [2]string) *httptest.ResponseRecorder {
+	request := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(form.Encode()))
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if basicAuth[0] != "" {
+		request.SetBasicAuth(basicAuth[0], basicAuth[1])
+	}
+	recorder := httptest.NewRecorder()
+	handler.ServeToken(recorder, request)
+	return recorder
+}
+
+func decodeTokenResponse(t *testing.T, recorder *httptest.ResponseRecorder) TokenResponse {
+	t.Helper()
+	var response TokenResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	return response
+}
+
+func decodeErrorResponse(t *testing.T, recorder *httptest.ResponseRecorder) ErrorResponse {
+	t.Helper()
+	var response ErrorResponse
+	require.NoError(t, json.NewDecoder(recorder.Body).Decode(&response))
+	return response
+}
+
+func auditEventLogged(t *testing.T, auditBuf *bytes.Buffer, eventType string) bool {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimRight(auditBuf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		audit, ok := record["audit"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if audit["event_type"] == eventType {
+			return true
+		}
+	}
+	return false
+}
+
+func auditAuthFailureWithReason(t *testing.T, auditBuf *bytes.Buffer, reason string) bool {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimRight(auditBuf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		audit, ok := record["audit"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if audit["event_type"] != security.EventAuthFailure {
+			continue
+		}
+		details, ok := audit["details"].(map[string]any)
+		if !ok {
+			continue
+		}
+		if details["reason"] == reason {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHandler_ServeToken_RefreshGrant_HappyPath_ConfidentialClient(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-confidential", "family-conf", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+
+	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeTokenResponse(t, recorder)
+	require.NotEmpty(t, response.AccessToken)
+	require.NotEmpty(t, response.RefreshToken)
+	require.NotEqual(t, refreshToken, response.RefreshToken, "rotation must mint a new refresh token")
+	require.Equal(t, testTokenTypeBearer, response.TokenType)
+	require.True(t, auditEventLogged(t, env.auditBuf, security.EventTokenRefreshed))
+}
+
+func TestHandler_ServeToken_RefreshGrant_HappyPath_PublicClient(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, _ := env.registerClient(t, ClientTypePublic)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-public", "family-pub", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", clientID)
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{})
+
+	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeTokenResponse(t, recorder)
+	require.NotEmpty(t, response.AccessToken)
+	require.NotEmpty(t, response.RefreshToken)
+	require.NotEqual(t, refreshToken, response.RefreshToken)
+	require.True(t, auditEventLogged(t, env.auditBuf, security.EventTokenRefreshed))
+}
+
+func TestHandler_ServeToken_RefreshGrant_ConfidentialClient_NoAuth(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, _ := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-noauth", "family-noauth", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", clientID)
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{})
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidClient, response.Error)
+	require.True(t, auditAuthFailureWithReason(t, env.auditBuf, "confidential_client_refresh_missing_auth"))
+}
+
+// Basic Auth client_id wins over the form client_id silently. A future change
+// that adds strict mismatch detection (returning invalid_client) breaks this
+// test by design.
+func TestHandler_ServeToken_RefreshGrant_BasicAuthOverridesFormClientID(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-mismatch", "family-mismatch", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+	form.Set("client_id", "form-value-does-not-match")
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+
+	require.Equal(t, http.StatusOK, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeTokenResponse(t, recorder)
+	require.NotEmpty(t, response.AccessToken)
+	require.NotEmpty(t, response.RefreshToken)
+}
+
+func TestHandler_ServeToken_RefreshGrant_WrongClientBinding(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientA, _ := env.registerClient(t, ClientTypeConfidential)
+	clientB, secretB := env.registerClient(t, ClientTypeConfidential)
+
+	refreshToken := env.seedRefreshToken(t, clientA, "user-binding", "family-binding", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientB, secretB})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
+	require.True(t, auditEventLogged(t, env.auditBuf, security.EventRefreshTokenClientBindingMismatch))
+}
+
+func TestHandler_ServeToken_RefreshGrant_ReusedRefreshToken(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-reuse", "family-reuse", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	firstRecorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+	require.Equal(t, http.StatusOK, firstRecorder.Code, "first refresh body: %s", firstRecorder.Body.String())
+
+	secondRecorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+	require.Equal(t, http.StatusBadRequest, secondRecorder.Code, "second refresh body: %s", secondRecorder.Body.String())
+	response := decodeErrorResponse(t, secondRecorder)
+	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
+	require.True(t, auditEventLogged(t, env.auditBuf, security.EventRefreshTokenReuseDetected))
+}
+
+func TestHandler_ServeToken_RefreshGrant_ExpiredRefreshToken(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedRefreshToken(t, clientID, "user-expired", "family-expired", time.Now().Add(-time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
+}
+
+func TestHandler_ServeToken_RefreshGrant_LegacyRefreshTokenWithoutBinding(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+	refreshToken := env.seedLegacyRefreshToken(t, "user-legacy", time.Now().Add(time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", refreshToken)
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidGrant, response.Error)
+	require.True(t, auditEventLogged(t, env.auditBuf, security.EventRefreshTokenMissingClientBinding))
+}
+
+func TestHandler_ServeToken_RefreshGrant_MissingRefreshToken(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, secret := env.registerClient(t, ClientTypeConfidential)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, secret})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidRequest, response.Error)
+}
+
+func TestHandler_ServeToken_RefreshGrant_MissingClientID_PublicClient(t *testing.T) {
+	env := newRefreshTestEnv(t)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "any-refresh-token")
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{})
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidRequest, response.Error)
+}
+
+func TestHandler_ServeToken_RefreshGrant_UnknownClient(t *testing.T) {
+	env := newRefreshTestEnv(t)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "any-refresh-token")
+	form.Set("client_id", "client-that-was-never-registered")
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{})
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidClient, response.Error)
+}
+
+func TestHandler_ServeToken_RefreshGrant_BadClientSecret(t *testing.T) {
+	env := newRefreshTestEnv(t)
+	clientID, _ := env.registerClient(t, ClientTypeConfidential)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "any-refresh-token")
+
+	recorder := doRefreshRequest(env.handler, form, [2]string{clientID, "wrong-secret"})
+
+	require.Equal(t, http.StatusUnauthorized, recorder.Code, "body: %s", recorder.Body.String())
+	response := decodeErrorResponse(t, recorder)
+	require.Equal(t, ErrorCodeInvalidClient, response.Error)
+}

--- a/handler_test.go
+++ b/handler_test.go
@@ -2846,6 +2846,82 @@ func TestHandler_ServeToken_AuthorizationCode(t *testing.T) {
 	}
 }
 
+func TestHandler_ServeToken_AuthorizationCode_BasicAuthAndFormClientIDMismatch_Rejected(t *testing.T) {
+	ctx := context.Background()
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	client, secret, err := handler.server.RegisterClient(
+		ctx,
+		"Test Client",
+		"confidential",
+		"",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.168.1.100",
+		10,
+	)
+	if err != nil {
+		t.Fatalf("RegisterClient() error = %v", err)
+	}
+
+	formData := url.Values{}
+	formData.Set("grant_type", "authorization_code")
+	formData.Set("code", "any-code")
+	formData.Set("redirect_uri", "https://example.com/callback")
+	formData.Set("client_id", "form-value-does-not-match")
+
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(client.ClientID, secret)
+	w := httptest.NewRecorder()
+
+	handler.ServeToken(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	var errResp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != ErrorCodeInvalidClient {
+		t.Errorf("error = %q, want %q", errResp.Error, ErrorCodeInvalidClient)
+	}
+	if !strings.Contains(errResp.ErrorDescription, "does not match") {
+		t.Errorf("error_description = %q, want it to contain %q", errResp.ErrorDescription, "does not match")
+	}
+}
+
+func TestHandler_ServeToken_AuthorizationCode_UnknownBasicAuthClient(t *testing.T) {
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	formData := url.Values{}
+	formData.Set("grant_type", "authorization_code")
+	formData.Set("code", "any-code")
+	formData.Set("redirect_uri", "https://example.com/callback")
+
+	req := httptest.NewRequest(http.MethodPost, "/token", strings.NewReader(formData.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth("client-that-was-never-registered", "any-secret")
+	w := httptest.NewRecorder()
+
+	handler.ServeToken(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d, body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+	var errResp ErrorResponse
+	if err := json.NewDecoder(w.Body).Decode(&errResp); err != nil {
+		t.Fatalf("failed to decode error response: %v", err)
+	}
+	if errResp.Error != ErrorCodeInvalidClient {
+		t.Errorf("error = %q, want %q", errResp.Error, ErrorCodeInvalidClient)
+	}
+}
+
 func TestHandler_ServeClientRegistration_Success(t *testing.T) {
 	handler, store := setupTestHandler(t)
 	defer store.Stop()

--- a/handler_test.go
+++ b/handler_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
@@ -3869,6 +3870,33 @@ func TestHandler_ServeTokenIntrospection(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
 	}
+}
+
+func TestHandler_ServeTokenIntrospection_BasicFormClientIDMismatchRejected(t *testing.T) {
+	ctx := context.Background()
+
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	client, secret, err := handler.server.RegisterClient(ctx, "Introspect Client", "confidential", "", []string{"https://example.com/cb"}, []string{"openid"}, "192.168.1.5", 10)
+	require.NoError(t, err)
+
+	form := url.Values{}
+	form.Set("token", "any-opaque-token")
+	form.Set("client_id", "form-value-does-not-match")
+
+	req := httptest.NewRequest(http.MethodPost, "/introspect", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetBasicAuth(client.ClientID, secret)
+	w := httptest.NewRecorder()
+
+	handler.ServeTokenIntrospection(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "body: %s", w.Body.String())
+	var response map[string]string
+	require.NoError(t, json.NewDecoder(w.Body).Decode(&response))
+	require.Equal(t, ErrorCodeInvalidClient, response["error"])
+	require.Contains(t, response["error_description"], "does not match")
 }
 
 // CORS Tests

--- a/handler_test.go
+++ b/handler_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	testTokenTypeBearer         = "Bearer"
 	testClientRemoteAddr        = "192.168.1.100:12345"
 	testOriginApp               = "https://app.example.com"
 	testIssuer                  = "https://auth.example.com"
@@ -1565,8 +1564,8 @@ func TestHandler_writeTokenResponse(t *testing.T) {
 		t.Errorf("AccessToken = %q, want %q", tokenResp.AccessToken, token.AccessToken)
 	}
 
-	if tokenResp.TokenType != testTokenTypeBearer {
-		t.Errorf("TokenType = %q, want %q", tokenResp.TokenType, testTokenTypeBearer)
+	if tokenResp.TokenType != tokenTypeBearer {
+		t.Errorf("TokenType = %q, want %q", tokenResp.TokenType, tokenTypeBearer)
 	}
 }
 
@@ -1599,8 +1598,8 @@ func TestHandler_writeTokenResponse_WithIDToken(t *testing.T) {
 		t.Errorf("AccessToken = %q, want %q", tokenResp.AccessToken, tokenWithIDToken.AccessToken)
 	}
 
-	if tokenResp.TokenType != testTokenTypeBearer {
-		t.Errorf("TokenType = %q, want %q", tokenResp.TokenType, testTokenTypeBearer)
+	if tokenResp.TokenType != tokenTypeBearer {
+		t.Errorf("TokenType = %q, want %q", tokenResp.TokenType, tokenTypeBearer)
 	}
 
 	// Verify id_token is included in response (OIDC compliance)
@@ -2841,8 +2840,8 @@ func TestHandler_ServeToken_AuthorizationCode(t *testing.T) {
 		t.Error("RefreshToken should not be empty")
 	}
 
-	if tokenResp.TokenType != testTokenTypeBearer {
-		t.Errorf("TokenType = %q, want %q", tokenResp.TokenType, testTokenTypeBearer)
+	if tokenResp.TokenType != tokenTypeBearer {
+		t.Errorf("TokenType = %q, want %q", tokenResp.TokenType, tokenTypeBearer)
 	}
 }
 


### PR DESCRIPTION
Closes #304.

## Summary

- RFC 6749 §2.3.1: all four authenticated endpoints (`/token` for `authorization_code` + `refresh_token` grants, `/revoke`, `/introspect`) reject requests where Basic Authorization `client_id` and form `client_id` disagree. Response is `400 invalid_client` with description `client_id in Basic Authorization header does not match form parameter`; audited as `auth_failure` with `reason=client_id_mismatch_basic_vs_form`, pinning the Basic-Auth identity.
- Single helper `rejectBasicFormClientIDMismatch` consolidates the gate so the four sites share log message / audit reason / error code / metric shape, resolves gocognit on `authenticateRefreshTokenClient` and `ServeTokenRevocation`, and closes the introspection gap.
- `parseBasicAuth` honours the `r.BasicAuth()` `ok` flag — a malformed `Authorization: Basic` header no longer propagates as an empty `client_id` "match".
- `handleAuthorizationCodeGrant` records the HTTP metric using `oauthErr.Status` (400 for the mismatch path, 401 for auth failure) instead of always tagging 401.
- New `handler_refresh_token_test.go` drives `/oauth/token` via `httptest` for the refresh-token grant. The 13 separate top-level functions are consolidated into one table-driven `TestHandler_ServeToken_RefreshGrant` using testify/require; coverage is unchanged. Audit-event assertions run through a shared `scanAuditRecords` helper that fails fast on unparseable lines so a log-format regression cannot silently false-negative.

## Status code rationale (RFC 6749 §5.2)

The §2.3.1 mismatch is a client-side request error (the two `client_id` values are inconsistent), not a failed authentication attempt — `400 invalid_client` is the spec-appropriate response. `401` plus `WWW-Authenticate` is reserved for the case where the credentials themselves are missing or wrong, which is exercised separately (`refresh_grant / "bad client secret" / "confidential client without authentication"`) and remains `401`.

## Coverage delta

| Function | Before | After |
| --- | --- | --- |
| `handleRefreshTokenGrant` | 0.0% | 100.0% |
| `authenticateRefreshTokenClient` | 0.0% | 100.0% |
| `authenticateClient` | 76.5% | 100.0% |

Verified locally via `go test -coverprofile=cov.out ./. && go tool cover -func=cov.out | grep -E 'handleRefreshTokenGrant|authenticateRefreshTokenClient|authenticateClient'`. Full suite passes under `-race`.