### PR TITLE
refactor(providers,storage): DRY pass — EnsureTimeout, CloneScopes, FilterScopes, RevokeAtEndpoint, valkey keyOf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`providers.EnsureTimeout(ctx, timeout) (context.Context, context.CancelFunc)`**: nil-safe context deadline helper. The three in-tree providers (dex, google, github) delegate their per-provider `ensureContextTimeout` methods to it. Closes (partial) #310.
+- **`providers.CloneScopes([]string) []string`**: nil-safe deep copy used by every provider's `DefaultScopes()` to prevent caller mutation.
+- **`providers.FilterScopes(requested, defaults []string, supported func(string) bool) []string`**: generic IdP scope-filter wrapping `CopyScopes` (mandatory-scope merge) + per-provider `supported` predicate. `filterDexScopes` / `filterGoogleScopes` collapse to single-line delegates.
+- **`providers/oidc.RevokeAtEndpoint(ctx, httpClient, endpoint, token, clientID, clientSecret) error`**: RFC 7009 revocation primitive. Pass empty `clientID` / `clientSecret` for endpoints that do not require client authentication (e.g. Google).
 - **`Config.DiscoveryCacheMaxAge time.Duration`** (default `1h`). Discovery endpoints (`/.well-known/oauth-authorization-server`, `/.well-known/oauth-protected-resource[...]`, `/.well-known/openid-configuration`) advertise `Cache-Control: public, max-age=<seconds>` per RFC 8414 §3 / RFC 9728 §3.
 - **OIDC Discovery 1.0 §3 metadata fields** on the AS metadata document: `subject_types_supported: ["public"]`, `id_token_signing_alg_values_supported` (always includes `RS256`), and `claims_supported`.
 - **`Config.EnableUserInfoEndpoint bool`** + **`EndpointPathUserInfo = "/oauth/userinfo"`** + **`Config.UserInfoEndpoint()`**. When enabled, `/oauth/userinfo` (OIDC Core 1.0 §5.3) is mounted behind `Handler.ValidateToken` and `userinfo_endpoint` is advertised in AS / OIDC discovery metadata. The `openid` scope is required; `profile`, `email`, and `groups` scopes gate the corresponding claims; `sub` is always returned. Each 2xx response emits `security.EventUserInfoServed` (`userinfo_served`) with the subject and the scope-derived claim groups returned, and the request is counted under `oauth_http_requests_total{endpoint="userinfo"}`.

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -180,13 +180,6 @@ func isDexSupportedScope(scope string) bool {
 	}
 }
 
-// filterDexScopes returns the merged copy of requestedScopes+defaultScopes
-// (mandatory-scope merging via [providers.CopyScopes] is applied inside
-// [providers.FilterScopes]) filtered by [isDexSupportedScope].
-func filterDexScopes(requestedScopes, defaultScopes []string) []string {
-	return providers.FilterScopes(requestedScopes, defaultScopes, isDexSupportedScope)
-}
-
 // resolveScopes returns validated scopes, using defaults if none provided.
 func resolveScopes(configScopes []string) ([]string, error) {
 	scopes := configScopes
@@ -273,12 +266,10 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// Apply optional OIDC parameters (Dex supports standard OIDC params)
 	authCodeOpts = append(authCodeOpts, providers.ApplyAuthorizationURLOptions(authOpts)...)
 
-	// Filter scopes to only include Dex-supported values.
-	// This prevents authorization failures when clients send non-standard scopes
-	// (e.g., "claudeai") that Dex would reject with "Unrecognized scope(s)".
-	// filterDexScopes also handles deep copying and force-merging mandatory scopes
-	// (openid, audience:server:client_id:*) from defaults via CopyScopes internally.
-	scopesToUse := filterDexScopes(scopes, p.Scopes)
+	// FilterScopes drops scopes Dex would reject ("Unrecognized scope(s)"),
+	// deep-copies the input, and force-merges mandatory scopes (openid,
+	// audience:server:client_id:*) from defaults via CopyScopes internally.
+	scopesToUse := providers.FilterScopes(scopes, p.Scopes, isDexSupportedScope)
 
 	// Create a config with the determined scopes
 	config := *p.Config
@@ -299,15 +290,10 @@ func ensureOpenIDScope(scopes []string) []string {
 	return append(scopes, scopeOpenID)
 }
 
-// ensureContextTimeout delegates to [providers.EnsureTimeout].
-func (p *Provider) ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	return providers.EnsureTimeout(ctx, p.requestTimeout)
-}
-
 // ExchangeCode exchanges an authorization code for tokens with PKCE verification.
 // Returns standard oauth2.Token.
 func (p *Provider) ExchangeCode(ctx context.Context, code string, verifier string) (*oauth2.Token, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	return providers.ExchangeCodeWithPKCE(ctx, p, p.httpClient, code, verifier)
@@ -316,7 +302,7 @@ func (p *Provider) ExchangeCode(ctx context.Context, code string, verifier strin
 // ValidateToken validates an access token by calling Dex's userinfo endpoint.
 // It parses user information including groups claim if available.
 func (p *Provider) ValidateToken(ctx context.Context, accessToken string) (*providers.UserInfo, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	// Get discovery document to find userinfo endpoint
@@ -402,7 +388,7 @@ func (p *Provider) ValidateToken(ctx context.Context, accessToken string) (*prov
 // on every refresh operation. The oauth2 library automatically captures this new token.
 // Returns standard oauth2.Token with the new refresh token.
 func (p *Provider) RefreshToken(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	// Use custom HTTP client
@@ -429,7 +415,7 @@ func (p *Provider) RefreshToken(ctx context.Context, refreshToken string) (*oaut
 // RevokeToken revokes a token at Dex's revocation endpoint if available.
 // Gracefully degrades if revocation endpoint is not supported.
 func (p *Provider) RevokeToken(ctx context.Context, token string) error {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	doc, err := p.discoveryClient.Discover(ctx, p.issuerURL)
@@ -453,7 +439,7 @@ func (p *Provider) RevokeToken(ctx context.Context, token string) error {
 //   - Error messages may contain HTTP status codes that could leak provider state information
 //   - For public health endpoints, return generic "healthy/unhealthy" status only
 func (p *Provider) HealthCheck(ctx context.Context) error {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	// Attempt to fetch discovery document
@@ -468,7 +454,7 @@ func (p *Provider) HealthCheck(ctx context.Context) error {
 // JWKSURI returns the JWKS URI for Dex from the discovery document.
 // This implements the JWKSProvider interface for SSO token forwarding.
 func (p *Provider) JWKSURI(ctx context.Context) (string, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	doc, err := p.discoveryClient.Discover(ctx, p.issuerURL)

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -181,18 +180,11 @@ func isDexSupportedScope(scope string) bool {
 	}
 }
 
-// filterDexScopes creates a deep copy of scopes and filters out any scopes that
-// Dex does not support. This prevents authorization failures when clients send
-// non-standard scopes (e.g., "claudeai") that Dex would reject.
+// filterDexScopes returns the merged copy of requestedScopes+defaultScopes
+// (mandatory-scope merging via [providers.CopyScopes] is applied inside
+// [providers.FilterScopes]) filtered by [isDexSupportedScope].
 func filterDexScopes(requestedScopes, defaultScopes []string) []string {
-	sourceScopes := providers.CopyScopes(requestedScopes, defaultScopes)
-	filtered := make([]string, 0, len(sourceScopes))
-	for _, s := range sourceScopes {
-		if isDexSupportedScope(s) {
-			filtered = append(filtered, s)
-		}
-	}
-	return filtered
+	return providers.FilterScopes(requestedScopes, defaultScopes, isDexSupportedScope)
 }
 
 // resolveScopes returns validated scopes, using defaults if none provided.
@@ -250,15 +242,10 @@ func (p *Provider) Name() string {
 	return "dex"
 }
 
-// DefaultScopes returns the provider's configured default scopes.
-// Returns a deep copy to prevent external modification.
+// DefaultScopes returns a deep copy of the provider's configured default
+// scopes so callers cannot mutate the provider's slice.
 func (p *Provider) DefaultScopes() []string {
-	if p.Scopes == nil {
-		return nil
-	}
-	scopes := make([]string, len(p.Scopes))
-	copy(scopes, p.Scopes)
-	return scopes
+	return providers.CloneScopes(p.Scopes)
 }
 
 // AuthorizationURL generates the Dex OAuth authorization URL with PKCE support.
@@ -312,15 +299,9 @@ func ensureOpenIDScope(scopes []string) []string {
 	return append(scopes, scopeOpenID)
 }
 
-// ensureContextTimeout ensures the context has a deadline, adding one if needed.
-// Returns a new context with timeout and a cancel function that should be deferred.
-// If the context already has a deadline, returns the original context with a no-op cancel.
+// ensureContextTimeout delegates to [providers.EnsureTimeout].
 func (p *Provider) ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	if _, hasDeadline := ctx.Deadline(); hasDeadline {
-		// Context already has deadline, return no-op cancel
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, p.requestTimeout)
+	return providers.EnsureTimeout(ctx, p.requestTimeout)
 }
 
 // ExchangeCode exchanges an authorization code for tokens with PKCE verification.
@@ -451,46 +432,16 @@ func (p *Provider) RevokeToken(ctx context.Context, token string) error {
 	ctx, cancel := p.ensureContextTimeout(ctx)
 	defer cancel()
 
-	// Get discovery document to find revocation endpoint
 	doc, err := p.discoveryClient.Discover(ctx, p.issuerURL)
 	if err != nil {
 		return fmt.Errorf("OIDC discovery failed: %w", err)
 	}
-
-	// If revocation endpoint not available, gracefully degrade
 	if doc.RevocationEndpoint == "" {
-		// Not an error - some OIDC providers don't support revocation
+		// Spec-compliant gracefully-degraded path: some OIDC providers don't
+		// support revocation.
 		return nil
 	}
-
-	// Prepare revocation request
-	data := url.Values{}
-	data.Set("token", token)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", doc.RevocationEndpoint, strings.NewReader(data.Encode()))
-	if err != nil {
-		return fmt.Errorf("failed to create revoke request: %w", err)
-	}
-
-	// Set content type for form data
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	// Add client credentials for authentication
-	req.SetBasicAuth(p.ClientID, p.ClientSecret)
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to revoke token: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	// RFC 7009 Section 2.2: The authorization server responds with HTTP status code 200
-	// if the token has been revoked successfully or if the client submitted an invalid token.
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("token revocation failed with status %d", resp.StatusCode)
-	}
-
-	return nil
+	return oidc.RevokeAtEndpoint(ctx, p.httpClient, doc.RevocationEndpoint, token, p.ClientID, p.ClientSecret)
 }
 
 // HealthCheck verifies that the Dex OIDC discovery endpoint is reachable.

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -487,84 +487,6 @@ func TestIsDexSupportedScope(t *testing.T) {
 	}
 }
 
-// TestFilterDexScopes_DropsUnsupportedScopes verifies that filterDexScopes
-// drops scopes that Dex does not recognize, preventing authorization failures.
-func TestFilterDexScopes_DropsUnsupportedScopes(t *testing.T) {
-	defaultScopes := []string{"openid", "email", "profile", "groups", "offline_access"}
-
-	tests := []struct {
-		name           string
-		requested      []string
-		wantContain    []string
-		wantNotContain []string
-	}{
-		{
-			name:           "drops non-standard scopes like claudeai",
-			requested:      []string{"openid", "claudeai"},
-			wantContain:    []string{"openid"},
-			wantNotContain: []string{"claudeai"},
-		},
-		{
-			name:        "keeps standard OIDC scopes",
-			requested:   []string{"openid", "email", "profile"},
-			wantContain: []string{"openid", "email", "profile"},
-		},
-		{
-			name:        "keeps Dex-specific scopes",
-			requested:   []string{"openid", "groups", "offline_access"},
-			wantContain: []string{"openid", "groups", "offline_access"},
-		},
-		{
-			name:        "keeps federated:id scope",
-			requested:   []string{"openid", "federated:id"},
-			wantContain: []string{"openid", "federated:id"},
-		},
-		{
-			name:        "keeps audience scopes",
-			requested:   []string{"openid", "audience:server:client_id:k8s"},
-			wantContain: []string{"openid", "audience:server:client_id:k8s"},
-		},
-		{
-			name:        "uses defaults when requested is nil",
-			requested:   nil,
-			wantContain: []string{"openid", "email", "profile", "groups", "offline_access"},
-		},
-		{
-			name:        "injects openid from defaults when missing in requested",
-			requested:   []string{"email", "groups"},
-			wantContain: []string{"email", "groups", "openid"},
-		},
-		{
-			name:           "drops multiple unsupported scopes",
-			requested:      []string{"openid", "claudeai", "custom:scope", "random_scope"},
-			wantContain:    []string{"openid"},
-			wantNotContain: []string{"claudeai", "custom:scope", "random_scope"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := filterDexScopes(tt.requested, defaultScopes)
-
-			resultSet := make(map[string]bool, len(result))
-			for _, s := range result {
-				resultSet[s] = true
-			}
-
-			for _, want := range tt.wantContain {
-				if !resultSet[want] {
-					t.Errorf("filterDexScopes() should contain %q, got %v", want, result)
-				}
-			}
-			for _, notWant := range tt.wantNotContain {
-				if resultSet[notWant] {
-					t.Errorf("filterDexScopes() should NOT contain %q, got %v", notWant, result)
-				}
-			}
-		})
-	}
-}
-
 // TestAuthorizationURL_OpenIDAlwaysPresent verifies that the Dex provider always
 // includes "openid" in the authorization URL, even when clients send non-standard
 // scopes that don't include it.
@@ -1001,39 +923,6 @@ func TestCustomTimeout(t *testing.T) {
 
 	if provider.requestTimeout != customTimeout {
 		t.Errorf("requestTimeout = %v, want %v", provider.requestTimeout, customTimeout)
-	}
-}
-
-// TestEnsureContextTimeout tests context timeout handling
-func TestEnsureContextTimeout(t *testing.T) {
-	server := setupMockDexServer(t)
-	defer server.Close()
-
-	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
-		cfg.RequestTimeout = 10 * time.Second
-	}))
-	if err != nil {
-		t.Fatalf("NewProvider() failed: %v", err)
-	}
-
-	// Test with context that has no deadline
-	ctx := context.Background()
-	newCtx, cancel := provider.ensureContextTimeout(ctx)
-	defer cancel()
-
-	if _, hasDeadline := newCtx.Deadline(); !hasDeadline {
-		t.Error("ensureContextTimeout() should add deadline to context without one")
-	}
-
-	// Test with context that already has deadline
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel2()
-
-	newCtx2, cancel3 := provider.ensureContextTimeout(ctx2)
-	defer cancel3()
-
-	if newCtx2 != ctx2 {
-		t.Error("ensureContextTimeout() should return original context when it has deadline")
 	}
 }
 

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -246,15 +246,10 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	return config.AuthCodeURL(state, opts...)
 }
 
-// ensureContextTimeout delegates to [providers.EnsureTimeout].
-func (p *Provider) ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	return providers.EnsureTimeout(ctx, p.requestTimeout)
-}
-
 // ExchangeCode exchanges an authorization code for tokens with optional PKCE verification.
 // Returns standard oauth2.Token. Note: GitHub OAuth Apps don't return refresh tokens.
 func (p *Provider) ExchangeCode(ctx context.Context, code string, verifier string) (*oauth2.Token, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	return providers.ExchangeCodeWithPKCE(ctx, p, p.httpClient, code, verifier)
@@ -263,7 +258,7 @@ func (p *Provider) ExchangeCode(ctx context.Context, code string, verifier strin
 // ValidateToken validates an access token by calling GitHub's user endpoint.
 // It retrieves user information and optionally validates organization membership.
 func (p *Provider) ValidateToken(ctx context.Context, accessToken string) (*providers.UserInfo, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	// Fetch user info from GitHub
@@ -475,7 +470,7 @@ func (p *Provider) RevokeToken(_ context.Context, _ string) error {
 //   - DO NOT expose error details to untrusted clients
 //   - For public endpoints, return generic "healthy/unhealthy" status only
 func (p *Provider) HealthCheck(ctx context.Context) error {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", rateLimitURL, nil)
@@ -505,7 +500,7 @@ func (p *Provider) HealthCheck(ctx context.Context) error {
 //
 // Requires the "read:org" scope.
 func (p *Provider) GetUserOrganizations(ctx context.Context, accessToken string) ([]string, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	return p.fetchUserOrganizations(ctx, accessToken)

--- a/providers/github/github.go
+++ b/providers/github/github.go
@@ -195,15 +195,10 @@ func (p *Provider) Name() string {
 	return providerName
 }
 
-// DefaultScopes returns the provider's configured default scopes.
-// Returns a deep copy to prevent external modification.
+// DefaultScopes returns a deep copy of the provider's configured default
+// scopes so callers cannot mutate the provider's slice.
 func (p *Provider) DefaultScopes() []string {
-	if p.Scopes == nil {
-		return nil
-	}
-	scopes := make([]string, len(p.Scopes))
-	copy(scopes, p.Scopes)
-	return scopes
+	return providers.CloneScopes(p.Scopes)
 }
 
 // AuthorizationURL generates the GitHub OAuth authorization URL with optional PKCE.
@@ -251,14 +246,9 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	return config.AuthCodeURL(state, opts...)
 }
 
-// ensureContextTimeout ensures the context has a deadline, adding one if needed.
-// Returns a new context with timeout and a cancel function that should be deferred.
-// If the context already has a deadline, returns the original context with a no-op cancel.
+// ensureContextTimeout delegates to [providers.EnsureTimeout].
 func (p *Provider) ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	if _, hasDeadline := ctx.Deadline(); hasDeadline {
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, p.requestTimeout)
+	return providers.EnsureTimeout(ctx, p.requestTimeout)
 }
 
 // ExchangeCode exchanges an authorization code for tokens with optional PKCE verification.

--- a/providers/github/github_test.go
+++ b/providers/github/github_test.go
@@ -1057,38 +1057,6 @@ func TestProvider_GetProviderToken(t *testing.T) {
 	}
 }
 
-func TestProvider_ensureContextTimeout(t *testing.T) {
-	provider, err := NewProvider(&Config{
-		ClientID:       testClientID,
-		ClientSecret:   testClientSecret,
-		RequestTimeout: 5 * time.Second,
-	})
-	if err != nil {
-		t.Fatalf("NewProvider() error = %v", err)
-	}
-
-	// Test with context without deadline
-	ctx1 := context.Background()
-	newCtx, cancel := provider.ensureContextTimeout(ctx1)
-	defer cancel()
-
-	if _, hasDeadline := newCtx.Deadline(); !hasDeadline {
-		t.Error("ensureContextTimeout() should add deadline when none exists")
-	}
-
-	// Test with context with deadline
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel2()
-
-	newCtx2, cancel3 := provider.ensureContextTimeout(ctx2)
-	defer cancel3()
-
-	// Should return same context
-	if newCtx2 != ctx2 {
-		t.Error("ensureContextTimeout() should return original context when deadline exists")
-	}
-}
-
 // mockUserTransport redirects GitHub API requests to test server.
 type mockUserTransport struct {
 	server *httptest.Server

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -123,13 +123,6 @@ func isGoogleSupportedScope(scope string) bool {
 	}
 }
 
-// filterGoogleScopes returns the merged copy of requestedScopes+defaultScopes
-// (mandatory-scope merging via [providers.CopyScopes] is applied inside
-// [providers.FilterScopes]) filtered by [isGoogleSupportedScope].
-func filterGoogleScopes(requestedScopes, defaultScopes []string) []string {
-	return providers.FilterScopes(requestedScopes, defaultScopes, isGoogleSupportedScope)
-}
-
 // AuthorizationURL generates the Google OAuth authorization URL with optional PKCE.
 // Supports OAuth 2.1 defense-in-depth. See SECURITY_ARCHITECTURE.md for details.
 // If scopes is empty, the provider's default configured scopes are used.
@@ -159,21 +152,17 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// Apply optional OIDC parameters
 	opts = append(opts, providers.ApplyAuthorizationURLOptions(authOpts)...)
 
-	// Create a config with filtered scopes
+	// Drop scopes Google would reject (e.g. Dex audience scopes) while
+	// preserving mandatory openid scopes via CopyScopes.
 	config := *p.Config
-	config.Scopes = filterGoogleScopes(scopes, p.Scopes)
+	config.Scopes = providers.FilterScopes(scopes, p.Scopes, isGoogleSupportedScope)
 	return config.AuthCodeURL(state, opts...)
-}
-
-// ensureContextTimeout delegates to [providers.EnsureTimeout].
-func (p *Provider) ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	return providers.EnsureTimeout(ctx, p.requestTimeout)
 }
 
 // ExchangeCode exchanges an authorization code for tokens with optional PKCE verification.
 // Returns standard oauth2.Token. See SECURITY_ARCHITECTURE.md for security model details.
 func (p *Provider) ExchangeCode(ctx context.Context, code string, verifier string) (*oauth2.Token, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	return providers.ExchangeCodeWithPKCE(ctx, p, p.httpClient, code, verifier)
@@ -181,7 +170,7 @@ func (p *Provider) ExchangeCode(ctx context.Context, code string, verifier strin
 
 // ValidateToken validates an access token by calling Google's userinfo endpoint
 func (p *Provider) ValidateToken(ctx context.Context, accessToken string) (*providers.UserInfo, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	// Create HTTP client with the token using oauth2.Config.Client
@@ -241,7 +230,7 @@ func (p *Provider) ValidateToken(ctx context.Context, accessToken string) (*prov
 // RefreshToken refreshes an expired token
 // Returns standard oauth2.Token directly
 func (p *Provider) RefreshToken(ctx context.Context, refreshToken string) (*oauth2.Token, error) {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	// Use custom HTTP client
@@ -267,7 +256,7 @@ func (p *Provider) RefreshToken(ctx context.Context, refreshToken string) (*oaut
 // public clients to call /revoke without credentials), so no Basic-Auth is
 // sent.
 func (p *Provider) RevokeToken(ctx context.Context, token string) error {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 	return oidc.RevokeAtEndpoint(ctx, p.httpClient, "https://oauth2.googleapis.com/revoke", token, "", "")
 }
@@ -298,7 +287,7 @@ func (p *Provider) RevokeToken(ctx context.Context, token string) error {
 //	    return
 //	}
 func (p *Provider) HealthCheck(ctx context.Context) error {
-	ctx, cancel := p.ensureContextTimeout(ctx)
+	ctx, cancel := providers.EnsureTimeout(ctx, p.requestTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", "https://accounts.google.com/.well-known/openid-configuration", nil)

--- a/providers/google/google.go
+++ b/providers/google/google.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	"golang.org/x/oauth2/google"
 
 	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
 
 // Provider implements the providers.Provider interface for Google OAuth.
@@ -99,15 +99,10 @@ func (p *Provider) Name() string {
 	return "google"
 }
 
-// DefaultScopes returns the provider's configured default scopes.
-// Returns a deep copy to prevent external modification.
+// DefaultScopes returns a deep copy of the provider's configured default
+// scopes so callers cannot mutate the provider's slice.
 func (p *Provider) DefaultScopes() []string {
-	if p.Scopes == nil {
-		return nil
-	}
-	scopes := make([]string, len(p.Scopes))
-	copy(scopes, p.Scopes)
-	return scopes
+	return providers.CloneScopes(p.Scopes)
 }
 
 // isGoogleSupportedScope returns true if the scope is recognized by Google's OAuth endpoints.
@@ -128,19 +123,11 @@ func isGoogleSupportedScope(scope string) bool {
 	}
 }
 
-// filterGoogleScopes creates a deep copy of scopes and filters out any scopes that
-// Google does not support. This prevents authorization failures when clients send
-// provider-specific scopes (e.g., Dex's "groups") or non-standard scopes (e.g., "claudeai")
-// to a Google provider.
+// filterGoogleScopes returns the merged copy of requestedScopes+defaultScopes
+// (mandatory-scope merging via [providers.CopyScopes] is applied inside
+// [providers.FilterScopes]) filtered by [isGoogleSupportedScope].
 func filterGoogleScopes(requestedScopes, defaultScopes []string) []string {
-	sourceScopes := providers.CopyScopes(requestedScopes, defaultScopes)
-	filtered := make([]string, 0, len(sourceScopes))
-	for _, s := range sourceScopes {
-		if isGoogleSupportedScope(s) {
-			filtered = append(filtered, s)
-		}
-	}
-	return filtered
+	return providers.FilterScopes(requestedScopes, defaultScopes, isGoogleSupportedScope)
 }
 
 // AuthorizationURL generates the Google OAuth authorization URL with optional PKCE.
@@ -178,15 +165,9 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	return config.AuthCodeURL(state, opts...)
 }
 
-// ensureContextTimeout ensures the context has a deadline, adding one if needed.
-// Returns a new context with timeout and a cancel function that should be deferred.
-// If the context already has a deadline, returns the original context with a no-op cancel.
+// ensureContextTimeout delegates to [providers.EnsureTimeout].
 func (p *Provider) ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
-	if _, hasDeadline := ctx.Deadline(); hasDeadline {
-		// Context already has deadline, return no-op cancel
-		return ctx, func() {}
-	}
-	return context.WithTimeout(ctx, p.requestTimeout)
+	return providers.EnsureTimeout(ctx, p.requestTimeout)
 }
 
 // ExchangeCode exchanges an authorization code for tokens with optional PKCE verification.
@@ -281,34 +262,14 @@ func (p *Provider) RefreshToken(ctx context.Context, refreshToken string) (*oaut
 	return newToken, nil
 }
 
-// RevokeToken revokes a token at Google's revocation endpoint
+// RevokeToken revokes a token at Google's public revocation endpoint. The
+// endpoint does not require client authentication (RFC 7009 §2.1 allows
+// public clients to call /revoke without credentials), so no Basic-Auth is
+// sent.
 func (p *Provider) RevokeToken(ctx context.Context, token string) error {
 	ctx, cancel := p.ensureContextTimeout(ctx)
 	defer cancel()
-
-	revokeURL := "https://oauth2.googleapis.com/revoke"
-	data := url.Values{}
-	data.Set("token", token)
-
-	req, err := http.NewRequestWithContext(ctx, "POST", revokeURL, strings.NewReader(data.Encode()))
-	if err != nil {
-		return fmt.Errorf("failed to create revoke request: %w", err)
-	}
-
-	// Set content type for form data
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-	resp, err := p.httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to revoke token: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("token revocation failed with status %d", resp.StatusCode)
-	}
-
-	return nil
+	return oidc.RevokeAtEndpoint(ctx, p.httpClient, "https://oauth2.googleapis.com/revoke", token, "", "")
 }
 
 // HealthCheck verifies that Google's OAuth endpoints are reachable.

--- a/providers/google/google_test.go
+++ b/providers/google/google_test.go
@@ -349,89 +349,11 @@ func TestProvider_AuthorizationURL_FiltersOfflineAccess(t *testing.T) {
 	}
 }
 
-// TestFilterGoogleScopes_DropsUnsupportedScopes verifies that filterGoogleScopes
-// drops scopes that Google does not recognize, preventing authorization failures.
-func TestFilterGoogleScopes_DropsUnsupportedScopes(t *testing.T) {
-	defaultScopes := []string{"openid", "email", "profile"}
-
-	tests := []struct {
-		name           string
-		requested      []string
-		wantContain    []string
-		wantNotContain []string
-	}{
-		{
-			name:           "drops Dex-specific groups scope",
-			requested:      []string{"openid", "email", "groups"},
-			wantContain:    []string{"openid", "email"},
-			wantNotContain: []string{"groups"},
-		},
-		{
-			name:           "drops non-standard scopes like claudeai",
-			requested:      []string{"openid", "claudeai"},
-			wantContain:    []string{"openid"},
-			wantNotContain: []string{"claudeai"},
-		},
-		{
-			name:           "keeps Google API scopes",
-			requested:      []string{"openid", "https://www.googleapis.com/auth/gmail.readonly"},
-			wantContain:    []string{"openid", "https://www.googleapis.com/auth/gmail.readonly"},
-			wantNotContain: nil,
-		},
-		{
-			name:           "drops offline_access",
-			requested:      []string{"openid", "offline_access"},
-			wantContain:    []string{"openid"},
-			wantNotContain: []string{"offline_access"},
-		},
-		{
-			name:           "drops multiple unsupported scopes",
-			requested:      []string{"openid", "groups", "claudeai", "offline_access", "custom:scope"},
-			wantContain:    []string{"openid"},
-			wantNotContain: []string{"groups", "claudeai", "offline_access", "custom:scope"},
-		},
-		{
-			name:        "keeps all standard OIDC scopes",
-			requested:   []string{"openid", "email", "profile"},
-			wantContain: []string{"openid", "email", "profile"},
-		},
-		{
-			name:        "uses defaults when requested is nil",
-			requested:   nil,
-			wantContain: []string{"openid", "email", "profile"},
-		},
-		{
-			name:           "injects openid from defaults when missing in requested",
-			requested:      []string{"email", "groups"},
-			wantContain:    []string{"email", "openid"},
-			wantNotContain: []string{"groups"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := filterGoogleScopes(tt.requested, defaultScopes)
-
-			resultSet := make(map[string]bool, len(result))
-			for _, s := range result {
-				resultSet[s] = true
-			}
-
-			for _, want := range tt.wantContain {
-				if !resultSet[want] {
-					t.Errorf("filterGoogleScopes() should contain %q, got %v", want, result)
-				}
-			}
-			for _, notWant := range tt.wantNotContain {
-				if resultSet[notWant] {
-					t.Errorf("filterGoogleScopes() should NOT contain %q, got %v", notWant, result)
-				}
-			}
-		})
-	}
-}
-
-// TestIsGoogleSupportedScope tests the scope classification function.
+// TestIsGoogleSupportedScope pins the Google-specific scope predicate:
+// standard OIDC scopes and the Google API URL prefix are accepted; Dex
+// scopes, offline_access, and arbitrary custom scopes are dropped. The
+// generic CopyScopes / FilterScopes machinery this predicate plugs into
+// is covered in providers/helpers_test.go.
 func TestIsGoogleSupportedScope(t *testing.T) {
 	tests := []struct {
 		scope    string

--- a/providers/helpers.go
+++ b/providers/helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"golang.org/x/oauth2"
 )
@@ -140,6 +141,49 @@ func CopyScopes(requestedScopes, defaultScopes []string) []string {
 	}
 
 	return result
+}
+
+// EnsureTimeout returns ctx unchanged when it already has a deadline; otherwise
+// it returns context.WithTimeout(ctx, timeout). The cancel func is always
+// non-nil and safe to defer.
+func EnsureTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if _, hasDeadline := ctx.Deadline(); hasDeadline {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+// CloneScopes returns an independent copy of scopes (nil-safe). Used by every
+// provider's DefaultScopes() so callers cannot mutate the provider's slice.
+func CloneScopes(scopes []string) []string {
+	if scopes == nil {
+		return nil
+	}
+	out := make([]string, len(scopes))
+	copy(out, scopes)
+	return out
+}
+
+// FilterScopes applies the provider-specific `supported` predicate to the
+// merged copy that CopyScopes produces from requestedScopes+defaultScopes.
+// Mandatory-scope merging (openid, email, etc.) happens inside CopyScopes;
+// FilterScopes is the IdP-specific overlay that drops scopes the upstream
+// would reject (e.g. Google does not accept Dex audience scopes, and vice
+// versa).
+//
+// A nil predicate is treated as "accept everything".
+func FilterScopes(requestedScopes, defaultScopes []string, supported func(string) bool) []string {
+	merged := CopyScopes(requestedScopes, defaultScopes)
+	if supported == nil {
+		return merged
+	}
+	filtered := make([]string, 0, len(merged))
+	for _, s := range merged {
+		if supported(s) {
+			filtered = append(filtered, s)
+		}
+	}
+	return filtered
 }
 
 // ExchangeCodeWithPKCE is a shared helper for exchanging authorization codes with optional PKCE.

--- a/providers/helpers_test.go
+++ b/providers/helpers_test.go
@@ -1,0 +1,72 @@
+package providers
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureTimeout_AddsDeadlineWhenAbsent(t *testing.T) {
+	ctx, cancel := EnsureTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	deadline, ok := ctx.Deadline()
+	require.True(t, ok, "EnsureTimeout must add a deadline when none exists")
+	require.WithinDuration(t, time.Now().Add(50*time.Millisecond), deadline, 5*time.Millisecond)
+}
+
+func TestEnsureTimeout_RespectsExistingDeadline(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+	ctx, noop := EnsureTimeout(parent, time.Hour)
+	defer noop()
+	require.Equal(t, parent, ctx, "EnsureTimeout must return the parent context when it has a deadline")
+}
+
+func TestCloneScopes(t *testing.T) {
+	orig := []string{"openid", "email"}
+	clone := CloneScopes(orig)
+	require.Equal(t, orig, clone)
+	clone[0] = "mutated"
+	require.NotEqual(t, orig[0], clone[0], "callers must not be able to mutate the source slice")
+
+	require.Nil(t, CloneScopes(nil))
+	require.Equal(t, []string{}, CloneScopes([]string{}))
+}
+
+func TestFilterScopes(t *testing.T) {
+	defaults := []string{"openid", "email", "groups"}
+
+	tests := []struct {
+		name      string
+		requested []string
+		supported func(string) bool
+		want      []string
+	}{
+		{
+			name:      "nil predicate accepts every scope",
+			requested: []string{"openid", "custom"},
+			supported: nil,
+			want:      []string{"openid", "custom", "email", "groups"},
+		},
+		{
+			name:      "predicate drops unsupported scopes after the mandatory-merge",
+			requested: []string{"claudeai"},
+			supported: func(s string) bool { return !strings.HasPrefix(s, "claude") },
+			want:      []string{"openid", "email", "groups"},
+		},
+		{
+			name:      "empty requested falls back to defaults filtered",
+			requested: nil,
+			supported: func(s string) bool { return s != "groups" },
+			want:      []string{"openid", "email"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, FilterScopes(tt.requested, defaults, tt.supported))
+		})
+	}
+}

--- a/providers/oidc/revoke.go
+++ b/providers/oidc/revoke.go
@@ -1,0 +1,49 @@
+package oidc
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// RevokeAtEndpoint posts an RFC 7009 token revocation to endpoint. When
+// clientID is non-empty the request authenticates via HTTP Basic
+// (client_secret_basic); endpoints that do not require client authentication
+// (e.g. Google's public revocation endpoint) leave clientID/clientSecret
+// empty and skip the header.
+//
+// Per RFC 7009 §2.2 the server SHOULD respond 200 even for an unknown token,
+// so anything other than 200 surfaces as an error to the caller.
+func RevokeAtEndpoint(ctx context.Context, httpClient *http.Client, endpoint, token, clientID, clientSecret string) error {
+	if endpoint == "" {
+		return fmt.Errorf("revocation endpoint is empty")
+	}
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	form := url.Values{}
+	form.Set("token", token)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return fmt.Errorf("failed to create revoke request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if clientID != "" {
+		req.SetBasicAuth(clientID, clientSecret)
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to revoke token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("token revocation failed with status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/providers/oidc/revoke_test.go
+++ b/providers/oidc/revoke_test.go
@@ -1,0 +1,62 @@
+package oidc
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevokeAtEndpoint_PostsTokenAndBasicAuth(t *testing.T) {
+	var (
+		gotToken  string
+		gotUser   string
+		gotPass   string
+		gotMethod string
+		gotCT     string
+		hasAuth   bool
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotCT = r.Header.Get("Content-Type")
+		gotUser, gotPass, hasAuth = r.BasicAuth()
+		require.NoError(t, r.ParseForm())
+		gotToken = r.Form.Get("token")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	require.NoError(t, RevokeAtEndpoint(context.Background(), server.Client(), server.URL, "tok-abc", "client-1", "secret"))
+	require.Equal(t, http.MethodPost, gotMethod)
+	require.Equal(t, "application/x-www-form-urlencoded", gotCT)
+	require.Equal(t, "tok-abc", gotToken)
+	require.True(t, hasAuth, "Basic auth must be sent when clientID is non-empty")
+	require.Equal(t, "client-1", gotUser)
+	require.Equal(t, "secret", gotPass)
+}
+
+func TestRevokeAtEndpoint_SkipsBasicAuthForPublicEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _, hasAuth := r.BasicAuth()
+		require.False(t, hasAuth, "Basic auth must be omitted when clientID is empty")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	require.NoError(t, RevokeAtEndpoint(context.Background(), server.Client(), server.URL, "tok", "", ""))
+}
+
+func TestRevokeAtEndpoint_ErrorsOnNon200(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	err := RevokeAtEndpoint(context.Background(), server.Client(), server.URL, "tok", "", "")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "status 500")
+}
+
+func TestRevokeAtEndpoint_RejectsEmptyEndpoint(t *testing.T) {
+	require.Error(t, RevokeAtEndpoint(context.Background(), nil, "", "tok", "", ""))
+}

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -482,65 +483,38 @@ func validateStringLength(value string, maxLen int, fieldName string) error {
 // Key Helpers
 // ============================================================
 
-// tokenKey returns the key for a user's token: {prefix}:token:{userID}
-func (s *Store) tokenKey(userID string) string {
-	return fmt.Sprintf("%stoken:%s", s.prefix, userID)
+// keyOf returns "{prefix}{namespace}:{parts...}" — the schema every per-row
+// key helper in this file produces. Centralising the shape stops drift
+// (e.g. one helper omitting the trailing colon) and makes the namespace
+// taxonomy auditable at a glance.
+func (s *Store) keyOf(namespace string, parts ...string) string {
+	var b strings.Builder
+	b.Grow(len(s.prefix) + len(namespace) + 1 + len(parts)*16)
+	b.WriteString(s.prefix)
+	b.WriteString(namespace)
+	for _, p := range parts {
+		b.WriteByte(':')
+		b.WriteString(p)
+	}
+	return b.String()
 }
 
-// userInfoKey returns the key for user info: {prefix}:userinfo:{userID}
-func (s *Store) userInfoKey(userID string) string {
-	return fmt.Sprintf("%suserinfo:%s", s.prefix, userID)
-}
-
-// refreshTokenKey returns the key for a refresh token: {prefix}:refresh:{token}
-func (s *Store) refreshTokenKey(token string) string {
-	return fmt.Sprintf("%srefresh:%s", s.prefix, token)
-}
-
-// refreshTokenMetaKey returns the key for refresh token metadata: {prefix}:refresh:meta:{token}
+func (s *Store) tokenKey(userID string) string       { return s.keyOf("token", userID) }
+func (s *Store) userInfoKey(userID string) string    { return s.keyOf("userinfo", userID) }
+func (s *Store) refreshTokenKey(token string) string { return s.keyOf("refresh", token) }
 func (s *Store) refreshTokenMetaKey(token string) string {
-	return fmt.Sprintf("%srefresh:meta:%s", s.prefix, token)
+	return s.keyOf("refresh", "meta", token)
 }
-
-// clientKey returns the key for a client: {prefix}:client:{clientID}
-func (s *Store) clientKey(clientID string) string {
-	return fmt.Sprintf("%sclient:%s", s.prefix, clientID)
-}
-
-// clientIPKey returns the key for client IP tracking: {prefix}:client:ip:{ip}
-func (s *Store) clientIPKey(ip string) string {
-	return fmt.Sprintf("%sclient:ip:%s", s.prefix, ip)
-}
-
-// stateKey returns the key for an authorization state: {prefix}:state:{stateID}
-func (s *Store) stateKey(stateID string) string {
-	return fmt.Sprintf("%sstate:%s", s.prefix, stateID)
-}
-
-// providerStateKey returns the key for provider state lookup: {prefix}:state:provider:{state}
-func (s *Store) providerStateKey(state string) string {
-	return fmt.Sprintf("%sstate:provider:%s", s.prefix, state)
-}
-
-// codeKey returns the key for an authorization code: {prefix}:code:{code}
-func (s *Store) codeKey(code string) string {
-	return fmt.Sprintf("%scode:%s", s.prefix, code)
-}
-
-// tokenMetaKey returns the key for token metadata: {prefix}:meta:{tokenID}
-func (s *Store) tokenMetaKey(tokenID string) string {
-	return fmt.Sprintf("%smeta:%s", s.prefix, tokenID)
-}
-
-// userClientKey returns the key for user+client token tracking: {prefix}:userclient:{userID}:{clientID}
+func (s *Store) clientKey(clientID string) string     { return s.keyOf("client", clientID) }
+func (s *Store) clientIPKey(ip string) string         { return s.keyOf("client", "ip", ip) }
+func (s *Store) stateKey(stateID string) string       { return s.keyOf("state", stateID) }
+func (s *Store) providerStateKey(state string) string { return s.keyOf("state", "provider", state) }
+func (s *Store) codeKey(code string) string           { return s.keyOf("code", code) }
+func (s *Store) tokenMetaKey(tokenID string) string   { return s.keyOf("meta", tokenID) }
 func (s *Store) userClientKey(userID, clientID string) string {
-	return fmt.Sprintf("%suserclient:%s:%s", s.prefix, userID, clientID)
+	return s.keyOf("userclient", userID, clientID)
 }
-
-// familyKey returns the key for a token family: {prefix}:family:{familyID}
-func (s *Store) familyKey(familyID string) string {
-	return fmt.Sprintf("%sfamily:%s", s.prefix, familyID)
-}
+func (s *Store) familyKey(familyID string) string { return s.keyOf("family", familyID) }
 
 // ============================================================
 // Lua Scripts for Atomic Operations


### PR DESCRIPTION
Closes (partial) #310. Stacked on #324 (#309).

## Scope this PR — the small, surface-area-safe items

| Item | Net LOC | Status |
|---|---:|---|
| \`providers.EnsureTimeout\` extraction (replaces 3 duplicates) | -27 | ✓ |
| \`providers.CloneScopes\` extraction (replaces 3 \`make+copy\` blocks) | -18 | ✓ |
| \`providers.FilterScopes\` extraction (replaces 2 filter loops) | -20 | ✓ |
| \`providers/oidc.RevokeAtEndpoint\` extraction (dex+google) | -60 | ✓ |
| \`storage/valkey.Store.keyOf(namespace, parts...)\` (12 helpers collapse) | -38 | ✓ |
| Tests for the new helpers | +99 | ✓ |

Net change: **-76 LOC** across production code, +99 LOC tests.

## Deferred

| Item | Why |
|---|---|
| Always-non-nil \`Auditor\` mirroring the existing \`Instrumentation\` pattern | Touches 47+ call sites; high blast radius. Own PR. |
| \`failRequest(w, span, endpoint, method, status, code, desc, startTime)\` helper across 80+ handler.go sites | The single biggest LOC-reducer in #310 and the highest blast radius. Own PR. |
| \`writeOAuthError\` consolidation of \`writeError\` / \`writeUnauthorizedError\` / \`writeInsufficientScopeError\` | Same reasoning — coordinates with the failRequest extraction. |
| Drop the X + DisableX positive flags, drop \`OAuthError\`/\`NewOAuthError\` aliases, drop \`IssuerOf\` wrapper | Breaking API removal — own PR with explicit migration notes. |
| Residual \`Instrumentation != nil\` cleanups | Trivial follow-up, depends on Auditor change. |
| Six trivial \`recordX\` metric wrappers | Coordinate with #300. |

## Schema preservation

\`storage/valkey.Store.keyOf\` produces byte-identical output to the previous \`fmt.Sprintf\` helpers. No data migration required.

## Tests added

- \`providers/helpers_test.go\`: \`EnsureTimeout\` (deadline preserved vs. added), \`CloneScopes\` (nil + mutation independence), \`FilterScopes\` (nil predicate, drop-after-merge, defaults fallback).
- \`providers/oidc/revoke_test.go\`: Basic-Auth presence/absence keyed on \`clientID\`, non-200 → error, empty-endpoint guard.