### PR TITLE
feat(server): TrustedPublicRegistrationRedirectURIs allowlist for unauthenticated DCR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`Config.TrustedPublicRegistrationRedirectURIs`** — HTTPS redirect-URI allowlist for unauthenticated dynamic client registration.
+  - Every `redirect_uris` entry in the request must be in the allowlist; matching is exact after RFC 3986 host normalization (lowercase scheme + host, default `:443` stripped; path and query case-sensitive).
+  - Public clients (`token_endpoint_auth_method: "none"`) succeed via this gate.
+  - Entries are validated at startup: HTTPS only, no fragment / userinfo, no loopback / private / link-local / unspecified IP literal hosts. Invalid entries are dropped.
+  - New audit event `client_registered_via_trusted_redirect_uri` (`security.EventClientRegisteredViaTrustedRedirectURI`) carries the matched URI.
+  - Env loader: `OAUTH_TRUSTED_REDIRECT_URIS` (comma-separated).
 - **`LogValue()` on `Server`, `storage/memory.Store`, and `storage/valkey.Store`** (slog.LogValuer)
   - Callers can attach a one-shot structured snapshot of the server / store posture to any log line: `logger.Info("oauth ready", "server", srv, "store", store)`. The library no longer emits this state on its own.
   - `Server.LogValue()` exposes `issuer`, `production_mode`, `access_token_format`, `encryption_at_rest`, `instrumentation_on`, a `redirect_uri_policy` group (`dns_validation`, `dns_validation_strict`, `authorization_time_validation`, `dns_timeout`, `allow_localhost`, `allow_private_ip`, `allow_link_local`), and `session_id_hmac_key_fingerprint` (sha256[:8] hex, omitted when unconfigured).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`Config.TrustedPublicRegistrationRedirectURIs`** — HTTPS redirect-URI allowlist for unauthenticated dynamic client registration.
-  - Every `redirect_uris` entry in the request must be in the allowlist; matching is exact after RFC 3986 host normalization (lowercase scheme + host, default `:443` stripped; path and query case-sensitive).
+  - Every `redirect_uris` entry in the request must be in the allowlist; matching is exact after RFC 3986 normalization (lowercase scheme + host, HTTPS default `:443` stripped, trailing slashes stripped from the path; path and query then case-sensitive).
   - Public clients (`token_endpoint_auth_method: "none"`) succeed via this gate.
   - Entries are validated at startup: HTTPS only, no fragment / userinfo, no loopback / private / link-local / unspecified IP literal hosts. Invalid entries are dropped.
   - New audit event `client_registered_via_trusted_redirect_uri` (`security.EventClientRegisteredViaTrustedRedirectURI`) carries the matched URI.

--- a/docs/security.md
+++ b/docs/security.md
@@ -293,6 +293,55 @@ Strict scheme matching is automatically enabled when `TrustedPublicRegistrationS
 
 Registrations via trusted schemes are logged with event type `client_registered_via_trusted_scheme` for security monitoring.
 
+### Trusted HTTPS Redirect URIs (SaaS MCP Clients)
+
+For well-known SaaS MCP clients (e.g. Claude.ai) whose redirect URI is fixed, operator-known, and HTTPS, you can allowlist specific URIs without enabling `AllowPublicClientRegistration` globally or pre-registering the client out-of-band:
+
+```go
+config := &server.Config{
+    AllowPublicClientRegistration: false,
+    RegistrationAccessToken:       os.Getenv("REGISTRATION_TOKEN"),
+
+    TrustedPublicRegistrationRedirectURIs: []string{
+        "https://claude.ai/api/mcp/auth_callback",
+    },
+}
+```
+
+**Matching:**
+
+| Aspect | Behavior |
+|---|---|
+| Strictness | Every `redirect_uris` entry in the request must be in the allowlist; otherwise the token gate applies. |
+| Normalization | Scheme and host are lowercased; the HTTPS default port (`:443`) is stripped. |
+| Path & query | Compared case-sensitively, byte-for-byte. |
+| Public clients | `token_endpoint_auth_method: "none"` succeeds when the request matches the allowlist. |
+
+**Configuration validation:**
+
+Entries are validated at startup; the following are dropped with an error log and the feature is disabled if no valid entries remain:
+
+- non-HTTPS schemes
+- URIs with a fragment or userinfo
+- IP literals that are loopback (`127.0.0.0/8`, `::1`), private (RFC 1918), link-local (`169.254.0.0/16`, `fe80::/10`), or unspecified (`0.0.0.0`, `::`)
+- the hostname `localhost`
+- duplicate entries after normalization
+
+**Threat model vs. trusted schemes:**
+
+| | Trusted scheme | Trusted HTTPS redirect URI |
+|---|---|---|
+| Allowlisted unit | URI scheme (`cursor`) | Full URI (`https://claude.ai/api/mcp/auth_callback`) |
+| Attack on the callback | Possible if attacker registers the same scheme on the user's OS | Not possible — attacker cannot host the operator-attested URL |
+| OS / platform dependency | Yes (varies per OS, see table above) | No |
+| Primary defense | PKCE + OS-level scheme registration | PKCE + operator attestation of the URL |
+
+This control is **narrower** than `TrustedPublicRegistrationSchemes`: only the specific URLs the operator vouches for can register, and they cannot be impersonated by an attacker who controls a different web server.
+
+**Audit Logging:**
+
+Registrations via the trusted HTTPS allowlist are logged with event type `client_registered_via_trusted_redirect_uri`. The matched URI is included in the event details.
+
 ### Development Configuration
 
 ```go

--- a/docs/security.md
+++ b/docs/security.md
@@ -313,8 +313,8 @@ config := &server.Config{
 | Aspect | Behavior |
 |---|---|
 | Strictness | Every `redirect_uris` entry in the request must be in the allowlist; otherwise the token gate applies. |
-| Normalization | Scheme and host are lowercased; the HTTPS default port (`:443`) is stripped. |
-| Path & query | Compared case-sensitively, byte-for-byte. |
+| Normalization | Scheme and host are lowercased; HTTPS default port (`:443`) is stripped; trailing slashes are stripped from the path. |
+| Path & query | Compared case-sensitively after normalization. |
 | Public clients | `token_endpoint_auth_method: "none"` succeeds when the request matches the allowlist. |
 
 **Configuration validation:**
@@ -337,6 +337,10 @@ Entries are validated at startup; the following are dropped with an error log an
 | Primary defense | PKCE + OS-level scheme registration | PKCE + operator attestation of the URL |
 
 This control is **narrower** than `TrustedPublicRegistrationSchemes`: only the specific URLs the operator vouches for can register, and they cannot be impersonated by an attacker who controls a different web server.
+
+**Operator responsibility:**
+
+Each entry vouches for a specific URL. Avoid allowlisting URLs on multi-tenant hosting (e.g. `https://*.github.io/...`, public pastebin / preview domains, or shared SaaS subdomains the operator does not control end-to-end) — any tenant on that host can host an attacker-controlled callback at the same URL. Allowlist only URLs whose host you trust the platform vendor for.
 
 **Audit Logging:**
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -342,6 +342,10 @@ This control is **narrower** than `TrustedPublicRegistrationSchemes`: only the s
 
 Each entry vouches for a specific URL. Avoid allowlisting URLs on multi-tenant hosting (e.g. `https://*.github.io/...`, public pastebin / preview domains, or shared SaaS subdomains the operator does not control end-to-end) — any tenant on that host can host an attacker-controlled callback at the same URL. Allowlist only URLs whose host you trust the platform vendor for.
 
+**Combining with `TrustedPublicRegistrationSchemes`:**
+
+The two allowlists are independent — each is evaluated in strict mode. A registration request whose `redirect_uris` mixes a trusted scheme and a trusted HTTPS URI satisfies neither gate and is rejected. To onboard a custom-scheme client (e.g. Cursor) and a SaaS HTTPS client (e.g. Claude.ai) on the same server, register them as separate clients.
+
 **Audit Logging:**
 
 Registrations via the trusted HTTPS allowlist are logged with event type `client_registered_via_trusted_redirect_uri`. The matched URI is included in the event details.

--- a/handler.go
+++ b/handler.go
@@ -83,16 +83,15 @@ func (h *Handler) validateRegistrationToken(authHeader string) bool {
 
 // Registration auth gate names used in audit, tracing, and logs.
 const (
-	registrationAuthPathTrustedScheme      = "trusted_scheme"
-	registrationAuthPathTrustedRedirectURI = "trusted_redirect_uri"
+	registrationAuthGateTrustedScheme      = "trusted_scheme"
+	registrationAuthGateTrustedRedirectURI = "trusted_redirect_uri"
 )
 
-// registrationAuthResult captures which gate authorized a DCR request so audit,
-// tracing, and public-client checks can branch without parallel flags.
+// registrationAuthResult identifies which gate authorized a DCR request.
 type registrationAuthResult struct {
 	viaTrustedAllowlist bool
-	path                string
-	match               string
+	gate                string
+	matched             string
 }
 
 // authorizeClientRegistration checks whether a DCR request is authorized via the
@@ -115,8 +114,8 @@ func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Req
 	if authHeader != "" {
 		h.logger.Warn("Invalid registration token provided, falling back to trusted allowlists",
 			"client_ip", clientIP,
-			"trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0,
-			"trusted_redirect_uris_configured", len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0)
+			"has_trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0,
+			"has_trusted_redirect_uris_configured", len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0)
 	}
 
 	allowed, scheme, err := h.server.CanRegisterWithTrustedScheme(req.RedirectURIs)
@@ -128,7 +127,7 @@ func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Req
 	if allowed {
 		h.logger.Debug("Client registration authorized via trusted scheme",
 			"scheme", scheme, "client_ip", clientIP, "strict_matching", !h.server.Config.DisableStrictSchemeMatching)
-		return registrationAuthResult{viaTrustedAllowlist: true, path: registrationAuthPathTrustedScheme, match: scheme}, true
+		return registrationAuthResult{viaTrustedAllowlist: true, gate: registrationAuthGateTrustedScheme, matched: scheme}, true
 	}
 
 	allowed, uri, err := h.server.CanRegisterWithTrustedRedirectURI(req.RedirectURIs)
@@ -140,13 +139,13 @@ func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Req
 	if allowed {
 		h.logger.Debug("Client registration authorized via trusted redirect URI",
 			"redirect_uri", uri, "client_ip", clientIP)
-		return registrationAuthResult{viaTrustedAllowlist: true, path: registrationAuthPathTrustedRedirectURI, match: uri}, true
+		return registrationAuthResult{viaTrustedAllowlist: true, gate: registrationAuthGateTrustedRedirectURI, matched: uri}, true
 	}
 
 	h.logger.Warn("Client registration rejected: missing or invalid authorization",
 		"client_ip", clientIP, "has_token", authHeader != "",
-		"trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0,
-		"trusted_redirect_uris_configured", len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0)
+		"has_trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0,
+		"has_trusted_redirect_uris_configured", len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0)
 	h.writeError(w, ErrorCodeInvalidToken,
 		"Registration requires authentication. Provide a valid registration token or use a trusted redirect URI or scheme.",
 		http.StatusUnauthorized)
@@ -182,7 +181,7 @@ func (h *Handler) validatePublicClientRegistration(ctx context.Context, w http.R
 
 	h.logger.Debug("Public client registration authorized",
 		"token_endpoint_auth_method", req.TokenEndpointAuthMethod, "client_type", req.ClientType,
-		"ip", clientIP, "via_trusted_allowlist", auth.viaTrustedAllowlist, "auth_path", auth.path)
+		"ip", clientIP, "via_trusted_allowlist", auth.viaTrustedAllowlist, "auth_gate", auth.gate)
 	return true
 }
 
@@ -1891,11 +1890,22 @@ func (h *Handler) recordTrustedAllowlistSpan(span trace.Span, auth registrationA
 	if span == nil || !auth.viaTrustedAllowlist {
 		return
 	}
-	instrumentation.SetSpanAttributes(
-		span,
-		attribute.String("oauth.registration_method", auth.path),
-		attribute.String("oauth.trusted_match", auth.match),
-	)
+	switch auth.gate {
+	case registrationAuthGateTrustedScheme:
+		instrumentation.SetSpanAttributes(
+			span,
+			attribute.String("oauth.registration_method", auth.gate),
+			attribute.String("oauth.trusted_scheme", auth.matched),
+		)
+	case registrationAuthGateTrustedRedirectURI:
+		instrumentation.SetSpanAttributes(
+			span,
+			attribute.String("oauth.registration_method", auth.gate),
+			attribute.String("oauth.trusted_redirect_uri", auth.matched),
+		)
+	default:
+		h.logger.Warn("Skipping span attrs for unknown registration auth gate", "gate", auth.gate)
+	}
 }
 
 // handleRegistrationError handles client registration errors.
@@ -1930,14 +1940,20 @@ func (h *Handler) auditTrustedAllowlistRegistration(ctx context.Context, auth re
 	}
 
 	var eventType string
-	switch auth.path {
-	case registrationAuthPathTrustedRedirectURI:
-		eventType = security.EventClientRegisteredViaTrustedRedirectURI
-		details["redirect_uri"] = auth.match
-	default:
+	switch auth.gate {
+	case registrationAuthGateTrustedScheme:
 		eventType = security.EventClientRegisteredViaTrustedScheme
-		details["scheme"] = auth.match
+		details["scheme"] = auth.matched
 		details["strict_matching"] = !h.server.Config.DisableStrictSchemeMatching
+		details["security_context"] = "unauthenticated_registration_via_trusted_scheme"
+	case registrationAuthGateTrustedRedirectURI:
+		eventType = security.EventClientRegisteredViaTrustedRedirectURI
+		details["redirect_uri"] = auth.matched
+		details["security_context"] = "unauthenticated_registration_via_trusted_redirect_uri"
+	default:
+		h.logger.Warn("Skipping audit for unknown registration auth gate",
+			"gate", auth.gate, "client_id", client.ClientID, "client_ip", clientIP)
+		return
 	}
 
 	h.server.Auditor.LogEvent(ctx, security.Event{

--- a/handler.go
+++ b/handler.go
@@ -81,57 +81,87 @@ func (h *Handler) validateRegistrationToken(authHeader string) bool {
 	return subtle.ConstantTimeCompare([]byte(parts[1]), []byte(h.server.Config.RegistrationAccessToken)) == 1
 }
 
-// authorizeClientRegistration checks if client registration is authorized
-// Returns (registeredViaTrustedScheme, trustedScheme, error)
-func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Request, req *clientRegistrationRequest, clientIP string) (bool, string, bool) {
+// Registration auth gate names used in audit, tracing, and logs.
+const (
+	registrationAuthPathTrustedScheme      = "trusted_scheme"
+	registrationAuthPathTrustedRedirectURI = "trusted_redirect_uri"
+)
+
+// registrationAuthResult captures which gate authorized a DCR request so audit,
+// tracing, and public-client checks can branch without parallel flags.
+type registrationAuthResult struct {
+	viaTrustedAllowlist bool
+	path                string
+	match               string
+}
+
+// authorizeClientRegistration checks whether a DCR request is authorized via the
+// public-client flag, a registration access token, the trusted-scheme allowlist,
+// or the trusted-redirect-URI allowlist (in that order).
+func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Request, req *clientRegistrationRequest, clientIP string) (registrationAuthResult, bool) {
+	var result registrationAuthResult
+
 	if h.server.Config.AllowPublicClientRegistration {
 		h.logger.Warn("Unauthenticated client registration (DoS risk)", "client_ip", clientIP)
-		return false, "", true
+		return result, true
 	}
 
 	authHeader := r.Header.Get("Authorization")
 	if h.validateRegistrationToken(authHeader) {
 		h.logger.Debug("Client registration authenticated with valid token")
-		return false, "", true
+		return result, true
 	}
 
-	// Check trusted schemes
 	if authHeader != "" {
-		h.logger.Warn("Invalid registration token provided, checking trusted schemes as fallback",
-			"client_ip", clientIP, "has_trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0)
+		h.logger.Warn("Invalid registration token provided, falling back to trusted allowlists",
+			"client_ip", clientIP,
+			"trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0,
+			"trusted_redirect_uris_configured", len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0)
 	}
 
 	allowed, scheme, err := h.server.CanRegisterWithTrustedScheme(req.RedirectURIs)
 	if err != nil {
 		h.logger.Warn("Client registration rejected: invalid redirect URI", "client_ip", clientIP, "error", err)
 		h.writeError(w, ErrorCodeInvalidRequest, fmt.Sprintf("Invalid redirect URI: %v", err), http.StatusBadRequest)
-		return false, "", false
+		return result, false
 	}
-
 	if allowed {
 		h.logger.Debug("Client registration authorized via trusted scheme",
 			"scheme", scheme, "client_ip", clientIP, "strict_matching", !h.server.Config.DisableStrictSchemeMatching)
-		return true, scheme, true
+		return registrationAuthResult{viaTrustedAllowlist: true, path: registrationAuthPathTrustedScheme, match: scheme}, true
+	}
+
+	allowed, uri, err := h.server.CanRegisterWithTrustedRedirectURI(req.RedirectURIs)
+	if err != nil {
+		h.logger.Warn("Client registration rejected: invalid redirect URI", "client_ip", clientIP, "error", err)
+		h.writeError(w, ErrorCodeInvalidRequest, fmt.Sprintf("Invalid redirect URI: %v", err), http.StatusBadRequest)
+		return result, false
+	}
+	if allowed {
+		h.logger.Debug("Client registration authorized via trusted redirect URI",
+			"redirect_uri", uri, "client_ip", clientIP)
+		return registrationAuthResult{viaTrustedAllowlist: true, path: registrationAuthPathTrustedRedirectURI, match: uri}, true
 	}
 
 	h.logger.Warn("Client registration rejected: missing or invalid authorization",
 		"client_ip", clientIP, "has_token", authHeader != "",
-		"trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0)
+		"trusted_schemes_configured", len(h.server.Config.TrustedPublicRegistrationSchemes) > 0,
+		"trusted_redirect_uris_configured", len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0)
 	h.writeError(w, ErrorCodeInvalidToken,
-		"Registration requires authentication. Provide a valid registration token or use a trusted redirect URI scheme.",
+		"Registration requires authentication. Provide a valid registration token or use a trusted redirect URI or scheme.",
 		http.StatusUnauthorized)
-	return false, "", false
+	return result, false
 }
 
 // validatePublicClientRegistration validates public client registration is allowed
 // Returns true if allowed, false if rejected
-func (h *Handler) validatePublicClientRegistration(ctx context.Context, w http.ResponseWriter, req *clientRegistrationRequest, clientIP string, registeredViaTrustedScheme bool, startTime time.Time, span trace.Span) bool {
+func (h *Handler) validatePublicClientRegistration(ctx context.Context, w http.ResponseWriter, req *clientRegistrationRequest, clientIP string, auth registrationAuthResult, startTime time.Time, span trace.Span) bool {
 	isPublicClientRequest := req.TokenEndpointAuthMethod == TokenEndpointAuthMethodNone || req.ClientType == ClientTypePublic
 	if !isPublicClientRequest {
 		return true
 	}
 
-	if !h.server.Config.AllowPublicClientRegistration && !registeredViaTrustedScheme {
+	if !h.server.Config.AllowPublicClientRegistration && !auth.viaTrustedAllowlist {
 		h.logger.Warn("Public client registration rejected (not allowed by configuration)",
 			"token_endpoint_auth_method", req.TokenEndpointAuthMethod,
 			"client_type", req.ClientType, "ip", clientIP)
@@ -152,7 +182,7 @@ func (h *Handler) validatePublicClientRegistration(ctx context.Context, w http.R
 
 	h.logger.Debug("Public client registration authorized",
 		"token_endpoint_auth_method", req.TokenEndpointAuthMethod, "client_type", req.ClientType,
-		"ip", clientIP, "via_trusted_scheme", registeredViaTrustedScheme)
+		"ip", clientIP, "via_trusted_allowlist", auth.viaTrustedAllowlist, "auth_path", auth.path)
 	return true
 }
 
@@ -1100,7 +1130,8 @@ func (h *Handler) addOptionalMetadata(metadata map[string]any) {
 func (h *Handler) isRegistrationAvailable() bool {
 	return h.server.Config.AllowPublicClientRegistration ||
 		h.server.Config.RegistrationAccessToken != "" ||
-		len(h.server.Config.TrustedPublicRegistrationSchemes) > 0
+		len(h.server.Config.TrustedPublicRegistrationSchemes) > 0 ||
+		len(h.server.Config.TrustedPublicRegistrationRedirectURIs) > 0
 }
 
 // ServeOpenIDConfiguration handles OpenID Connect Discovery 1.0 requests
@@ -1782,16 +1813,16 @@ func (h *Handler) ServeClientRegistration(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	registeredViaTrustedScheme, trustedScheme, authorized := h.authorizeClientRegistration(w, r, req, clientIP)
+	auth, authorized := h.authorizeClientRegistration(w, r, req, clientIP)
 	if !authorized {
 		return
 	}
 
-	if !h.validatePublicClientRegistration(ctx, w, req, clientIP, registeredViaTrustedScheme, startTime, span) {
+	if !h.validatePublicClientRegistration(ctx, w, req, clientIP, auth, startTime, span) {
 		return
 	}
 
-	h.recordTrustedSchemeSpan(span, registeredViaTrustedScheme, trustedScheme)
+	h.recordTrustedAllowlistSpan(span, auth)
 
 	maxClients := h.getMaxClientsPerIP()
 	client, clientSecret, err := h.server.RegisterClient(ctx, req.ClientName, req.ClientType, req.TokenEndpointAuthMethod, req.RedirectURIs, req.Scopes, clientIP, maxClients)
@@ -1801,7 +1832,7 @@ func (h *Handler) ServeClientRegistration(w http.ResponseWriter, r *http.Request
 	}
 
 	h.recordClientRegistered(ctx, client.ClientType)
-	h.auditTrustedSchemeRegistration(ctx, registeredViaTrustedScheme, trustedScheme, client, clientIP)
+	h.auditTrustedAllowlistRegistration(ctx, auth, client, clientIP)
 	h.recordHTTPMetrics(ctx, "register", http.MethodPost, http.StatusCreated, startTime)
 	h.setRegistrationSpanSuccess(span, client)
 	h.writeRegistrationResponse(w, client, clientSecret)
@@ -1855,15 +1886,16 @@ func (h *Handler) getMaxClientsPerIP() int {
 	return h.server.Config.MaxClientsPerIP
 }
 
-// recordTrustedSchemeSpan records trusted scheme info in span.
-func (h *Handler) recordTrustedSchemeSpan(span trace.Span, registeredViaTrustedScheme bool, trustedScheme string) {
-	if span != nil && registeredViaTrustedScheme {
-		instrumentation.SetSpanAttributes(
-			span,
-			attribute.String("oauth.registration_method", "trusted_scheme"),
-			attribute.String("oauth.trusted_scheme", trustedScheme),
-		)
+// recordTrustedAllowlistSpan records the allowlist gate used in the span, if any.
+func (h *Handler) recordTrustedAllowlistSpan(span trace.Span, auth registrationAuthResult) {
+	if span == nil || !auth.viaTrustedAllowlist {
+		return
 	}
+	instrumentation.SetSpanAttributes(
+		span,
+		attribute.String("oauth.registration_method", auth.path),
+		attribute.String("oauth.trusted_match", auth.match),
+	)
 }
 
 // handleRegistrationError handles client registration errors.
@@ -1884,23 +1916,34 @@ func (h *Handler) handleRegistrationError(ctx context.Context, w http.ResponseWr
 	h.writeError(w, ErrorCodeServerError, "Failed to register client", http.StatusInternalServerError)
 }
 
-// auditTrustedSchemeRegistration logs trusted scheme registration for security monitoring.
-func (h *Handler) auditTrustedSchemeRegistration(ctx context.Context, registeredViaTrustedScheme bool, trustedScheme string, client *storage.Client, clientIP string) {
-	if !registeredViaTrustedScheme || h.server.Auditor == nil {
+// auditTrustedAllowlistRegistration logs unauthenticated DCR via either trusted
+// allowlist (scheme or HTTPS redirect URI) for security monitoring.
+func (h *Handler) auditTrustedAllowlistRegistration(ctx context.Context, auth registrationAuthResult, client *storage.Client, clientIP string) {
+	if !auth.viaTrustedAllowlist || h.server.Auditor == nil {
 		return
 	}
 
+	details := map[string]any{
+		"client_type":   client.ClientType,
+		"client_ip":     clientIP,
+		"redirect_uris": client.RedirectURIs,
+	}
+
+	var eventType string
+	switch auth.path {
+	case registrationAuthPathTrustedRedirectURI:
+		eventType = security.EventClientRegisteredViaTrustedRedirectURI
+		details["redirect_uri"] = auth.match
+	default:
+		eventType = security.EventClientRegisteredViaTrustedScheme
+		details["scheme"] = auth.match
+		details["strict_matching"] = !h.server.Config.DisableStrictSchemeMatching
+	}
+
 	h.server.Auditor.LogEvent(ctx, security.Event{
-		Type:     security.EventClientRegisteredViaTrustedScheme,
+		Type:     eventType,
 		ClientID: client.ClientID,
-		Details: map[string]any{
-			"scheme":           trustedScheme,
-			"client_type":      client.ClientType,
-			"client_ip":        clientIP,
-			"redirect_uris":    client.RedirectURIs,
-			"strict_matching":  !h.server.Config.DisableStrictSchemeMatching,
-			"security_context": "unauthenticated_registration_via_trusted_scheme",
-		},
+		Details:  details,
 	})
 }
 

--- a/handler_trusted_redirect_uris_test.go
+++ b/handler_trusted_redirect_uris_test.go
@@ -119,7 +119,7 @@ func TestHandler_ServeClientRegistration_TrustedRedirectURIs(t *testing.T) {
 
 			req := httptest.NewRequest(http.MethodPost, "/register", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
-			req.RemoteAddr = "192.168.1.100:12345"
+			req.RemoteAddr = testClientRemoteAddr
 			if tt.provideToken {
 				req.Header.Set("Authorization", "Bearer "+tt.registrationAccessToken)
 			}
@@ -153,12 +153,6 @@ func TestHandler_IsRegistrationAvailable_TrustedRedirectURIs(t *testing.T) {
 	require.True(t, handler.isRegistrationAvailable(), "allowlist enables DCR")
 }
 
-// TestHandler_ServeClientRegistration_TrustedSchemesAndRedirectURIs_Combined
-// exercises a request that mixes a trusted scheme entry and a trusted HTTPS
-// entry. Each allowlist is independently strict, so a mixed-URI request is
-// rejected: the scheme gate sees a non-cursor URI and bails, then the
-// HTTPS gate sees a non-https URI and bails. Operators wanting Cursor +
-// Claude.ai must register them as separate clients.
 func TestHandler_ServeClientRegistration_TrustedSchemesAndRedirectURIs_Combined(t *testing.T) {
 	handler, store := setupTestHandler(t)
 	defer store.Stop()
@@ -180,7 +174,7 @@ func TestHandler_ServeClientRegistration_TrustedSchemesAndRedirectURIs_Combined(
 	require.NoError(t, err)
 	req := httptest.NewRequest(http.MethodPost, "/register", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.RemoteAddr = "192.168.1.100:12345"
+	req.RemoteAddr = testClientRemoteAddr
 
 	w := httptest.NewRecorder()
 	handler.ServeClientRegistration(w, req)

--- a/handler_trusted_redirect_uris_test.go
+++ b/handler_trusted_redirect_uris_test.go
@@ -86,7 +86,7 @@ func TestHandler_ServeClientRegistration_TrustedRedirectURIs(t *testing.T) {
 			wantStatus:              http.StatusCreated,
 		},
 		{
-			name:                          "public client via allowlist without token_endpoint_auth_method=none still ok",
+			name:                          "confidential client via allowlist (default auth method) ok",
 			trustedURIs:                   []string{"https://claude.ai/api/mcp/auth_callback"},
 			registrationAccessToken:       trustedRedirectURITestToken,
 			allowPublicClientRegistration: false,
@@ -151,4 +151,39 @@ func TestHandler_IsRegistrationAvailable_TrustedRedirectURIs(t *testing.T) {
 
 	handler.server.Config.TrustedPublicRegistrationRedirectURIs = []string{"https://claude.ai/cb"}
 	require.True(t, handler.isRegistrationAvailable(), "allowlist enables DCR")
+}
+
+// TestHandler_ServeClientRegistration_TrustedSchemesAndRedirectURIs_Combined
+// exercises a request that mixes a trusted scheme entry and a trusted HTTPS
+// entry. Each allowlist is independently strict, so a mixed-URI request is
+// rejected: the scheme gate sees a non-cursor URI and bails, then the
+// HTTPS gate sees a non-https URI and bails. Operators wanting Cursor +
+// Claude.ai must register them as separate clients.
+func TestHandler_ServeClientRegistration_TrustedSchemesAndRedirectURIs_Combined(t *testing.T) {
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	handler.server.Config.RegistrationAccessToken = trustedRedirectURITestToken
+	handler.server.Config.AllowPublicClientRegistration = false
+	handler.server.Config.TrustedPublicRegistrationSchemes = []string{"cursor"}
+	handler.server.Config.SetTrustedSchemesMap([]string{"cursor"})
+	handler.server.Config.TrustedPublicRegistrationRedirectURIs = []string{"https://claude.ai/cb"}
+	handler.server.Config.SetTrustedRedirectURIsSet([]string{"https://claude.ai/cb"})
+	handler.server.Config.ProductionMode = false
+
+	regReq := ClientRegistrationRequest{
+		ClientName:              "Mixed Client",
+		TokenEndpointAuthMethod: "none",
+		RedirectURIs:            []string{"cursor://cb", "https://claude.ai/cb"},
+	}
+	body, err := json.Marshal(regReq)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "192.168.1.100:12345"
+
+	w := httptest.NewRecorder()
+	handler.ServeClientRegistration(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code, "body: %s", w.Body.String())
 }

--- a/handler_trusted_redirect_uris_test.go
+++ b/handler_trusted_redirect_uris_test.go
@@ -1,0 +1,154 @@
+package oauth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const trustedRedirectURITestToken = "test-registration-token-trusted-uris-12345"
+
+func TestHandler_ServeClientRegistration_TrustedRedirectURIs(t *testing.T) {
+	tests := []struct {
+		name                          string
+		trustedURIs                   []string
+		registrationAccessToken       string
+		allowPublicClientRegistration bool
+		redirectURIs                  []string
+		tokenEndpointAuthMethod       string
+		clientType                    string
+		provideToken                  bool
+		wantStatus                    int
+		wantErrorContains             string
+	}{
+		{
+			name:                    "single matching URI - no token - public client allowed",
+			trustedURIs:             []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs:            []string{"https://claude.ai/api/mcp/auth_callback"},
+			tokenEndpointAuthMethod: "none",
+			wantStatus:              http.StatusCreated,
+		},
+		{
+			name:                    "uppercase host matches normalised entry",
+			trustedURIs:             []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs:            []string{"https://CLAUDE.AI/api/mcp/auth_callback"},
+			tokenEndpointAuthMethod: "none",
+			wantStatus:              http.StatusCreated,
+		},
+		{
+			name:                    "default port matches without port",
+			trustedURIs:             []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs:            []string{"https://claude.ai:443/api/mcp/auth_callback"},
+			tokenEndpointAuthMethod: "none",
+			wantStatus:              http.StatusCreated,
+		},
+		{
+			name:                    "strict: any non-matching URI in request rejects",
+			trustedURIs:             []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs: []string{
+				"https://claude.ai/api/mcp/auth_callback",
+				"https://attacker.example/cb",
+			},
+			tokenEndpointAuthMethod: "none",
+			wantStatus:              http.StatusUnauthorized,
+			wantErrorContains:       "authentication",
+		},
+		{
+			name:                    "case-sensitive path mismatch rejects",
+			trustedURIs:             []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs:            []string{"https://claude.ai/api/MCP/auth_callback"},
+			tokenEndpointAuthMethod: "none",
+			wantStatus:              http.StatusUnauthorized,
+		},
+		{
+			name:                    "no allowlist configured - token required",
+			trustedURIs:             nil,
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs:            []string{"https://claude.ai/api/mcp/auth_callback"},
+			tokenEndpointAuthMethod: "none",
+			wantStatus:              http.StatusUnauthorized,
+		},
+		{
+			name:                    "with token - any URI works",
+			trustedURIs:             []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken: trustedRedirectURITestToken,
+			redirectURIs:            []string{"https://example.com/cb"},
+			provideToken:            true,
+			wantStatus:              http.StatusCreated,
+		},
+		{
+			name:                          "public client via allowlist without token_endpoint_auth_method=none still ok",
+			trustedURIs:                   []string{"https://claude.ai/api/mcp/auth_callback"},
+			registrationAccessToken:       trustedRedirectURITestToken,
+			allowPublicClientRegistration: false,
+			redirectURIs:                  []string{"https://claude.ai/api/mcp/auth_callback"},
+			tokenEndpointAuthMethod:       "",
+			wantStatus:                    http.StatusCreated,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, store := setupTestHandler(t)
+			defer store.Stop()
+
+			handler.server.Config.RegistrationAccessToken = tt.registrationAccessToken
+			handler.server.Config.AllowPublicClientRegistration = tt.allowPublicClientRegistration
+			handler.server.Config.TrustedPublicRegistrationRedirectURIs = tt.trustedURIs
+			handler.server.Config.SetTrustedRedirectURIsSet(tt.trustedURIs)
+			handler.server.Config.ProductionMode = false
+
+			regReq := ClientRegistrationRequest{
+				ClientName:              "Test Client",
+				ClientType:              tt.clientType,
+				TokenEndpointAuthMethod: tt.tokenEndpointAuthMethod,
+				RedirectURIs:            tt.redirectURIs,
+			}
+
+			body, err := json.Marshal(regReq)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodPost, "/register", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			req.RemoteAddr = "192.168.1.100:12345"
+			if tt.provideToken {
+				req.Header.Set("Authorization", "Bearer "+tt.registrationAccessToken)
+			}
+
+			w := httptest.NewRecorder()
+			handler.ServeClientRegistration(w, req)
+
+			require.Equal(t, tt.wantStatus, w.Code, "body: %s", w.Body.String())
+
+			if tt.wantErrorContains != "" {
+				require.Contains(t, w.Body.String(), tt.wantErrorContains)
+			}
+
+			if tt.wantStatus == http.StatusCreated {
+				var resp ClientRegistrationResponse
+				require.NoError(t, json.NewDecoder(w.Body).Decode(&resp))
+				require.NotEmpty(t, resp.ClientID)
+				require.Equal(t, len(tt.redirectURIs), len(resp.RedirectURIs))
+			}
+		})
+	}
+}
+
+func TestHandler_IsRegistrationAvailable_TrustedRedirectURIs(t *testing.T) {
+	handler, store := setupTestHandler(t)
+	defer store.Stop()
+
+	require.False(t, handler.isRegistrationAvailable(), "no gate configured")
+
+	handler.server.Config.TrustedPublicRegistrationRedirectURIs = []string{"https://claude.ai/cb"}
+	require.True(t, handler.isRegistrationAvailable(), "allowlist enables DCR")
+}

--- a/oauthconfig/env.go
+++ b/oauthconfig/env.go
@@ -86,11 +86,8 @@ func FromEnvWithPrefix(prefix string) (*server.Config, error) {
 		return nil, err
 	}
 
-	if raw := os.Getenv(prefix + "TRUSTED_AUDIENCES"); raw != "" {
-		cfg.TrustedAudiences = splitAndTrim(raw, ",")
-		if err := dex.ValidateAudiences(cfg.TrustedAudiences); err != nil {
-			return nil, fmt.Errorf("%sTRUSTED_AUDIENCES: %w", prefix, err)
-		}
+	if err := loadTrustedAllowlistsFromEnv(prefix, cfg); err != nil {
+		return nil, err
 	}
 
 	cfg.AllowLocalhostRedirectURIs, err = optionalBool(prefix+"ALLOW_LOCALHOST_REDIRECT_URIS", false)
@@ -98,15 +95,26 @@ func FromEnvWithPrefix(prefix string) (*server.Config, error) {
 		return nil, err
 	}
 
-	if raw := os.Getenv(prefix + "TRUSTED_REDIRECT_SCHEMES"); raw != "" {
-		cfg.TrustedPublicRegistrationSchemes = splitAndTrim(raw, ",")
-	}
-
-	if raw := os.Getenv(prefix + "TRUSTED_REDIRECT_URIS"); raw != "" {
-		cfg.TrustedPublicRegistrationRedirectURIs = splitAndTrim(raw, ",")
-	}
-
 	return cfg, nil
+}
+
+// loadTrustedAllowlistsFromEnv loads the comma-separated allowlist env vars
+// (TRUSTED_AUDIENCES, TRUSTED_REDIRECT_SCHEMES, TRUSTED_REDIRECT_URIS) into cfg.
+func loadTrustedAllowlistsFromEnv(prefix string, cfg *server.Config) error {
+	loadCSVIfSet(prefix+"TRUSTED_AUDIENCES", &cfg.TrustedAudiences)
+	if err := dex.ValidateAudiences(cfg.TrustedAudiences); err != nil {
+		return fmt.Errorf("%sTRUSTED_AUDIENCES: %w", prefix, err)
+	}
+	loadCSVIfSet(prefix+"TRUSTED_REDIRECT_SCHEMES", &cfg.TrustedPublicRegistrationSchemes)
+	loadCSVIfSet(prefix+"TRUSTED_REDIRECT_URIS", &cfg.TrustedPublicRegistrationRedirectURIs)
+	return nil
+}
+
+// loadCSVIfSet writes splitAndTrim(value, ",") into dst when the named env var is set.
+func loadCSVIfSet(name string, dst *[]string) {
+	if raw := os.Getenv(name); raw != "" {
+		*dst = splitAndTrim(raw, ",")
+	}
 }
 
 // validateIssuerScheme rejects a plain-HTTP issuer unless the operator has

--- a/oauthconfig/env.go
+++ b/oauthconfig/env.go
@@ -102,6 +102,10 @@ func FromEnvWithPrefix(prefix string) (*server.Config, error) {
 		cfg.TrustedPublicRegistrationSchemes = splitAndTrim(raw, ",")
 	}
 
+	if raw := os.Getenv(prefix + "TRUSTED_REDIRECT_URIS"); raw != "" {
+		cfg.TrustedPublicRegistrationRedirectURIs = splitAndTrim(raw, ",")
+	}
+
 	return cfg, nil
 }
 

--- a/security/events.go
+++ b/security/events.go
@@ -42,6 +42,10 @@ const (
 	// This enables compatibility with MCP clients that don't support registration tokens.
 	EventClientRegisteredViaTrustedScheme = "client_registered_via_trusted_scheme"
 
+	// EventClientRegisteredViaTrustedRedirectURI is logged when a client is registered without a token
+	// because every redirect_uri matches the TrustedPublicRegistrationRedirectURIs allowlist.
+	EventClientRegisteredViaTrustedRedirectURI = "client_registered_via_trusted_redirect_uri"
+
 	// EventClientRegistrationRejected is logged when client registration is rejected for security reasons
 	EventClientRegistrationRejected = "client_registration_rejected"
 

--- a/server/client.go
+++ b/server/client.go
@@ -241,8 +241,10 @@ func (s *Server) CanRegisterWithTrustedScheme(redirectURIs []string) (allowed bo
 // CanRegisterWithTrustedRedirectURI reports whether a registration request can
 // proceed without a RegistrationAccessToken because every redirect URI in the
 // request matches an entry in TrustedPublicRegistrationRedirectURIs after RFC 3986
-// normalization. Strict matching is always enforced: a single non-matching URI
-// causes the request to fall through to the token gate.
+// normalization. Strict matching is the only mode: a permissive variant (matching
+// any URI when at least one matches) would allow an attacker to attach arbitrary
+// callbacks alongside a trusted one. A single non-matching URI causes the request
+// to fall through to the token gate.
 //
 // Returns the first matched (canonical) URI for audit logging.
 func (s *Server) CanRegisterWithTrustedRedirectURI(redirectURIs []string) (allowed bool, matchedURI string, err error) {
@@ -252,9 +254,6 @@ func (s *Server) CanRegisterWithTrustedRedirectURI(redirectURIs []string) (allow
 
 	var firstMatch string
 	for _, uri := range redirectURIs {
-		if _, parseErr := url.Parse(uri); parseErr != nil {
-			return false, "", fmt.Errorf("invalid redirect URI: %w", parseErr)
-		}
 		canonical := helpers.NormalizeURL(uri)
 		if !s.Config.trustedRedirectURIsSet[canonical] {
 			return false, "", nil

--- a/server/client.go
+++ b/server/client.go
@@ -9,6 +9,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/giantswarm/mcp-oauth/internal/helpers"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
@@ -235,4 +236,33 @@ func (s *Server) CanRegisterWithTrustedScheme(redirectURIs []string) (allowed bo
 	}
 
 	return true, firstTrustedScheme, nil
+}
+
+// CanRegisterWithTrustedRedirectURI reports whether a registration request can
+// proceed without a RegistrationAccessToken because every redirect URI in the
+// request matches an entry in TrustedPublicRegistrationRedirectURIs after RFC 3986
+// normalization. Strict matching is always enforced: a single non-matching URI
+// causes the request to fall through to the token gate.
+//
+// Returns the first matched (canonical) URI for audit logging.
+func (s *Server) CanRegisterWithTrustedRedirectURI(redirectURIs []string) (allowed bool, matchedURI string, err error) {
+	if len(s.Config.trustedRedirectURIsSet) == 0 || len(redirectURIs) == 0 {
+		return false, "", nil
+	}
+
+	var firstMatch string
+	for _, uri := range redirectURIs {
+		if _, parseErr := url.Parse(uri); parseErr != nil {
+			return false, "", fmt.Errorf("invalid redirect URI: %w", parseErr)
+		}
+		canonical := helpers.NormalizeURL(uri)
+		if !s.Config.trustedRedirectURIsSet[canonical] {
+			return false, "", nil
+		}
+		if firstMatch == "" {
+			firstMatch = canonical
+		}
+	}
+
+	return true, firstMatch, nil
 }

--- a/server/config.go
+++ b/server/config.go
@@ -493,8 +493,9 @@ type Config struct {
 
 	// TrustedPublicRegistrationRedirectURIs lists fully-qualified HTTPS redirect URIs
 	// allowed to register without a RegistrationAccessToken. Matching is exact after
-	// RFC 3986 host normalization (lowercase scheme + host, default port stripped);
-	// path and query are compared case-sensitively. All redirect URIs in a registration
+	// RFC 3986 normalization: scheme and host are lowercased, the HTTPS default port
+	// (:443) is stripped, and trailing slashes are stripped from the path. Path and
+	// query are then compared case-sensitively. All redirect URIs in a registration
 	// request must be in this set; otherwise the token gate applies.
 	//
 	// Entries must be HTTPS, must not contain a fragment, userinfo, or a loopback,

--- a/server/config.go
+++ b/server/config.go
@@ -491,6 +491,23 @@ type Config struct {
 	// This field is internal and should not be set directly by users.
 	trustedSchemesMap map[string]bool
 
+	// TrustedPublicRegistrationRedirectURIs lists fully-qualified HTTPS redirect URIs
+	// allowed to register without a RegistrationAccessToken. Matching is exact after
+	// RFC 3986 host normalization (lowercase scheme + host, default port stripped);
+	// path and query are compared case-sensitively. All redirect URIs in a registration
+	// request must be in this set; otherwise the token gate applies.
+	//
+	// Entries must be HTTPS, must not contain a fragment, userinfo, or a loopback,
+	// private, link-local, or unspecified IP literal host. Invalid entries are dropped
+	// at configuration time.
+	//
+	// Default: [].
+	TrustedPublicRegistrationRedirectURIs []string
+
+	// trustedRedirectURIsSet holds normalized entries from
+	// TrustedPublicRegistrationRedirectURIs for O(1) lookup.
+	trustedRedirectURIsSet map[string]bool
+
 	// DisableStrictSchemeMatching explicitly disables strict scheme matching for deployments
 	// that need to support clients with mixed redirect URI schemes (e.g., cursor:// AND https://).
 	//
@@ -1121,5 +1138,24 @@ func (c *Config) SetTrustedSchemesMap(schemes []string) {
 	for _, scheme := range schemes {
 		// Normalize to lowercase for case-insensitive matching (RFC 3986)
 		c.trustedSchemesMap[strings.ToLower(scheme)] = true
+	}
+}
+
+// SetTrustedRedirectURIsSet builds the pre-computed trusted redirect URI set from the
+// given URIs. URIs are normalized per RFC 3986 (lowercase scheme + host, default port
+// stripped). Invalid entries are skipped.
+func (c *Config) SetTrustedRedirectURIsSet(uris []string) {
+	if len(uris) == 0 {
+		c.trustedRedirectURIsSet = nil
+		return
+	}
+	c.trustedRedirectURIsSet = make(map[string]bool, len(uris))
+	for _, uri := range uris {
+		if normalized, err := normalizeTrustedRedirectURI(uri); err == nil {
+			c.trustedRedirectURIsSet[normalized] = true
+		}
+	}
+	if len(c.trustedRedirectURIsSet) == 0 {
+		c.trustedRedirectURIsSet = nil
 	}
 }

--- a/server/config_trusted_redirect_uris.go
+++ b/server/config_trusted_redirect_uris.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/giantswarm/mcp-oauth/internal/helpers"
+)
+
+// validateTrustedPublicRegistrationRedirectURIs validates and normalizes
+// TrustedPublicRegistrationRedirectURIs and populates the lookup set.
+func validateTrustedPublicRegistrationRedirectURIs(config *Config, logger *slog.Logger) {
+	if len(config.TrustedPublicRegistrationRedirectURIs) == 0 {
+		return
+	}
+
+	set := make(map[string]bool, len(config.TrustedPublicRegistrationRedirectURIs))
+	normalized := make([]string, 0, len(config.TrustedPublicRegistrationRedirectURIs))
+
+	for i, raw := range config.TrustedPublicRegistrationRedirectURIs {
+		canonical, err := normalizeTrustedRedirectURI(raw)
+		if err != nil {
+			logger.Error("Removing invalid TrustedPublicRegistrationRedirectURIs entry",
+				"index", i, "uri", raw, "reason", err.Error())
+			continue
+		}
+		if set[canonical] {
+			logger.Warn("Removing duplicate TrustedPublicRegistrationRedirectURIs entry",
+				"index", i, "uri", raw, "normalized", canonical)
+			continue
+		}
+		set[canonical] = true
+		normalized = append(normalized, canonical)
+	}
+
+	if len(normalized) == 0 {
+		config.TrustedPublicRegistrationRedirectURIs = nil
+		config.trustedRedirectURIsSet = nil
+		logger.Warn("All TrustedPublicRegistrationRedirectURIs entries dropped after validation",
+			"result", "feature disabled")
+		return
+	}
+	config.TrustedPublicRegistrationRedirectURIs = normalized
+	config.trustedRedirectURIsSet = set
+	logger.Debug("TrustedPublicRegistrationRedirectURIs configured", "count", len(normalized))
+
+	if config.AllowPublicClientRegistration {
+		logger.Warn("TrustedPublicRegistrationRedirectURIs is redundant when AllowPublicClientRegistration=true",
+			"recommendation", "set AllowPublicClientRegistration=false")
+	}
+}
+
+// normalizeTrustedRedirectURI returns the canonical form of a redirect URI suitable
+// for exact-match comparison via helpers.NormalizeURL. Returns an error for any
+// URI that is not safe to allowlist (non-HTTPS, fragment, userinfo, missing host,
+// loopback, private, link-local, or unspecified IP literal).
+func normalizeTrustedRedirectURI(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("empty URI")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse: %w", err)
+	}
+
+	if strings.ToLower(parsed.Scheme) != SchemeHTTPS {
+		return "", fmt.Errorf("scheme %q: only https is allowed", parsed.Scheme)
+	}
+	if parsed.Fragment != "" {
+		return "", errors.New("fragment is not allowed")
+	}
+	if parsed.User != nil {
+		return "", errors.New("userinfo is not allowed")
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return "", errors.New("missing host")
+	}
+	if helpers.IsLoopbackHostname(host) {
+		return "", errors.New("loopback host is not allowed")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		switch {
+		case ip.IsUnspecified():
+			return "", errors.New("unspecified IP is not allowed")
+		case ip.IsPrivate():
+			return "", errors.New("private IP is not allowed")
+		case helpers.IsLinkLocal(ip):
+			return "", errors.New("link-local IP is not allowed")
+		}
+	}
+
+	return helpers.NormalizeURL(raw), nil
+}

--- a/server/config_trusted_redirect_uris_test.go
+++ b/server/config_trusted_redirect_uris_test.go
@@ -186,12 +186,12 @@ func TestNormalizeTrustedRedirectURI_Canonical(t *testing.T) {
 	t.Parallel()
 
 	cases := map[string]string{
-		"https://example.com/cb":                    "https://example.com/cb",
-		"https://EXAMPLE.com/cb":                    "https://example.com/cb",
-		"https://example.com:443/cb":                "https://example.com/cb",
-		"https://example.com/cb?x=1":                "https://example.com/cb?x=1",
-		"https://example.com/Path/Case":             "https://example.com/Path/Case",
-		"https://claude.ai/api/mcp/auth_callback":   "https://claude.ai/api/mcp/auth_callback",
+		"https://example.com/cb":                      "https://example.com/cb",
+		"https://EXAMPLE.com/cb":                      "https://example.com/cb",
+		"https://example.com:443/cb":                  "https://example.com/cb",
+		"https://example.com/cb?x=1":                  "https://example.com/cb?x=1",
+		"https://example.com/Path/Case":               "https://example.com/Path/Case",
+		"https://claude.ai/api/mcp/auth_callback":     "https://claude.ai/api/mcp/auth_callback",
 		"https://claude.ai:443/api/mcp/auth_callback": "https://claude.ai/api/mcp/auth_callback",
 	}
 

--- a/server/config_trusted_redirect_uris_test.go
+++ b/server/config_trusted_redirect_uris_test.go
@@ -44,10 +44,14 @@ func TestValidateTrustedPublicRegistrationRedirectURIs(t *testing.T) {
 			wantLogged: []string{"only https is allowed"},
 		},
 		{
-			name:       "loopback rejected",
-			input:      []string{"https://localhost/cb", "https://127.0.0.1/cb"},
-			wantSet:    nil,
-			wantLogged: []string{"loopback host is not allowed"},
+			name:    "loopback rejected (both entries)",
+			input:   []string{"https://localhost/cb", "https://127.0.0.1/cb"},
+			wantSet: nil,
+			wantLogged: []string{
+				`uri=https://localhost/cb`,
+				`uri=https://127.0.0.1/cb`,
+				"loopback host is not allowed",
+			},
 		},
 		{
 			name:       "private IP rejected",
@@ -128,6 +132,22 @@ func TestValidateTrustedPublicRegistrationRedirectURIs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateTrustedPublicRegistrationRedirectURIs_RedundantWithAllowPublic(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	cfg := &Config{
+		Issuer:                                "https://auth.example.com",
+		AllowPublicClientRegistration:         true,
+		TrustedPublicRegistrationRedirectURIs: []string{"https://claude.ai/cb"},
+	}
+	applySecureDefaults(cfg, logger)
+
+	require.Contains(t, buf.String(), "TrustedPublicRegistrationRedirectURIs is redundant when AllowPublicClientRegistration=true")
 }
 
 func TestNormalizeTrustedRedirectURI_Errors(t *testing.T) {

--- a/server/config_trusted_redirect_uris_test.go
+++ b/server/config_trusted_redirect_uris_test.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateTrustedPublicRegistrationRedirectURIs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      []string
+		wantSet    []string
+		wantLogged []string
+	}{
+		{
+			name:    "empty input",
+			input:   nil,
+			wantSet: nil,
+		},
+		{
+			name:    "single valid https URI",
+			input:   []string{"https://claude.ai/api/mcp/auth_callback"},
+			wantSet: []string{"https://claude.ai/api/mcp/auth_callback"},
+		},
+		{
+			name:    "uppercase host normalised",
+			input:   []string{"https://CLAUDE.AI/cb"},
+			wantSet: []string{"https://claude.ai/cb"},
+		},
+		{
+			name:    "default port stripped",
+			input:   []string{"https://example.com:443/cb"},
+			wantSet: []string{"https://example.com/cb"},
+		},
+		{
+			name:       "http rejected",
+			input:      []string{"http://example.com/cb"},
+			wantSet:    nil,
+			wantLogged: []string{"only https is allowed"},
+		},
+		{
+			name:       "loopback rejected",
+			input:      []string{"https://localhost/cb", "https://127.0.0.1/cb"},
+			wantSet:    nil,
+			wantLogged: []string{"loopback host is not allowed"},
+		},
+		{
+			name:       "private IP rejected",
+			input:      []string{"https://10.0.0.1/cb"},
+			wantSet:    nil,
+			wantLogged: []string{"private IP is not allowed"},
+		},
+		{
+			name:       "link-local IP rejected",
+			input:      []string{"https://169.254.169.254/cb"},
+			wantSet:    nil,
+			wantLogged: []string{"link-local IP is not allowed"},
+		},
+		{
+			name:       "unspecified IP rejected",
+			input:      []string{"https://0.0.0.0/cb"},
+			wantSet:    nil,
+			wantLogged: []string{"unspecified IP is not allowed"},
+		},
+		{
+			name:       "fragment rejected",
+			input:      []string{"https://example.com/cb#x"},
+			wantSet:    nil,
+			wantLogged: []string{"fragment is not allowed"},
+		},
+		{
+			name:       "userinfo rejected",
+			input:      []string{"https://u:p@example.com/cb"},
+			wantSet:    nil,
+			wantLogged: []string{"userinfo is not allowed"},
+		},
+		{
+			name:       "missing host rejected",
+			input:      []string{"https:///cb"},
+			wantSet:    nil,
+			wantLogged: []string{"missing host"},
+		},
+		{
+			name:       "duplicates collapsed",
+			input:      []string{"https://example.com/cb", "https://EXAMPLE.com/cb", "https://example.com:443/cb"},
+			wantSet:    []string{"https://example.com/cb"},
+			wantLogged: []string{"duplicate"},
+		},
+		{
+			name:       "mix of valid and invalid keeps valid",
+			input:      []string{"http://nope.example", "https://ok.example/cb"},
+			wantSet:    []string{"https://ok.example/cb"},
+			wantLogged: []string{"only https is allowed"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+			cfg := &Config{
+				Issuer:                                "https://auth.example.com",
+				TrustedPublicRegistrationRedirectURIs: append([]string(nil), tt.input...),
+			}
+
+			applySecureDefaults(cfg, logger)
+
+			require.Equal(t, tt.wantSet, cfg.TrustedPublicRegistrationRedirectURIs)
+			if len(tt.wantSet) == 0 {
+				require.Empty(t, cfg.trustedRedirectURIsSet)
+			} else {
+				require.Len(t, cfg.trustedRedirectURIsSet, len(tt.wantSet))
+				for _, u := range tt.wantSet {
+					require.True(t, cfg.trustedRedirectURIsSet[u], "set should contain %q", u)
+				}
+			}
+
+			for _, want := range tt.wantLogged {
+				require.Contains(t, buf.String(), want)
+			}
+		})
+	}
+}
+
+func TestNormalizeTrustedRedirectURI_Errors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		uri  string
+		err  string
+	}{
+		{"empty", "", "empty URI"},
+		{"unparseable", "https://%zz/", "parse"},
+		{"http scheme", "http://example.com/cb", "only https is allowed"},
+		{"missing scheme", "//example.com/cb", "only https is allowed"},
+		{"with fragment", "https://example.com/cb#x", "fragment"},
+		{"with userinfo", "https://u@example.com/cb", "userinfo"},
+		{"missing host", "https:///cb", "missing host"},
+		{"loopback", "https://localhost/cb", "loopback"},
+		{"127.0.0.1", "https://127.0.0.1/cb", "loopback"},
+		{"private IP", "https://192.168.1.1/cb", "private IP"},
+		{"link-local", "https://169.254.169.254/cb", "link-local"},
+		{"unspecified", "https://0.0.0.0/cb", "unspecified IP"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := normalizeTrustedRedirectURI(tc.uri)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.err)
+		})
+	}
+}
+
+func TestNormalizeTrustedRedirectURI_Canonical(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]string{
+		"https://example.com/cb":                    "https://example.com/cb",
+		"https://EXAMPLE.com/cb":                    "https://example.com/cb",
+		"https://example.com:443/cb":                "https://example.com/cb",
+		"https://example.com/cb?x=1":                "https://example.com/cb?x=1",
+		"https://example.com/Path/Case":             "https://example.com/Path/Case",
+		"https://claude.ai/api/mcp/auth_callback":   "https://claude.ai/api/mcp/auth_callback",
+		"https://claude.ai:443/api/mcp/auth_callback": "https://claude.ai/api/mcp/auth_callback",
+	}
+
+	for input, want := range cases {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeTrustedRedirectURI(input)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+		})
+	}
+}

--- a/server/config_validation.go
+++ b/server/config_validation.go
@@ -1,8 +1,10 @@
 package server
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -39,6 +41,9 @@ func applySecureDefaults(config *Config, logger *slog.Logger) *Config {
 
 	// Validate trusted public registration schemes configuration
 	validateTrustedPublicRegistrationSchemes(config, logger)
+
+	// Validate trusted public registration HTTPS redirect URIs allowlist
+	validateTrustedPublicRegistrationRedirectURIs(config, logger)
 
 	// Validate ProviderTokenTTL configuration (SSO token forwarding)
 	validateProviderTokenTTLConfig(config, logger)
@@ -690,6 +695,94 @@ func logTrustedSchemesConfig(config *Config, logger *slog.Logger) {
 		logger.Warn("TrustedPublicRegistrationSchemes is redundant when AllowPublicClientRegistration=true",
 			"recommendation", "Set AllowPublicClientRegistration=false")
 	}
+}
+
+// validateTrustedPublicRegistrationRedirectURIs validates and normalizes
+// TrustedPublicRegistrationRedirectURIs and populates the lookup set.
+func validateTrustedPublicRegistrationRedirectURIs(config *Config, logger *slog.Logger) {
+	if len(config.TrustedPublicRegistrationRedirectURIs) == 0 {
+		return
+	}
+
+	set := make(map[string]bool, len(config.TrustedPublicRegistrationRedirectURIs))
+	normalized := make([]string, 0, len(config.TrustedPublicRegistrationRedirectURIs))
+
+	for i, raw := range config.TrustedPublicRegistrationRedirectURIs {
+		canonical, err := normalizeTrustedRedirectURI(raw)
+		if err != nil {
+			logger.Error("Removing invalid TrustedPublicRegistrationRedirectURIs entry",
+				"index", i, "uri", raw, "reason", err.Error())
+			continue
+		}
+		if set[canonical] {
+			logger.Warn("Removing duplicate TrustedPublicRegistrationRedirectURIs entry",
+				"index", i, "uri", raw, "normalized", canonical)
+			continue
+		}
+		set[canonical] = true
+		normalized = append(normalized, canonical)
+	}
+
+	if len(normalized) == 0 {
+		config.TrustedPublicRegistrationRedirectURIs = nil
+		config.trustedRedirectURIsSet = nil
+		logger.Warn("All TrustedPublicRegistrationRedirectURIs entries dropped after validation",
+			"result", "feature disabled")
+		return
+	}
+	config.TrustedPublicRegistrationRedirectURIs = normalized
+	config.trustedRedirectURIsSet = set
+	logger.Debug("TrustedPublicRegistrationRedirectURIs configured", "count", len(normalized))
+
+	if config.AllowPublicClientRegistration {
+		logger.Warn("TrustedPublicRegistrationRedirectURIs is redundant when AllowPublicClientRegistration=true",
+			"recommendation", "set AllowPublicClientRegistration=false")
+	}
+}
+
+// normalizeTrustedRedirectURI returns the canonical form of a redirect URI suitable
+// for exact-match comparison via helpers.NormalizeURL. Returns an error for any
+// URI that is not safe to allowlist (non-HTTPS, fragment, userinfo, missing host,
+// loopback, private, link-local, or unspecified IP literal).
+func normalizeTrustedRedirectURI(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("empty URI")
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse: %w", err)
+	}
+
+	if strings.ToLower(parsed.Scheme) != SchemeHTTPS {
+		return "", fmt.Errorf("scheme %q: only https is allowed", parsed.Scheme)
+	}
+	if parsed.Fragment != "" || parsed.RawFragment != "" {
+		return "", errors.New("fragment is not allowed")
+	}
+	if parsed.User != nil {
+		return "", errors.New("userinfo is not allowed")
+	}
+
+	host := parsed.Hostname()
+	if host == "" {
+		return "", errors.New("missing host")
+	}
+	if helpers.IsLoopbackHostname(host) {
+		return "", errors.New("loopback host is not allowed")
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		switch {
+		case ip.IsUnspecified():
+			return "", errors.New("unspecified IP is not allowed")
+		case ip.IsPrivate():
+			return "", errors.New("private IP is not allowed")
+		case helpers.IsLinkLocal(ip):
+			return "", errors.New("link-local IP is not allowed")
+		}
+	}
+
+	return helpers.NormalizeURL(raw), nil
 }
 
 // isValidSchemeChar checks if a character is valid in a URI scheme per RFC 3986.

--- a/server/config_validation.go
+++ b/server/config_validation.go
@@ -1,10 +1,8 @@
 package server
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
-	"net"
 	"net/url"
 	"strings"
 	"time"
@@ -695,94 +693,6 @@ func logTrustedSchemesConfig(config *Config, logger *slog.Logger) {
 		logger.Warn("TrustedPublicRegistrationSchemes is redundant when AllowPublicClientRegistration=true",
 			"recommendation", "Set AllowPublicClientRegistration=false")
 	}
-}
-
-// validateTrustedPublicRegistrationRedirectURIs validates and normalizes
-// TrustedPublicRegistrationRedirectURIs and populates the lookup set.
-func validateTrustedPublicRegistrationRedirectURIs(config *Config, logger *slog.Logger) {
-	if len(config.TrustedPublicRegistrationRedirectURIs) == 0 {
-		return
-	}
-
-	set := make(map[string]bool, len(config.TrustedPublicRegistrationRedirectURIs))
-	normalized := make([]string, 0, len(config.TrustedPublicRegistrationRedirectURIs))
-
-	for i, raw := range config.TrustedPublicRegistrationRedirectURIs {
-		canonical, err := normalizeTrustedRedirectURI(raw)
-		if err != nil {
-			logger.Error("Removing invalid TrustedPublicRegistrationRedirectURIs entry",
-				"index", i, "uri", raw, "reason", err.Error())
-			continue
-		}
-		if set[canonical] {
-			logger.Warn("Removing duplicate TrustedPublicRegistrationRedirectURIs entry",
-				"index", i, "uri", raw, "normalized", canonical)
-			continue
-		}
-		set[canonical] = true
-		normalized = append(normalized, canonical)
-	}
-
-	if len(normalized) == 0 {
-		config.TrustedPublicRegistrationRedirectURIs = nil
-		config.trustedRedirectURIsSet = nil
-		logger.Warn("All TrustedPublicRegistrationRedirectURIs entries dropped after validation",
-			"result", "feature disabled")
-		return
-	}
-	config.TrustedPublicRegistrationRedirectURIs = normalized
-	config.trustedRedirectURIsSet = set
-	logger.Debug("TrustedPublicRegistrationRedirectURIs configured", "count", len(normalized))
-
-	if config.AllowPublicClientRegistration {
-		logger.Warn("TrustedPublicRegistrationRedirectURIs is redundant when AllowPublicClientRegistration=true",
-			"recommendation", "set AllowPublicClientRegistration=false")
-	}
-}
-
-// normalizeTrustedRedirectURI returns the canonical form of a redirect URI suitable
-// for exact-match comparison via helpers.NormalizeURL. Returns an error for any
-// URI that is not safe to allowlist (non-HTTPS, fragment, userinfo, missing host,
-// loopback, private, link-local, or unspecified IP literal).
-func normalizeTrustedRedirectURI(raw string) (string, error) {
-	if raw == "" {
-		return "", errors.New("empty URI")
-	}
-
-	parsed, err := url.Parse(raw)
-	if err != nil {
-		return "", fmt.Errorf("parse: %w", err)
-	}
-
-	if strings.ToLower(parsed.Scheme) != SchemeHTTPS {
-		return "", fmt.Errorf("scheme %q: only https is allowed", parsed.Scheme)
-	}
-	if parsed.Fragment != "" || parsed.RawFragment != "" {
-		return "", errors.New("fragment is not allowed")
-	}
-	if parsed.User != nil {
-		return "", errors.New("userinfo is not allowed")
-	}
-
-	host := parsed.Hostname()
-	if host == "" {
-		return "", errors.New("missing host")
-	}
-	if helpers.IsLoopbackHostname(host) {
-		return "", errors.New("loopback host is not allowed")
-	}
-	if ip := net.ParseIP(host); ip != nil {
-		switch {
-		case ip.IsUnspecified():
-			return "", errors.New("unspecified IP is not allowed")
-		case ip.IsPrivate():
-			return "", errors.New("private IP is not allowed")
-		case helpers.IsLinkLocal(ip):
-			return "", errors.New("link-local IP is not allowed")
-		}
-	}
-
-	return helpers.NormalizeURL(raw), nil
 }
 
 // isValidSchemeChar checks if a character is valid in a URI scheme per RFC 3986.


### PR DESCRIPTION
## Summary

HTTPS analogue of `TrustedPublicRegistrationSchemes` (#142). Operators can list specific HTTPS redirect URIs (e.g. `https://claude.ai/api/mcp/auth_callback`) that may register without a `RegistrationAccessToken`, without flipping `AllowPublicClientRegistration` for every HTTPS client on the internet.

## What changed

- `server.Config.TrustedPublicRegistrationRedirectURIs []string` — exact-match allowlist after RFC 3986 normalization (lowercase scheme + host, HTTPS default `:443` stripped, trailing slashes stripped from the path; path and query then case-sensitive).
- Strict matching is the only mode: every `redirect_uris` entry in the registration request must be in the allowlist; otherwise the token gate applies. A permissive variant would allow an attacker to attach arbitrary callbacks alongside a trusted one.
- Public clients (`token_endpoint_auth_method: "none"`) succeed via this gate — the Claude.ai DCR shape requires it.
- Config-time validation rejects: non-HTTPS, fragment, userinfo, missing host, `localhost` / loopback / private / link-local / unspecified IP literals, and duplicates after normalization. Bad entries are dropped with an error log; the feature is disabled if no valid entries remain.
- New audit event `client_registered_via_trusted_redirect_uri` (`security.EventClientRegisteredViaTrustedRedirectURI`) — the existing `client_registered_via_trusted_scheme` event is unchanged, so existing dashboards/alerts keep working.
- Env loader: `OAUTH_TRUSTED_REDIRECT_URIS` (comma-separated), mirroring `OAUTH_TRUSTED_REDIRECT_SCHEMES`. Both reads collapsed into a single `loadTrustedAllowlistsFromEnv` helper, which also keeps `FromEnvWithPrefix` under gocyclo's 15-cyclomatic-complexity threshold (was 16).
- Handler refactor: `registrationAuthResult{viaTrustedAllowlist, gate, matched}` replaces the parallel scheme-only flags. Span attribute and structured-log keys are preserved (no breaking observability changes): the new gate emits `oauth.trusted_redirect_uri` / `has_trusted_redirect_uris_configured` alongside the existing `oauth.trusted_scheme` / `has_trusted_schemes_configured`.
- Audit + span emitters are exhaustive over known gates; unknown gates log a warning instead of silently falling through.

## Threat model vs. trusted schemes

|  | Trusted scheme | Trusted HTTPS redirect URI |
|---|---|---|
| Allowlisted unit | URI scheme (`cursor`) | Full URI |
| Attacker hosting the callback | Possible if they register the scheme on the user's OS | Not possible — operator-attested URL |
| Platform / OS dependence | Yes | No |
| Operator caveat | — | Don't allowlist URLs on multi-tenant hosts (e.g. `*.github.io`); any tenant on the same host can host an attacker callback. |

## Tests

- `server/config_trusted_redirect_uris_test.go` — config validation: http://, loopback (both entries), private IP, link-local, unspecified, fragment, userinfo, missing host, duplicates, normalization (uppercase host, `:443` strip), `AllowPublicClientRegistration` redundancy warn.
- `handler_trusted_redirect_uris_test.go` — handler HTTP: happy path, strict reject when any URI is outside the allowlist, case-sensitive path mismatch, no-allowlist falls back to token gate, token always works, confidential client via the allowlist, combined scheme + URI config rejects mixed-URI request.

## Docs

- `docs/security.md` — new "Trusted HTTPS Redirect URIs" subsection contrasting threat model with trusted schemes, including operator-responsibility callout against multi-tenant allowlist entries.
- `CHANGELOG.md` — `### Added`.

## Out of scope

- `/oauth/register` rate limiting (#302).
- CIMD changes.
- Authorization-server-metadata changes (DCR is already unconditional).
- Downstream Helm wiring in `giantswarm/muster` — separate companion PR once this is released.