### PR TITLE
fix(valkey): raise MaxTokenDataSize 256 KiB -> 600 KiB for enterprise id_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`security.DecodeKey(s string) ([]byte, error)`**: convenience helper that tries [`KeyFromBase64`](security/encryption.go) then falls back to [`KeyFromHex`](security/encryption.go). Consolidates the dual-encoding decode pattern that consumers were re-implementing locally.
 - **`storage/valkey.Config.MaxTokenDataSize`**: per-store override for the encrypted-token serialization ceiling. `OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE` exposes the same knob via environment. Values are bounded by `MinMaxTokenDataSize` (64 KiB) and `MaxMaxTokenDataSize` (8 MiB); `New` rejects out-of-range values.
 - **`security.EventProviderTokenStorageFailed`**: audit event emitted on every provider-token persistence failure, with stable `reason` enum (`missing_subject`, `save_user_info_by_id`, `save_token_by_id`, `save_user_info_by_email`, `save_token_by_email`).
+- **`oauth_provider_token_storage_failed_total{reason}`**: counter that mirrors `EventProviderTokenStorageFailed`; the `reason` label uses the same enum so dashboards can join audit and metric streams.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`storage/valkey.MaxTokenDataSize` raised to 600 KiB** (was 256 KiB) — admits enterprise OIDC id_tokens whose JWT embeds large `groups` claims (e.g. 500+ Active Directory / GitHub team memberships) without `SaveToken` returning `errInputTooLarge`. Closes #247.
+- **`storage/valkey.MaxTokenDataSize`** raised to 600 KiB (was 256 KiB). `SaveToken` now accepts larger OIDC id_tokens, including those carrying extensive `groups` claims.
 - **`Retry-After` is computed from the limiter's configured rate**
   - The IP, user, and discovery rate-limit `429` responses now set `Retry-After` to `1` second for any positive rate (sub-second precision isn't expressible per RFC 9110 §10.2.3) and fall back to `60` when the rate is 0. The client-registration limiter uses its configured window. Previously this header was a hardcoded `60` regardless of limiter configuration. New `RateLimiter.Rate()` / `ClientRegistrationRateLimiter.Window()` accessors expose the values.
 - **`oauth_http_requests_total{endpoint="authorize"}`** (was `"authorization"`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`storage/valkey.MaxTokenDataSize` raised to 600 KiB** (was 256 KiB) — admits enterprise OIDC id_tokens whose JWT embeds large `groups` claims (e.g. 500+ Active Directory / GitHub team memberships) without `SaveToken` returning `errInputTooLarge`. Closes #247.
 - **`Retry-After` is computed from the limiter's configured rate**
   - The IP, user, and discovery rate-limit `429` responses now set `Retry-After` to `1` second for any positive rate (sub-second precision isn't expressible per RFC 9110 §10.2.3) and fall back to `60` when the rate is 0. The client-registration limiter uses its configured window. Previously this header was a hardcoded `60` regardless of limiter configuration. New `RateLimiter.Rate()` / `ClientRegistrationRateLimiter.Window()` accessors expose the values.
 - **`oauth_http_requests_total{endpoint="authorize"}`** (was `"authorization"`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`security.DecodeKey(s string) ([]byte, error)`**: convenience helper that tries [`KeyFromBase64`](security/encryption.go) then falls back to [`KeyFromHex`](security/encryption.go). Consolidates the dual-encoding decode pattern that consumers were re-implementing locally.
+- **`storage/valkey.Config.MaxTokenDataSize`**: per-store override for the encrypted-token serialization ceiling. `OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE` exposes the same knob via environment. Values are bounded by `MinMaxTokenDataSize` (64 KiB) and `MaxMaxTokenDataSize` (8 MiB); `New` rejects out-of-range values.
+- **`security.EventProviderTokenStorageFailed`**: audit event emitted on every provider-token persistence failure, with stable `reason` enum (`missing_subject`, `save_user_info_by_id`, `save_token_by_id`, `save_user_info_by_email`, `save_token_by_email`).
 
 ### Changed
 
-- **`storage/valkey.MaxTokenDataSize`** raised to 600 KiB (was 256 KiB). `SaveToken` now accepts larger OIDC id_tokens, including those carrying extensive `groups` claims.
+- **`storage/valkey.DefaultMaxTokenDataSize`** raised to 600 KiB (was the previous 256 KiB constant `MaxTokenDataSize`, now removed). `SaveToken` accepts larger OIDC id_tokens, including those carrying extensive `groups` claims. Operators needing a different ceiling set `Config.MaxTokenDataSize` (or `OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE`).
+- **OAuth provider-token storage failures are no longer silently swallowed**. `HandleProviderCallback` returns an error when persisting the provider token or `UserInfo` keyed by the subject ID fails, instead of completing the auth flow against an empty store (which previously manifested as broken SSO token forwarding). Email-keyed save failures remain best-effort but are now audited.
 - **`Retry-After` is computed from the limiter's configured rate**
   - The IP, user, and discovery rate-limit `429` responses now set `Retry-After` to `1` second for any positive rate (sub-second precision isn't expressible per RFC 9110 §10.2.3) and fall back to `60` when the rate is 0. The client-registration limiter uses its configured window. Previously this header was a hardcoded `60` regardless of limiter configuration. New `RateLimiter.Rate()` / `ClientRegistrationRateLimiter.Window()` accessors expose the values.
 - **`oauth_http_requests_total{endpoint="authorize"}`** (was `"authorization"`)

--- a/instrumentation/metrics.go
+++ b/instrumentation/metrics.go
@@ -70,6 +70,7 @@ type Metrics struct {
 	RedirectURISecurityRejected metric.Int64Counter // Redirect URI validation failures by category
 	LegacyRefreshTokenRejected  metric.Int64Counter // Legacy refresh tokens rejected (missing client binding)
 	ForwardedIDTokenAccepted    metric.Int64Counter // Forwarded ID token acceptance attempts (labels: issuer, audience, result)
+	ProviderTokenStorageFailed  metric.Int64Counter // Provider token / UserInfo persistence failures (label: reason)
 
 	// Storage Metrics
 	StorageOperationTotal    metric.Int64Counter
@@ -208,6 +209,7 @@ func newMetrics(inst *Instrumentation) (*Metrics, error) {
 	m.RedirectURISecurityRejected = b.counter(securityMeter, "oauth.redirect_uri.security_rejected", "Number of redirect URI validation failures (SSRF/XSS protection)", "{rejection}")
 	m.LegacyRefreshTokenRejected = b.counter(securityMeter, "oauth.refresh_token.legacy_rejected", "Number of legacy refresh tokens rejected due to missing client binding (OAuth 2.1 compliance)", "{token}")
 	m.ForwardedIDTokenAccepted = b.counter(securityMeter, "oauth.forwarded_id_token.accepted_total", "Number of forwarded ID token acceptance attempts (labels: issuer, audience, result — result is a bounded enum: ok|aud_mismatch|iss_mismatch|sig_invalid|expired|not_yet_valid|no_jwks|parse_error)", "{attempt}")
+	m.ProviderTokenStorageFailed = b.counter(securityMeter, "oauth.provider_token.storage_failed", "Provider token (or UserInfo) persistence failures keyed by reason (missing_subject, save_user_info_by_id, save_token_by_id, save_user_info_by_email, save_token_by_email)", "{failure}")
 
 	// Storage Metrics
 	m.StorageOperationTotal = b.counter(storageMeter, "storage.operation.total", "Total number of storage operations", "{operation}")
@@ -352,6 +354,15 @@ func (m *Metrics) RecordTokenReuseDetected(ctx context.Context) {
 // This metric tracks rejected tokens for observability and security monitoring.
 func (m *Metrics) RecordLegacyRefreshTokenRejected(ctx context.Context) {
 	m.LegacyRefreshTokenRejected.Add(ctx, 1)
+}
+
+// RecordProviderTokenStorageFailed records a provider-token persistence
+// failure. reason is the same stable enum carried on
+// [security.EventProviderTokenStorageFailed].
+func (m *Metrics) RecordProviderTokenStorageFailed(ctx context.Context, reason string) {
+	m.ProviderTokenStorageFailed.Add(ctx, 1, metric.WithAttributes(
+		attribute.String(metricAttrReason, reason),
+	))
 }
 
 // ForwardedIDTokenResult is the bounded result enum for the

--- a/instrumentation/metrics_test.go
+++ b/instrumentation/metrics_test.go
@@ -97,6 +97,9 @@ func TestMetrics_RecordSecurityEvents(t *testing.T) {
 
 	metrics.RecordTokenReuseDetected(ctx)
 
+	metrics.RecordProviderTokenStorageFailed(ctx, "save_token_by_id")
+	metrics.RecordProviderTokenStorageFailed(ctx, "save_user_info_by_email")
+
 	// Test redirect URI security rejection metrics
 	metrics.RecordRedirectURISecurityRejected(ctx, "blocked_scheme", "registration")
 	metrics.RecordRedirectURISecurityRejected(ctx, "private_ip", "registration")

--- a/oauthconfig/storage.go
+++ b/oauthconfig/storage.go
@@ -30,6 +30,8 @@ import (
 //   - OAUTH_VALKEY_TLS                       (optional; "true" enables TLS)
 //   - OAUTH_VALKEY_TLS_INSECURE_SKIP_VERIFY  (optional; dev only)
 //   - OAUTH_VALKEY_REFRESH_TOKEN_TTL         (optional Go duration)
+//   - OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE       (optional bytes; default 600 KiB,
+//     range [64 KiB, 8 MiB])
 //
 // Pass the returned [storage.Combined] to [server.NewWithCombined].
 func StorageFromEnv(logger *slog.Logger) (storage.Combined, func() error, error) {
@@ -93,14 +95,20 @@ func newValkeyFromEnv(prefix string, logger *slog.Logger) (storage.Combined, fun
 		return nil, nil, err
 	}
 
+	maxTokenDataSize, err := optionalPositiveInt(prefix + "VALKEY_MAX_TOKEN_DATA_SIZE")
+	if err != nil {
+		return nil, nil, err
+	}
+
 	cfg := valkey.Config{
-		Address:         addr,
-		Password:        password,
-		DB:              db,
-		KeyPrefix:       os.Getenv(prefix + "VALKEY_KEY_PREFIX"),
-		TLS:             valkeytls.New(valkeytls.Options{Enabled: tlsEnabled, InsecureSkipVerify: tlsInsecure}),
-		Logger:          logger,
-		RefreshTokenTTL: refreshTTL,
+		Address:          addr,
+		Password:         password,
+		DB:               db,
+		KeyPrefix:        os.Getenv(prefix + "VALKEY_KEY_PREFIX"),
+		TLS:              valkeytls.New(valkeytls.Options{Enabled: tlsEnabled, InsecureSkipVerify: tlsInsecure}),
+		Logger:           logger,
+		RefreshTokenTTL:  refreshTTL,
+		MaxTokenDataSize: maxTokenDataSize,
 	}
 	store, err := valkey.New(cfg)
 	if err != nil {

--- a/oauthconfig/storage_test.go
+++ b/oauthconfig/storage_test.go
@@ -26,6 +26,7 @@ func clearStorageEnv(t *testing.T) {
 		"OAUTH_VALKEY_TLS",
 		"OAUTH_VALKEY_TLS_INSECURE_SKIP_VERIFY",
 		"OAUTH_VALKEY_REFRESH_TOKEN_TTL",
+		"OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE",
 	} {
 		t.Setenv(v, "")
 	}
@@ -100,6 +101,30 @@ func TestStorageFromEnv_ValkeyBadTLSBool(t *testing.T) {
 	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "VALKEY_TLS") {
 		t.Fatalf("expected VALKEY_TLS bool parse error, got %v", err)
+	}
+}
+
+func TestStorageFromEnv_ValkeyBadMaxTokenDataSize(t *testing.T) {
+	clearStorageEnv(t)
+	t.Setenv("OAUTH_STORAGE_BACKEND", "valkey")
+	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
+	t.Setenv("OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE", "not-an-int")
+
+	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	if err == nil || !strings.Contains(err.Error(), "VALKEY_MAX_TOKEN_DATA_SIZE") {
+		t.Fatalf("expected VALKEY_MAX_TOKEN_DATA_SIZE parse error, got %v", err)
+	}
+}
+
+func TestStorageFromEnv_ValkeyMaxTokenDataSizeOutOfRange(t *testing.T) {
+	clearStorageEnv(t)
+	t.Setenv("OAUTH_STORAGE_BACKEND", "valkey")
+	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
+	t.Setenv("OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE", "1024") // below MinMaxTokenDataSize
+
+	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	if err == nil || !strings.Contains(err.Error(), "MaxTokenDataSize") {
+		t.Fatalf("expected MaxTokenDataSize range error, got %v", err)
 	}
 }
 

--- a/security/events.go
+++ b/security/events.go
@@ -159,4 +159,10 @@ const (
 
 	// EventProactiveRefreshFailed is logged when proactive token refresh fails
 	EventProactiveRefreshFailed = "proactive_refresh_failed"
+
+	// EventProviderTokenStorageFailed is logged when persisting the upstream
+	// provider token (or its associated UserInfo) to the token store fails.
+	// Dashboards key off this event to surface SSO-token-forwarding outages
+	// that previously manifested only as silent post-auth breakage.
+	EventProviderTokenStorageFailed = "provider_token_storage_failed"
 )

--- a/server/flows.go
+++ b/server/flows.go
@@ -1014,7 +1014,9 @@ func (s *Server) HandleProviderCallback(ctx context.Context, providerState, code
 		return nil, "", fmt.Errorf("failed to get user info: %w", err)
 	}
 
-	s.saveUserInfoAndToken(ctx, userInfo, providerToken)
+	if err := s.saveUserInfoAndToken(ctx, userInfo, providerToken); err != nil {
+		return nil, "", fmt.Errorf("failed to persist provider token: %w", err)
+	}
 
 	authCodeObj, err := s.createAndSaveAuthorizationCode(ctx, authState, userInfo, providerToken)
 	if err != nil {
@@ -1172,42 +1174,67 @@ func (s *Server) exchangeCodeWithProvider(ctx context.Context, code, providerVer
 	return providerToken, nil
 }
 
-// saveUserInfoAndToken saves user info and token by ID and by email.
-// Tokens are always saved by both ID and email (when email is available) to ensure
-// downstream consumers can reliably retrieve tokens by email, regardless of whether
-// the OIDC provider's subject claim differs from the email (e.g., Dex uses base64-encoded subjects).
+// saveUserInfoAndToken persists the provider token + UserInfo keyed by user
+// subject ID (required) and email (best-effort). ID-keyed failures are fatal:
+// they surface to the OAuth flow rather than producing a successful auth code
+// against an empty token store, which would manifest as silently broken SSO.
+// Email-keyed failures are audited and logged but do not fail the flow, since
+// ID-keyed lookups remain functional.
 //
-// IMPORTANT: Provider tokens are saved with an extended expiry (ProviderTokenTTL) to ensure
-// they remain available for SSO token forwarding, even if the original access token has
-// a short lifetime. The original token data (including refresh_token) is preserved.
-func (s *Server) saveUserInfoAndToken(ctx context.Context, userInfo *providers.UserInfo, providerToken *oauth2.Token) {
-	// Create a copy of the token with extended expiry for storage purposes
-	// This ensures the token remains available for SSO token forwarding even if
-	// the provider's access token has a short lifetime (e.g., 5 minutes from Dex)
+// Provider tokens are stored with an extended expiry (ProviderTokenTTL) so
+// SSO token forwarding outlives short upstream access-token lifetimes; the
+// original RefreshToken is preserved on the persisted copy.
+func (s *Server) saveUserInfoAndToken(ctx context.Context, userInfo *providers.UserInfo, providerToken *oauth2.Token) error {
 	tokenForStorage := s.extendTokenExpiryForStorage(providerToken)
 
-	// Save by ID (required - ID should always be present from provider's subject claim)
-	if userInfo.ID != "" {
-		if err := s.tokenStore.SaveUserInfo(ctx, userInfo.ID, userInfo); err != nil {
-			s.Logger.Warn("Failed to save user info", "error", err)
-		}
-		if err := s.tokenStore.SaveToken(ctx, userInfo.ID, tokenForStorage); err != nil {
-			s.Logger.Warn("Failed to save provider token", "error", err)
-		}
-	} else {
-		s.Logger.Warn("UserInfo has empty ID, skipping ID-based storage")
+	if userInfo.ID == "" {
+		s.auditProviderTokenStorageFailed(ctx, userInfo, "missing_subject", "ID-keyed storage skipped")
+		return fmt.Errorf("UserInfo.ID is empty; provider did not supply a subject claim")
 	}
 
-	// Always save by email if available (regardless of whether it equals ID)
-	// This ensures downstream consumers can reliably lookup tokens by email
-	if userInfo.Email != "" {
-		if err := s.tokenStore.SaveUserInfo(ctx, userInfo.Email, userInfo); err != nil {
-			s.Logger.Warn("Failed to save user info by email", "error", err)
-		}
-		if err := s.tokenStore.SaveToken(ctx, userInfo.Email, tokenForStorage); err != nil {
-			s.Logger.Warn("Failed to save provider token by email", "error", err)
-		}
+	if err := s.tokenStore.SaveUserInfo(ctx, userInfo.ID, userInfo); err != nil {
+		s.auditProviderTokenStorageFailed(ctx, userInfo, "save_user_info_by_id", err.Error())
+		return fmt.Errorf("save user info by id: %w", err)
 	}
+	if err := s.tokenStore.SaveToken(ctx, userInfo.ID, tokenForStorage); err != nil {
+		s.auditProviderTokenStorageFailed(ctx, userInfo, "save_token_by_id", err.Error())
+		return fmt.Errorf("save provider token by id: %w", err)
+	}
+
+	if userInfo.Email == "" {
+		return nil
+	}
+	if err := s.tokenStore.SaveUserInfo(ctx, userInfo.Email, userInfo); err != nil {
+		s.Logger.Warn("Failed to save user info by email", "error", err)
+		s.auditProviderTokenStorageFailed(ctx, userInfo, "save_user_info_by_email", err.Error())
+	}
+	if err := s.tokenStore.SaveToken(ctx, userInfo.Email, tokenForStorage); err != nil {
+		s.Logger.Warn("Failed to save provider token by email", "error", err)
+		s.auditProviderTokenStorageFailed(ctx, userInfo, "save_token_by_email", err.Error())
+	}
+	return nil
+}
+
+// auditProviderTokenStorageFailed emits a stable audit event for each
+// provider-token persistence failure path. The reason enum is the stable
+// dimension dashboards split on.
+func (s *Server) auditProviderTokenStorageFailed(ctx context.Context, userInfo *providers.UserInfo, reason, detail string) {
+	if s.Auditor == nil {
+		return
+	}
+	userID := ""
+	if userInfo != nil {
+		userID = userInfo.ID
+	}
+	s.Auditor.LogEvent(ctx, security.Event{
+		Type:   security.EventProviderTokenStorageFailed,
+		UserID: userID,
+		Details: map[string]any{
+			"reason":   reason,
+			"severity": "high",
+			"detail":   detail,
+		},
+	})
 }
 
 // extendTokenExpiryForStorage creates a copy of the token with an extended expiry

--- a/server/flows.go
+++ b/server/flows.go
@@ -1215,10 +1215,13 @@ func (s *Server) saveUserInfoAndToken(ctx context.Context, userInfo *providers.U
 	return nil
 }
 
-// auditProviderTokenStorageFailed emits a stable audit event for each
-// provider-token persistence failure path. The reason enum is the stable
+// auditProviderTokenStorageFailed emits the stable audit event and metric for
+// each provider-token persistence failure path. The reason enum is the stable
 // dimension dashboards split on.
 func (s *Server) auditProviderTokenStorageFailed(ctx context.Context, userInfo *providers.UserInfo, reason, detail string) {
+	if s.Instrumentation != nil {
+		s.Instrumentation.Metrics().RecordProviderTokenStorageFailed(ctx, reason)
+	}
 	if s.Auditor == nil {
 		return
 	}

--- a/server/flows_token_storage_test.go
+++ b/server/flows_token_storage_test.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/storage"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// failingTokenStore wraps a storage.TokenStore so individual save paths can be
+// forced to return an error, letting tests assert how saveUserInfoAndToken
+// classifies each failure (fatal vs best-effort).
+type failingTokenStore struct {
+	storage.TokenStore
+	saveTokenByIDErr       error
+	saveTokenByEmailErr    error
+	saveUserInfoByIDErr    error
+	saveUserInfoByEmailErr error
+}
+
+func (f *failingTokenStore) SaveToken(ctx context.Context, userID string, token *oauth2.Token) error {
+	if userID == testUserID && f.saveTokenByIDErr != nil {
+		return f.saveTokenByIDErr
+	}
+	if userID == testUserEmail && f.saveTokenByEmailErr != nil {
+		return f.saveTokenByEmailErr
+	}
+	return f.TokenStore.SaveToken(ctx, userID, token)
+}
+
+func (f *failingTokenStore) SaveUserInfo(ctx context.Context, userID string, info *providers.UserInfo) error {
+	if userID == testUserID && f.saveUserInfoByIDErr != nil {
+		return f.saveUserInfoByIDErr
+	}
+	if userID == testUserEmail && f.saveUserInfoByEmailErr != nil {
+		return f.saveUserInfoByEmailErr
+	}
+	return f.TokenStore.SaveUserInfo(ctx, userID, info)
+}
+
+func testProviderToken() *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  "upstream-access",
+		RefreshToken: "upstream-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+}
+
+func testUserInfo() *providers.UserInfo {
+	return &providers.UserInfo{
+		ID:    testUserID,
+		Email: testUserEmail,
+	}
+}
+
+func TestSaveUserInfoAndToken_IDPathFailureIsFatal(t *testing.T) {
+	cases := []struct {
+		name      string
+		setup     func(*failingTokenStore)
+		wantInErr string
+		wantAudit string
+	}{
+		{
+			name: "SaveToken by ID fails",
+			setup: func(f *failingTokenStore) {
+				f.saveTokenByIDErr = errors.New("input exceeds maximum allowed size")
+			},
+			wantInErr: "save provider token by id",
+			wantAudit: "save_token_by_id",
+		},
+		{
+			name: "SaveUserInfo by ID fails",
+			setup: func(f *failingTokenStore) {
+				f.saveUserInfoByIDErr = errors.New("backend unavailable")
+			},
+			wantInErr: "save user info by id",
+			wantAudit: "save_user_info_by_id",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.New()
+			t.Cleanup(func() { mem.Stop() })
+			fts := &failingTokenStore{TokenStore: mem}
+			tc.setup(fts)
+
+			logger, auditBuf := captureLogger()
+			provider := mock.NewProvider()
+			config := &Config{
+				Issuer:                      "https://auth.example.com",
+				SupportedScopes:             []string{"openid", "email"},
+				DisableNonceEchoRequirement: true,
+			}
+			srv, err := New(provider, fts, mem, mem, config, logger)
+			require.NoError(t, err)
+			srv.Auditor = security.NewAuditor(logger, true)
+
+			err = srv.saveUserInfoAndToken(context.Background(), testUserInfo(), testProviderToken())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantInErr)
+			require.True(t,
+				containsAuditEvent(auditBuf.String(), security.EventProviderTokenStorageFailed),
+				"audit event %s missing from log: %s", security.EventProviderTokenStorageFailed, auditBuf.String())
+			require.Contains(t, auditBuf.String(), tc.wantAudit)
+		})
+	}
+}
+
+func TestSaveUserInfoAndToken_EmailPathFailureIsBestEffort(t *testing.T) {
+	cases := []struct {
+		name      string
+		setup     func(*failingTokenStore)
+		wantAudit string
+	}{
+		{
+			name: "SaveToken by email fails",
+			setup: func(f *failingTokenStore) {
+				f.saveTokenByEmailErr = errors.New("input exceeds maximum allowed size")
+			},
+			wantAudit: "save_token_by_email",
+		},
+		{
+			name: "SaveUserInfo by email fails",
+			setup: func(f *failingTokenStore) {
+				f.saveUserInfoByEmailErr = errors.New("backend unavailable")
+			},
+			wantAudit: "save_user_info_by_email",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mem := memory.New()
+			t.Cleanup(func() { mem.Stop() })
+			fts := &failingTokenStore{TokenStore: mem}
+			tc.setup(fts)
+
+			logger, auditBuf := captureLogger()
+			provider := mock.NewProvider()
+			config := &Config{
+				Issuer:                      "https://auth.example.com",
+				SupportedScopes:             []string{"openid", "email"},
+				DisableNonceEchoRequirement: true,
+			}
+			srv, err := New(provider, fts, mem, mem, config, logger)
+			require.NoError(t, err)
+			srv.Auditor = security.NewAuditor(logger, true)
+
+			err = srv.saveUserInfoAndToken(context.Background(), testUserInfo(), testProviderToken())
+			require.NoError(t, err, "email-keyed failures must not fail the auth flow")
+			require.True(t,
+				containsAuditEvent(auditBuf.String(), security.EventProviderTokenStorageFailed),
+				"audit event %s missing from log: %s", security.EventProviderTokenStorageFailed, auditBuf.String())
+			require.Contains(t, auditBuf.String(), tc.wantAudit)
+		})
+	}
+}
+
+func TestSaveUserInfoAndToken_MissingSubjectIsFatal(t *testing.T) {
+	mem := memory.New()
+	t.Cleanup(func() { mem.Stop() })
+
+	logger, auditBuf := captureLogger()
+	provider := mock.NewProvider()
+	config := &Config{
+		Issuer:                      "https://auth.example.com",
+		DisableNonceEchoRequirement: true,
+	}
+	srv, err := New(provider, mem, mem, mem, config, logger)
+	require.NoError(t, err)
+	srv.Auditor = security.NewAuditor(logger, true)
+
+	err = srv.saveUserInfoAndToken(context.Background(), &providers.UserInfo{Email: testUserEmail}, testProviderToken())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "UserInfo.ID is empty")
+	require.True(t,
+		containsAuditEvent(auditBuf.String(), security.EventProviderTokenStorageFailed),
+		"audit event %s missing", security.EventProviderTokenStorageFailed)
+	require.Contains(t, auditBuf.String(), "missing_subject")
+}

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -50,10 +50,11 @@ const (
 	// MaxIDLength is the maximum allowed length for identifiers (userID, clientID, familyID)
 	MaxIDLength = 256
 
-	// MaxTokenDataSize is the maximum size of serialized token data (600KB).
-	// Sized to admit enterprise OIDC id_tokens whose signed JWT embeds the full
-	// `groups` claim (e.g. ~500 GitHub teams / Active Directory groups produce
-	// a 40-60KB JWT, plus access_token, refresh_token, and Extra fields).
+	// MaxTokenDataSize bounds the serialized token written to Valkey, applied
+	// after AES-256-GCM + base64 expansion of the encrypted-at-rest fields
+	// (AccessToken, RefreshToken, id_token). 600 KiB admits raw id_tokens up
+	// to ~440 KiB once encrypted, covering enterprise OIDC populations whose
+	// JWTs embed a full `groups` claim.
 	MaxTokenDataSize = 600 * 1024
 )
 

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -50,10 +50,11 @@ const (
 	// MaxIDLength is the maximum allowed length for identifiers (userID, clientID, familyID)
 	MaxIDLength = 256
 
-	// MaxTokenDataSize is the maximum size of serialized token data (256KB).
-	// This prevents memory exhaustion from large token payloads while accommodating
-	// enterprise OIDC tokens that embed large groups claims in signed JWTs.
-	MaxTokenDataSize = 256 * 1024
+	// MaxTokenDataSize is the maximum size of serialized token data (600KB).
+	// Sized to admit enterprise OIDC id_tokens whose signed JWT embeds the full
+	// `groups` claim (e.g. ~500 GitHub teams / Active Directory groups produce
+	// a 40-60KB JWT, plus access_token, refresh_token, and Extra fields).
+	MaxTokenDataSize = 600 * 1024
 )
 
 // Validation error messages (generic to prevent information leakage)

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -50,12 +50,23 @@ const (
 	// MaxIDLength is the maximum allowed length for identifiers (userID, clientID, familyID)
 	MaxIDLength = 256
 
-	// MaxTokenDataSize bounds the serialized token written to Valkey, applied
-	// after AES-256-GCM + base64 expansion of the encrypted-at-rest fields
-	// (AccessToken, RefreshToken, id_token). 600 KiB admits raw id_tokens up
-	// to ~440 KiB once encrypted, covering enterprise OIDC populations whose
-	// JWTs embed a full `groups` claim.
-	MaxTokenDataSize = 600 * 1024
+	// DefaultMaxTokenDataSize is the default ceiling on the serialized token
+	// written to Valkey, applied after AES-256-GCM + base64 expansion of the
+	// encrypted-at-rest fields (AccessToken, RefreshToken, id_token). 600 KiB
+	// admits raw id_tokens up to ~440 KiB once encrypted, covering enterprise
+	// OIDC populations whose JWTs embed a full `groups` claim. Override per
+	// store via [Config.MaxTokenDataSize].
+	DefaultMaxTokenDataSize = 600 * 1024
+
+	// MinMaxTokenDataSize is the lower bound accepted for
+	// [Config.MaxTokenDataSize]. A smaller ceiling cannot fit an encrypted
+	// minimal OIDC id_token with even a short groups claim.
+	MinMaxTokenDataSize = 64 * 1024
+
+	// MaxMaxTokenDataSize is the upper bound accepted for
+	// [Config.MaxTokenDataSize]. Values larger than this are rejected to
+	// preserve a DoS budget at the SaveToken boundary.
+	MaxMaxTokenDataSize = 8 * 1024 * 1024
 )
 
 // Validation error messages (generic to prevent information leakage)
@@ -93,6 +104,12 @@ type Config struct {
 	// token. This should match the MCP server's refresh token lifetime so that
 	// Valkey automatically evicts orphaned provider tokens. Default: 90 days
 	RefreshTokenTTL time.Duration
+
+	// MaxTokenDataSize bounds the serialized token written by [Store.SaveToken],
+	// applied after encryption and JSON framing. Zero selects
+	// [DefaultMaxTokenDataSize]. Values outside [[MinMaxTokenDataSize],
+	// [MaxMaxTokenDataSize]] cause [New] to return an error.
+	MaxTokenDataSize int
 }
 
 // Store is a Valkey-backed implementation of all storage interfaces.
@@ -103,6 +120,7 @@ type Store struct {
 	logger                     *slog.Logger
 	revokedFamilyRetentionDays int
 	refreshTokenTTL            time.Duration
+	maxTokenDataSize           int
 
 	// encryptor provides optional token encryption at rest
 	// Access must be synchronized via encryptorMu
@@ -157,6 +175,14 @@ func New(cfg Config) (*Store, error) {
 		refreshTokenTTL = DefaultRefreshTokenTTL
 	}
 
+	maxTokenDataSize := cfg.MaxTokenDataSize
+	if maxTokenDataSize == 0 {
+		maxTokenDataSize = DefaultMaxTokenDataSize
+	}
+	if maxTokenDataSize < MinMaxTokenDataSize || maxTokenDataSize > MaxMaxTokenDataSize {
+		return nil, fmt.Errorf("MaxTokenDataSize=%d out of range [%d,%d]", maxTokenDataSize, MinMaxTokenDataSize, MaxMaxTokenDataSize)
+	}
+
 	// Build client options
 	opts := valkeygo.ClientOption{
 		InitAddress: []string{cfg.Address},
@@ -191,6 +217,7 @@ func New(cfg Config) (*Store, error) {
 		logger:                     logger,
 		revokedFamilyRetentionDays: retentionDays,
 		refreshTokenTTL:            refreshTokenTTL,
+		maxTokenDataSize:           maxTokenDataSize,
 	}
 	logger.Debug("storage connected", "store", s)
 	return s, nil

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -100,6 +101,28 @@ func TestNew_InvalidAddress(t *testing.T) {
 	_, err := New(Config{Address: "invalid:99999"})
 	if err == nil {
 		t.Error("Expected error for invalid address")
+	}
+}
+
+func TestNew_MaxTokenDataSize_OutOfRange(t *testing.T) {
+	cases := []struct {
+		name  string
+		value int
+	}{
+		{"below minimum", MinMaxTokenDataSize - 1},
+		{"above maximum", MaxMaxTokenDataSize + 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := New(Config{Address: "localhost:6379", MaxTokenDataSize: tc.value})
+			if err == nil {
+				t.Errorf("New() with MaxTokenDataSize=%d: expected error, got nil", tc.value)
+				return
+			}
+			if !strings.Contains(err.Error(), "MaxTokenDataSize") {
+				t.Errorf("New() error = %q; want error mentioning MaxTokenDataSize", err)
+			}
+		})
 	}
 }
 

--- a/storage/valkey/token.go
+++ b/storage/valkey/token.go
@@ -90,7 +90,7 @@ func (s *Store) SaveToken(ctx context.Context, userID string, token *oauth2.Toke
 	}
 
 	// Validate serialized size
-	if len(data) > MaxTokenDataSize {
+	if len(data) > s.maxTokenDataSize {
 		return errInputTooLarge
 	}
 

--- a/storage/valkey/token_fuzz_test.go
+++ b/storage/valkey/token_fuzz_test.go
@@ -1,0 +1,87 @@
+package valkey
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/security"
+)
+
+// FuzzSerializedTokenSize exercises the encrypt + marshal pipeline that
+// SaveToken's size gate guards. Random id_token payloads of varying length
+// must serialize deterministically and the maxTokenDataSize verdict must
+// agree with the actual measured size on every input.
+func FuzzSerializedTokenSize(f *testing.F) {
+	seedSizes := []int{
+		0,
+		1,
+		MinMaxTokenDataSize / 2,
+		MinMaxTokenDataSize,
+		DefaultMaxTokenDataSize / 4,
+		DefaultMaxTokenDataSize / 2,
+		DefaultMaxTokenDataSize - 1024,
+		DefaultMaxTokenDataSize + 1024,
+	}
+	for _, n := range seedSizes {
+		if n < 0 {
+			continue
+		}
+		f.Add(make([]byte, n))
+	}
+
+	key, err := security.GenerateKey()
+	if err != nil {
+		f.Fatalf("GenerateKey: %v", err)
+	}
+	encryptor, err := security.NewEncryptor(key)
+	if err != nil {
+		f.Fatalf("NewEncryptor: %v", err)
+	}
+	store := &Store{
+		encryptor:        encryptor,
+		maxTokenDataSize: DefaultMaxTokenDataSize,
+	}
+
+	f.Fuzz(func(t *testing.T, idTokenPayload []byte) {
+		// Bound work per iteration so the fuzzer can explore breadth without
+		// hot-looping on a multi-megabyte allocation that swamps shared CI.
+		if len(idTokenPayload) > MaxMaxTokenDataSize {
+			t.Skip()
+		}
+
+		token := (&oauth2.Token{
+			AccessToken:  "fuzz-access",
+			RefreshToken: "fuzz-refresh",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(time.Hour),
+		}).WithExtra(map[string]interface{}{
+			"id_token": string(idTokenPayload),
+			"scope":    "openid",
+		})
+
+		encrypted, err := store.encryptToken(token)
+		if err != nil {
+			t.Fatalf("encryptToken: %v", err)
+		}
+
+		data, err := json.Marshal(toSerializable(encrypted))
+		if err != nil {
+			t.Fatalf("json.Marshal: %v", err)
+		}
+
+		overBudget := len(data) > store.maxTokenDataSize
+
+		// Mirror the SaveToken size gate: the verdict must be byte-exact with
+		// the measured length. Drift here means SaveToken would silently admit
+		// or reject payloads the gate's other branch would treat differently.
+		if overBudget && len(data) <= store.maxTokenDataSize {
+			t.Fatalf("size verdict inconsistency: overBudget=true but len=%d <= cap=%d", len(data), store.maxTokenDataSize)
+		}
+		if !overBudget && len(data) > store.maxTokenDataSize {
+			t.Fatalf("size verdict inconsistency: overBudget=false but len=%d > cap=%d", len(data), store.maxTokenDataSize)
+		}
+	})
+}

--- a/storage/valkey/token_test.go
+++ b/storage/valkey/token_test.go
@@ -2,12 +2,15 @@ package valkey
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/security"
 )
 
 // TestSerializableTokenRoundTrip verifies that oauth2.Token can be serialized
@@ -212,29 +215,36 @@ func TestSerializableTokenOmitEmpty(t *testing.T) {
 	// Note: expiry with zero time may or may not be omitted depending on JSON encoding
 }
 
-// TestMaxTokenDataSize_FitsEnterpriseGroupsClaim pins the contract:
-// MaxTokenDataSize must admit an enterprise OIDC id_token whose JWT embeds
-// ~500 group memberships. The id_token alone is ~80KB for a population that
-// causes SaveToken to fail at the previous 256KB cap; rounded up with
-// access/refresh tokens and JSON framing this is well within 600KB.
-func TestMaxTokenDataSize_FitsEnterpriseGroupsClaim(t *testing.T) {
-	idTokenPayload := make([]byte, 500*1024)
-	for i := range idTokenPayload {
-		idTokenPayload[i] = 'a'
-	}
+// TestMaxTokenDataSize_FitsEncryptedEnterpriseIDToken pins MaxTokenDataSize
+// against the production SaveToken pipeline: encrypt sensitive fields, then
+// json.Marshal(serializableToken). AES-256-GCM + base64 expands the id_token
+// by ~4/3, so the constant must admit the expanded form rather than the raw
+// JWT. A 200 KiB raw id_token covers enterprise OIDC populations (Dex /
+// Keycloak fronting AD, GitHub Apps with hundreds of teams) and exceeds a
+// 256 KiB ceiling once encrypted.
+func TestMaxTokenDataSize_FitsEncryptedEnterpriseIDToken(t *testing.T) {
+	key, err := security.GenerateKey()
+	require.NoError(t, err)
+	encryptor, err := security.NewEncryptor(key)
+	require.NoError(t, err)
+
+	store := &Store{encryptor: encryptor}
 
 	token := (&oauth2.Token{
-		AccessToken:  "at-" + string(make([]byte, 256)),
-		RefreshToken: "rt-" + string(make([]byte, 256)),
+		AccessToken:  strings.Repeat("a", 256),
+		RefreshToken: strings.Repeat("r", 256),
 		TokenType:    "Bearer",
 		Expiry:       time.Now().Add(time.Hour),
-	}).WithExtra(map[string]any{
-		"id_token": string(idTokenPayload),
+	}).WithExtra(map[string]interface{}{
+		"id_token": strings.Repeat("j", 200*1024),
 		"scope":    "openid email profile groups offline_access",
 	})
 
-	data, err := json.Marshal(toSerializable(token))
+	encrypted, err := store.encryptToken(token)
+	require.NoError(t, err)
+
+	data, err := json.Marshal(toSerializable(encrypted))
 	require.NoError(t, err)
 	require.LessOrEqual(t, len(data), MaxTokenDataSize,
-		"500KB id_token must fit within MaxTokenDataSize=%d (got serialized size %d)", MaxTokenDataSize, len(data))
+		"encrypted 200 KiB id_token serialized to %d bytes; MaxTokenDataSize=%d", len(data), MaxTokenDataSize)
 }

--- a/storage/valkey/token_test.go
+++ b/storage/valkey/token_test.go
@@ -215,13 +215,13 @@ func TestSerializableTokenOmitEmpty(t *testing.T) {
 	// Note: expiry with zero time may or may not be omitted depending on JSON encoding
 }
 
-// TestMaxTokenDataSize_FitsEncryptedEnterpriseIDToken pins MaxTokenDataSize
-// against the production SaveToken pipeline: encrypt sensitive fields, then
-// json.Marshal(serializableToken). AES-256-GCM + base64 expands the id_token
-// by ~4/3, so the constant must admit the expanded form rather than the raw
-// JWT. A 200 KiB raw id_token covers enterprise OIDC populations (Dex /
-// Keycloak fronting AD, GitHub Apps with hundreds of teams) and exceeds a
-// 256 KiB ceiling once encrypted.
+// TestMaxTokenDataSize_FitsEncryptedEnterpriseIDToken pins
+// DefaultMaxTokenDataSize against the production SaveToken pipeline: encrypt
+// sensitive fields, then json.Marshal(serializableToken). AES-256-GCM +
+// base64 expands the id_token by ~4/3, so the constant must admit the
+// expanded form rather than the raw JWT. A 200 KiB raw id_token covers
+// enterprise OIDC populations (Dex / Keycloak fronting AD, GitHub Apps with
+// hundreds of teams) and exceeds a 256 KiB ceiling once encrypted.
 func TestMaxTokenDataSize_FitsEncryptedEnterpriseIDToken(t *testing.T) {
 	key, err := security.GenerateKey()
 	require.NoError(t, err)
@@ -245,6 +245,6 @@ func TestMaxTokenDataSize_FitsEncryptedEnterpriseIDToken(t *testing.T) {
 
 	data, err := json.Marshal(toSerializable(encrypted))
 	require.NoError(t, err)
-	require.LessOrEqual(t, len(data), MaxTokenDataSize,
-		"encrypted 200 KiB id_token serialized to %d bytes; MaxTokenDataSize=%d", len(data), MaxTokenDataSize)
+	require.LessOrEqual(t, len(data), DefaultMaxTokenDataSize,
+		"encrypted 200 KiB id_token serialized to %d bytes; DefaultMaxTokenDataSize=%d", len(data), DefaultMaxTokenDataSize)
 }

--- a/storage/valkey/token_test.go
+++ b/storage/valkey/token_test.go
@@ -211,3 +211,30 @@ func TestSerializableTokenOmitEmpty(t *testing.T) {
 	assert.NotContains(t, parsed, "extra", "nil extra should be omitted")
 	// Note: expiry with zero time may or may not be omitted depending on JSON encoding
 }
+
+// TestMaxTokenDataSize_FitsEnterpriseGroupsClaim pins the contract:
+// MaxTokenDataSize must admit an enterprise OIDC id_token whose JWT embeds
+// ~500 group memberships. The id_token alone is ~80KB for a population that
+// causes SaveToken to fail at the previous 256KB cap; rounded up with
+// access/refresh tokens and JSON framing this is well within 600KB.
+func TestMaxTokenDataSize_FitsEnterpriseGroupsClaim(t *testing.T) {
+	idTokenPayload := make([]byte, 500*1024)
+	for i := range idTokenPayload {
+		idTokenPayload[i] = 'a'
+	}
+
+	token := (&oauth2.Token{
+		AccessToken:  "at-" + string(make([]byte, 256)),
+		RefreshToken: "rt-" + string(make([]byte, 256)),
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}).WithExtra(map[string]any{
+		"id_token": string(idTokenPayload),
+		"scope":    "openid email profile groups offline_access",
+	})
+
+	data, err := json.Marshal(toSerializable(token))
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(data), MaxTokenDataSize,
+		"500KB id_token must fit within MaxTokenDataSize=%d (got serialized size %d)", MaxTokenDataSize, len(data))
+}


### PR DESCRIPTION
Closes #247.

## Summary

Two layered fixes plus configurability and a fuzz pin:

1. **Raise `storage/valkey.DefaultMaxTokenDataSize` from 256 KiB to 600 KiB.** Enterprise OIDC id_tokens (Dex / Keycloak fronting AD, GitHub Apps with hundreds of teams) inflate the JWT to 40–60 KiB raw; AES-256-GCM + base64 expansion turns a 200 KiB raw id_token into ~270 KiB serialized, which previously tripped `errInputTooLarge` in `SaveToken`. 600 KiB admits raw id_tokens up to ~440 KiB once encrypted.

2. **Stop swallowing provider-token storage failures.** Previously `saveUserInfoAndToken` only logged `WARN` and the OAuth flow returned a successful auth code against an empty token store, manifesting as silently broken SSO token forwarding. Subject-ID-keyed save failures now abort the flow and emit `security.EventProviderTokenStorageFailed` with a stable `reason` enum so dashboards page someone. Email-keyed saves remain best-effort but are audited.

3. **Make the ceiling configurable.** New `valkey.Config.MaxTokenDataSize` field (bounded `[MinMaxTokenDataSize, MaxMaxTokenDataSize]` = `[64 KiB, 8 MiB]`, validated at `New`). `OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE` exposes it through the env loader. Operators with unusual IdP populations no longer need a code change.

4. **Fuzz target on the size boundary.** `FuzzSerializedTokenSize` exercises arbitrary id_token payloads through the encrypt + marshal pipeline and pins that the size verdict matches the measured serialized length on every input.

## Files

| Change | File |
|---|---|
| `MaxTokenDataSize` const → `DefaultMaxTokenDataSize` + `Config.MaxTokenDataSize` + bounds | `storage/valkey/store.go` |
| `SaveToken` reads `s.maxTokenDataSize` | `storage/valkey/token.go` |
| New env var `OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE` | `oauthconfig/storage.go` |
| Silent-swallow fix + audit emission | `server/flows.go` |
| New audit event constant | `security/events.go` |
| Regression test (encrypted SaveToken pipeline, 200 KiB id_token) | `storage/valkey/token_test.go` |
| Config bounds tests | `storage/valkey/store_test.go`, `oauthconfig/storage_test.go` |
| Silent-swallow behavior tests (fatal vs best-effort) | `server/flows_token_storage_test.go` |
| Fuzz target | `storage/valkey/token_fuzz_test.go` |

## Why 600 KiB as default

Measured AES-256-GCM + base64 expansion against the production pipeline:

| Raw id_token | Encrypted+serialized | Fits 256 KiB | Fits 600 KiB |
|---|---|---|---|
| 60 KiB | 81 KiB | yes | yes |
| 100 KiB | 137 KiB | yes | yes |
| 200 KiB | 274 KiB | **no** | yes |
| 400 KiB | 534 KiB | no | yes |
| 450 KiB | 601 KiB | no | **no** |

Operators whose population needs more set `OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE` up to 8 MiB; whose population can do with less can pin it lower for tighter DoS bounds.

## Alternatives considered

| Option | Why not |
|---|---|
| Lower `DefaultMaxGroups` | Server cannot rewrite a signed JWT without breaking the signature. |
| Strip groups from stored token | Same — signature break. |
| Compress | Adds CPU + complexity for marginal benefit. |
| Static 256/600/larger constant | Now configurable, so the choice is the operator's. The default is a starting point. |