### PR TITLE
feat(security): DecodeKey convenience that tries base64 then hex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`security.DecodeKey(s string) ([]byte, error)`**: convenience helper that tries [`KeyFromBase64`](security/encryption.go) then falls back to [`KeyFromHex`](security/encryption.go). Consolidates the dual-encoding decode pattern that consumers were re-implementing locally.
+
 ### Changed
 
 - **`Retry-After` is computed from the limiter's configured rate**

--- a/security/encryption.go
+++ b/security/encryption.go
@@ -201,3 +201,22 @@ func KeyFromHex(s string) ([]byte, error) {
 func KeyToHex(key []byte) string {
 	return hex.EncodeToString(key)
 }
+
+// DecodeKey decodes an AES-256 token-encryption key from either base64
+// (what `openssl rand -base64 32` produces) or hex (`openssl rand -hex 32`).
+// Detection tries base64 first and falls back to hex. The returned key
+// is guaranteed to be 32 bytes.
+//
+// DecodeKey is a convenience over [KeyFromBase64] and [KeyFromHex] for
+// operators who configure the same secret across tools that emit different
+// encodings.
+func DecodeKey(s string) ([]byte, error) {
+	if key, err := KeyFromBase64(s); err == nil {
+		return key, nil
+	}
+	key, err := KeyFromHex(s)
+	if err != nil {
+		return nil, fmt.Errorf("encryption key is neither valid base64 nor hex: %w", err)
+	}
+	return key, nil
+}

--- a/security/encryption_test.go
+++ b/security/encryption_test.go
@@ -397,6 +397,52 @@ func TestKeyFromHex_Invalid(t *testing.T) {
 
 func bytesToHex(b []byte) string { return hex.EncodeToString(b) }
 
+func TestDecodeKey(t *testing.T) {
+	key, err := GenerateKey()
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+
+	t.Run("base64", func(t *testing.T) {
+		decoded, err := DecodeKey(KeyToBase64(key))
+		if err != nil {
+			t.Fatalf("DecodeKey(base64) error = %v", err)
+		}
+		if !bytes.Equal(decoded, key) {
+			t.Error("DecodeKey(base64) round-trip mismatch")
+		}
+	})
+
+	t.Run("hex", func(t *testing.T) {
+		decoded, err := DecodeKey(KeyToHex(key))
+		if err != nil {
+			t.Fatalf("DecodeKey(hex) error = %v", err)
+		}
+		if !bytes.Equal(decoded, key) {
+			t.Error("DecodeKey(hex) round-trip mismatch")
+		}
+	})
+}
+
+func TestDecodeKey_Invalid(t *testing.T) {
+	tests := []struct {
+		name    string
+		encoded string
+	}{
+		{"empty", ""},
+		{"neither base64 nor hex", "!!!not-a-key!!!"},
+		{"base64 wrong length", base64.StdEncoding.EncodeToString(make([]byte, 16))},
+		{"hex wrong length", hex.EncodeToString(make([]byte, 16))},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := DecodeKey(tt.encoded); err == nil {
+				t.Errorf("DecodeKey(%q) succeeded, want error", tt.encoded)
+			}
+		})
+	}
+}
+
 func TestEncryptionFormat(t *testing.T) {
 	key := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, key); err != nil {


### PR DESCRIPTION
## Summary

Add `security.DecodeKey(s string) ([]byte, error)`: a convenience helper that calls `KeyFromBase64` first and falls back to `KeyFromHex` when base64 decoding fails. Both arms reuse the existing 32-byte length validation.

```go
key, err := security.DecodeKey(cfg.EncryptionKey)
```

## Why

Two known consumers (muster's broker and aggregator) were re-implementing the same combiner around `KeyFromBase64` / `KeyFromHex`:

```go
keyBytes, err := security.KeyFromBase64(cfg.EncryptionKey)
if err != nil {
    keyBytes, err = security.KeyFromHex(cfg.EncryptionKey)
}
```

That pattern is awkward (the inner `err` shadowing pattern reads badly), and it doesn't centralize the dual-encoding policy — if mcp-oauth ever standardizes on one encoding or adds a third, every consumer changes.

`KeyFromBase64` and `KeyFromHex` already live here; `DecodeKey` belongs next to them.

## Scope

- `security/encryption.go`: +`DecodeKey`
- `security/encryption_test.go`: round-trip + invalid-input tests
- `CHANGELOG.md`: `### Added` entry

No behavioral change to existing callers.

## Test

- `go test -race ./security/...` passes
- `go vet ./...` clean