### PR TITLE
fix(handler,obs): rate-limit /oauth/callback + pin /authorize observability outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- **`/authorize` observability is pinned**: span attributes (`oauth.error`, `oauth.error_description`), span error reason, and the `auth_failure` audit event (with `reason=invalid_client` / `invalid_redirect_uri`, `clientID` populated, `userID` empty) are now asserted on every `respondAuthorizationError` and `ValidateRedirectURIForAuthorization` failure branch. Closes #330.
 - **Fuzz coverage** for four parsing / validation primitives: `ParseCallbackQuery` (types.go), `providers/oidc.ValidateExternalURL`, `Server.computePKCEChallenge` (S256 method), and `server.validateCodeVerifierFormat`. Seed corpora committed; each is panic-clean against a 2s exploratory burst. Closes (partial) #311.
 - **Coverage gaps closed** for `Handler.handleRegistrationError` (HTTP-error mapping for the registration-limit vs generic branches) and `Server.handleRefreshTokenError` (classification of not-found / expired / transient errors).
 - **AEAD authentication regression test** in `security/encryption_test.go` — a single-bit flip of the ciphertext tag must fail `Decrypt`. Catches a regression where AES-GCM gets swapped for a non-authenticated mode.
 
+### Fixed
+
+- **`/authorize` "invalid authorization URL" branch now records `oauth.error=server_error` on its span.** Previously the handler called `instrumentation.SetSpanSuccess` before the URL parse / scheme check, so the later `SetSpanError` on the invalid-URL fallback was a no-op (OTel's `SetStatus` is monotonic, `Ok` outranks `Error`). Surfaced by the new observability tests for #330.
+
 ### Security
 
+- **`/oauth/callback` is now gated by the IP rate limiter** alongside `/authorize`, `/token`, `/revoke`, `/introspect`. The gap left by #302 left an unauthenticated brute-force surface against the provider-state value space (CWE-307). Rejects emit `oauth_http_requests_total{endpoint="callback",status="429"}`, `oauth_rate_limit_exceeded_total{limiter_type="ip"}`, and a `rate_limit_exceeded` audit record. Closes #339.
 - **Token-at-rest ciphertext envelope is now versioned (`0x01 ‖ kid ‖ nonce ‖ ct`)** — sets up future key rotation by tagging every new write with a 1-byte `kid`. Decrypt accepts both v1 and the legacy v0 (`nonce ‖ ct`) layout, falling through on AEAD-verification failure so the ~1/256 of v0 rows whose first nonce byte coincides with the v1 tag still decode. Rolling upgrades across a multi-replica fleet require updating every replica before allowing v1 writes — old replicas cannot read v1. Memory-only deployments are unaffected. Closes (partial) #309.
 - **`security.KeyRing` interface** seam under `security.Encryptor`. The built-in single-key implementation produces and consumes the v1 envelope; consumers wiring external KMS / multi-key rotation supply their own `KeyRing`. Public API of `*Encryptor` is unchanged.
 - **`security.WithPIIRedaction(bool)` option on `security.NewAuditor`** — when enabled, audit records emit `client_id_hash`, `ip_address_hash`, and `user_agent_hash` (truncated SHA-256) instead of the cleartext fields. `user_id_hash` is unchanged. Default off — existing slog sinks continue to receive cleartext. CWE-532.

--- a/handler/authorize.go
+++ b/handler/authorize.go
@@ -432,12 +432,12 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	// Record authorization started metric
 	h.recordAuthorizationStarted(r.Context(), clientID)
 
-	h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusFound, startTime)
-	instrumentation.SetSpanSuccess(span)
-
 	// Parse and validate scheme before redirecting. authURL is built by the
 	// configured provider's AuthorizationURL(); the parse + scheme check is
 	// defense in depth against a misconfigured provider returning a non-HTTP URL.
+	// SetSpanSuccess is deferred until past this check — OTel SetStatus is
+	// monotonic (Ok > Error), so marking success early would silently swallow
+	// the SetSpanError call inside respondAuthorizationError below.
 	parsedAuthURL, err := url.Parse(authURL)
 	if err != nil || (parsedAuthURL.Scheme != "https" && parsedAuthURL.Scheme != "http") {
 		h.logger.Error("Provider returned invalid authorization URL", "error", err)
@@ -450,6 +450,9 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
+
+	h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusFound, startTime)
+	instrumentation.SetSpanSuccess(span)
 	// #nosec G710 -- authURL is built by the configured provider's
 	// AuthorizationURL() (server-controlled host) and re-validated above to be
 	// http/https. Not user-controllable; not an open redirect.
@@ -471,6 +474,10 @@ func (h *Handler) ServeCallback(w http.ResponseWriter, r *http.Request) {
 
 	// Set CORS headers for browser-based clients
 	h.setCORSHeaders(w, r)
+
+	if _, ok := h.gateIPRateLimit(w, r, span, endpointCallback, http.MethodGet, startTime); !ok {
+		return
+	}
 
 	// Parse callback parameters
 	state := r.URL.Query().Get("state")

--- a/handler/handler_authorize_observability_test.go
+++ b/handler/handler_authorize_observability_test.go
@@ -1,0 +1,396 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/codes"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	oauth "github.com/giantswarm/mcp-oauth"
+	"github.com/giantswarm/mcp-oauth/instrumentation"
+	"github.com/giantswarm/mcp-oauth/internal/testutil"
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/server"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// observabilityEnv bundles the capture surfaces tests assert against:
+// span attributes/status via a tracetest.SpanRecorder, and audit-event JSON
+// records via a slog handler writing to auditBuf.
+type observabilityEnv struct {
+	handler  *Handler
+	provider *mock.Provider
+	recorder *tracetest.SpanRecorder
+	auditBuf *bytes.Buffer
+}
+
+func newObservabilityEnv(t *testing.T) *observabilityEnv {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(store.Stop)
+
+	provider := mock.NewProvider()
+
+	auditBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(auditBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	auditor := security.NewAuditor(logger, true)
+
+	// Propagate a no-op Instrumentation into storage so its startStorageSpan
+	// uses the noop tracer instead of falling back to trace.SpanFromContext —
+	// the latter would let storage's defer span.End() end the handler's
+	// parent span and erase the attributes the test pins.
+	inst, err := instrumentation.New(instrumentation.Config{Enabled: false})
+	require.NoError(t, err)
+
+	srv, err := server.New(
+		provider, store, store, store,
+		&server.Config{Issuer: testIssuer, DisableNonceEchoRequirement: true},
+		logger,
+		server.WithAuditor(auditor),
+		server.WithInstrumentation(inst),
+	)
+	require.NoError(t, err)
+
+	handler := New(srv, logger)
+
+	recorder := tracetest.NewSpanRecorder()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	handler.tracer = tp.Tracer("http")
+
+	return &observabilityEnv{
+		handler:  handler,
+		provider: provider,
+		recorder: recorder,
+		auditBuf: auditBuf,
+	}
+}
+
+// soleEndedSpan returns the single span finished during the call. Fails the
+// test when zero or multiple spans were emitted so drift in span boundaries
+// surfaces in the same assertion path that pins the attributes.
+func (e *observabilityEnv) soleEndedSpan(t *testing.T) sdktrace.ReadOnlySpan {
+	t.Helper()
+	spans := e.recorder.Ended()
+	require.Lenf(t, spans, 1, "expected exactly 1 ended span, got %d", len(spans))
+	return spans[0]
+}
+
+func spanAttr(t *testing.T, span sdktrace.ReadOnlySpan, key string) (string, bool) {
+	t.Helper()
+	for _, a := range span.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+// requireSpanError asserts span.Status() is codes.Error with the given
+// description, plus oauth.error == errorCode and a non-empty
+// oauth.error_description.
+func requireSpanError(t *testing.T, span sdktrace.ReadOnlySpan, wantStatusDesc, wantErrorCode string) {
+	t.Helper()
+	require.Equal(t, codes.Error, span.Status().Code, "span status code")
+	require.Equal(t, wantStatusDesc, span.Status().Description, "span status description")
+
+	gotCode, ok := spanAttr(t, span, "oauth.error")
+	require.True(t, ok, "oauth.error attribute missing")
+	require.Equal(t, wantErrorCode, gotCode)
+
+	gotDesc, ok := spanAttr(t, span, "oauth.error_description")
+	require.True(t, ok, "oauth.error_description attribute missing")
+	require.NotEmpty(t, gotDesc, "oauth.error_description must be non-empty")
+}
+
+// auditRecord is the shape security.Auditor.LogEvent emits via slog: each
+// audit field lives under the "audit" group.
+type auditRecord struct {
+	Audit struct {
+		EventType  string `json:"event_type"`
+		UserIDHash string `json:"user_id_hash"`
+		ClientID   string `json:"client_id"`
+		IPAddress  string `json:"ip_address"`
+		Details    struct {
+			Reason string `json:"reason"`
+		} `json:"details"`
+	} `json:"audit"`
+}
+
+// requireAuthFailureAudit asserts an EventAuthFailure record with the given
+// reason, populated clientID, and an empty userID (no user context at the
+// /authorize gate). security.hashForLogging("") returns the sentinel
+// "<empty>", which is what the userID hash field will contain when no user
+// context is known.
+const emptyUserIDHashSentinel = "<empty>"
+
+func requireAuthFailureAudit(t *testing.T, buf *bytes.Buffer, wantClientID, wantReason string) {
+	t.Helper()
+
+	for _, line := range bytes.Split(bytes.TrimRight(buf.Bytes(), "\n"), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var rec auditRecord
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Audit.EventType != security.EventAuthFailure {
+			continue
+		}
+		if rec.Audit.Details.Reason != wantReason {
+			continue
+		}
+		require.Equal(t, wantClientID, rec.Audit.ClientID, "audit clientID")
+		require.Equal(t, emptyUserIDHashSentinel, rec.Audit.UserIDHash, "userID must be empty at /authorize gate")
+		return
+	}
+	t.Fatalf("no auth_failure audit with reason=%q found in:\n%s", wantReason, buf.String())
+}
+
+// TestHandler_ServeAuthorization_StateMissing_Observability pins the span
+// attributes + status for the state-missing redirect branch.
+func TestHandler_ServeAuthorization_StateMissing_Observability(t *testing.T) {
+	env := newObservabilityEnv(t)
+
+	client, _, err := env.handler.server.RegisterClient(
+		context.Background(),
+		"obs-client", "confidential", "",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.0.2.1", 10,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"https://example.com/callback"},
+		"response_type":         {"code"},
+		"scope":                 {"openid"},
+		"code_challenge":        {"test-challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+
+	w := httptest.NewRecorder()
+	env.handler.ServeAuthorization(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	requireSpanError(t, env.soleEndedSpan(t), "state missing", oauth.ErrorCodeInvalidRequest)
+}
+
+func TestHandler_ServeAuthorization_StateTooShort_Observability(t *testing.T) {
+	env := newObservabilityEnv(t)
+
+	client, _, err := env.handler.server.RegisterClient(
+		context.Background(),
+		"obs-client", "confidential", "",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.0.2.1", 10,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"https://example.com/callback"},
+		"response_type":         {"code"},
+		"scope":                 {"openid"},
+		"state":                 {"short"},
+		"code_challenge":        {"test-challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+
+	w := httptest.NewRecorder()
+	env.handler.ServeAuthorization(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	requireSpanError(t, env.soleEndedSpan(t), "state too short", oauth.ErrorCodeInvalidRequest)
+}
+
+func TestHandler_ServeAuthorization_UnsupportedResponseType_Observability(t *testing.T) {
+	env := newObservabilityEnv(t)
+
+	client, _, err := env.handler.server.RegisterClient(
+		context.Background(),
+		"obs-client", "confidential", "",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.0.2.1", 10,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"https://example.com/callback"},
+		"response_type":         {"token"},
+		"scope":                 {"openid"},
+		"state":                 {testutil.GenerateRandomString(43)},
+		"code_challenge":        {"test-challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+
+	w := httptest.NewRecorder()
+	env.handler.ServeAuthorization(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	requireSpanError(t, env.soleEndedSpan(t), "unsupported response_type", oauth.ErrorCodeUnsupportedResponseType)
+}
+
+// TestHandler_ServeAuthorization_InvalidProviderURL_Observability triggers
+// the "invalid authorization URL" branch of respondAuthorizationError via a
+// mock provider returning a non-http(s) URL, and pins the resulting span
+// shape.
+func TestHandler_ServeAuthorization_InvalidProviderURL_Observability(t *testing.T) {
+	env := newObservabilityEnv(t)
+
+	env.provider.AuthorizationURLFunc = func(state, codeChallenge, codeChallengeMethod string, _ []string, _ *providers.AuthorizationURLOptions) string {
+		return "javascript:alert(1)"
+	}
+
+	client, _, err := env.handler.server.RegisterClient(
+		context.Background(),
+		"obs-client", "confidential", "",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.0.2.1", 10,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"https://example.com/callback"},
+		"response_type":         {"code"},
+		"scope":                 {"openid"},
+		"state":                 {testutil.GenerateRandomString(43)},
+		"code_challenge":        {"test-challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+
+	w := httptest.NewRecorder()
+	env.handler.ServeAuthorization(w, req)
+
+	require.Equal(t, http.StatusFound, w.Code)
+	requireSpanError(t, env.soleEndedSpan(t), "invalid authorization URL", oauth.ErrorCodeServerError)
+}
+
+// TestHandler_ServeAuthorization_InvalidClient_AuditEvent pins the audit
+// emission on the ValidateRedirectURIForAuthorization failure: an unknown
+// client must yield an auth_failure record with reason=invalid_client,
+// clientID populated, userID empty.
+func TestHandler_ServeAuthorization_InvalidClient_AuditEvent(t *testing.T) {
+	env := newObservabilityEnv(t)
+
+	const unknownClientID = "client-does-not-exist"
+	req := httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+		"client_id":             {unknownClientID},
+		"redirect_uri":          {"https://example.com/callback"},
+		"response_type":         {"code"},
+		"scope":                 {"openid"},
+		"state":                 {testutil.GenerateRandomString(43)},
+		"code_challenge":        {"test-challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+
+	w := httptest.NewRecorder()
+	env.handler.ServeAuthorization(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code, "unknown client must JSON-error (no redirect target)")
+	requireAuthFailureAudit(t, env.auditBuf, unknownClientID, oauth.ErrorCodeInvalidClient)
+}
+
+// TestHandler_ServeAuthorization_InvalidRedirectURI_AuditEvent pins the
+// audit emission on a known client with an unregistered redirect_uri.
+func TestHandler_ServeAuthorization_InvalidRedirectURI_AuditEvent(t *testing.T) {
+	env := newObservabilityEnv(t)
+
+	client, _, err := env.handler.server.RegisterClient(
+		context.Background(),
+		"obs-client", "confidential", "",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"192.0.2.1", 10,
+	)
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodGet, "/authorize?"+url.Values{
+		"client_id":             {client.ClientID},
+		"redirect_uri":          {"https://attacker.example/landing"},
+		"response_type":         {"code"},
+		"scope":                 {"openid"},
+		"state":                 {testutil.GenerateRandomString(43)},
+		"code_challenge":        {"test-challenge"},
+		"code_challenge_method": {"S256"},
+	}.Encode(), nil)
+
+	w := httptest.NewRecorder()
+	env.handler.ServeAuthorization(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+	require.Empty(t, w.Header().Get("Location"), "unregistered redirect_uri must not redirect")
+	requireAuthFailureAudit(t, env.auditBuf, client.ClientID, oauth.ErrorCodeInvalidRedirectURI)
+}
+
+// TestHandler_ServeCallback_IPRateLimit_AuditEmitted pins the audit-event
+// side-effect of the new /oauth/callback gate (issue #339). The 429 path
+// itself is covered by the table-driven test; this test proves the audit
+// surface a downstream SIEM dashboard relies on still fires for the new
+// endpoint.
+func TestHandler_ServeCallback_IPRateLimit_AuditEmitted(t *testing.T) {
+	store := memory.New()
+	t.Cleanup(store.Stop)
+
+	auditBuf := &bytes.Buffer{}
+	logger := slog.New(slog.NewJSONHandler(auditBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	auditor := security.NewAuditor(logger, true)
+
+	srv, err := server.New(
+		mock.NewProvider(), store, store, store,
+		&server.Config{Issuer: testIssuer},
+		logger,
+		server.WithAuditor(auditor),
+	)
+	require.NoError(t, err)
+
+	srv.RateLimiter = security.NewRateLimiter(0, 1, nil) // 1 token, no refill
+	t.Cleanup(srv.RateLimiter.Stop)
+
+	handler := New(srv, logger)
+
+	send := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state="+testStateMinLen+"&code=x", nil)
+		req.RemoteAddr = testClientRemoteAddr
+		w := httptest.NewRecorder()
+		handler.ServeCallback(w, req)
+		return w
+	}
+
+	send() // consume the single bucket token
+	w := send()
+
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+	require.NotEmpty(t, w.Header().Get("Retry-After"), "Retry-After header missing on 429")
+
+	var found bool
+	for _, line := range bytes.Split(bytes.TrimRight(auditBuf.Bytes(), "\n"), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		if strings.Contains(string(line), `"event_type":"`+security.EventRateLimitExceeded+`"`) {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected %s audit event for /oauth/callback rate-limit reject; got:\n%s", security.EventRateLimitExceeded, auditBuf.String())
+}

--- a/handler/handler_ratelimit_test.go
+++ b/handler/handler_ratelimit_test.go
@@ -60,7 +60,7 @@ type endpointCase struct {
 }
 
 // oauthEndpointCases returns one case per CWE-307 endpoint:
-// /authorize, /token, /revoke, /introspect.
+// /authorize, /callback, /token, /revoke, /introspect.
 func oauthEndpointCases() []endpointCase {
 	return []endpointCase{
 		{
@@ -71,6 +71,15 @@ func oauthEndpointCases() []endpointCase {
 				return req
 			},
 			serve: func(h *Handler, w http.ResponseWriter, r *http.Request) { h.ServeAuthorization(w, r) },
+		},
+		{
+			name: "ServeCallback",
+			request: func(remoteAddr string) *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/oauth/callback?state="+testStateMinLen+"&code=x", nil)
+				req.RemoteAddr = remoteAddr
+				return req
+			},
+			serve: func(h *Handler, w http.ResponseWriter, r *http.Request) { h.ServeCallback(w, r) },
 		},
 		{
 			name: "ServeToken",


### PR DESCRIPTION
## Summary

- Closes #339 — `/oauth/callback` is now gated by `gateIPRateLimit` at handler entry, matching `/authorize`, `/token`, `/revoke`, `/introspect`. Closes the CWE-307 gap that PR #302 left open (every other request-bearing endpoint guarded its entry; callback did not).
- Closes #330 — pinned span attributes (`oauth.error`, `oauth.error_description`) + span error reason on every `respondAuthorizationError` branch of `/authorize`, and the `auth_failure` audit event (`reason=invalid_client` / `invalid_redirect_uri`, `clientID` populated, `userID` empty) on `ValidateRedirectURIForAuthorization` failures. Tests use a `tracetest.SpanRecorder` for span capture and a slog-backed `*security.Auditor` for audit capture.

## Tests in this PR

- `TestHandler_ServeAuthorization_StateMissing_Observability`
- `TestHandler_ServeAuthorization_StateTooShort_Observability`
- `TestHandler_ServeAuthorization_UnsupportedResponseType_Observability`
- `TestHandler_ServeAuthorization_InvalidProviderURL_Observability`
- `TestHandler_ServeAuthorization_InvalidClient_AuditEvent`
- `TestHandler_ServeAuthorization_InvalidRedirectURI_AuditEvent`
- `TestHandler_ServeCallback_IPRateLimit_AuditEmitted`
- Existing `TestHandler_OAuthEndpoints_IPRateLimit` table extended with a `ServeCallback` case so the burst, per-IP, and no-limiter properties now cover callback alongside the other four endpoints.

## Drive-by fix surfaced by the new tests

The `/authorize` "invalid authorization URL" branch was setting span status to `Ok` (`instrumentation.SetSpanSuccess`) before the URL parse + scheme check, and OTel's `SetStatus` is monotonic (`Ok` outranks `Error`) — so the later `SetSpanError("invalid authorization URL")` on the fallback was silently swallowed. Moved the success marker past the URL validation. This is exactly the silent-drift class #330 was designed to catch.

## Notes

- Test setup wires a noop `*instrumentation.Instrumentation` through `server.WithInstrumentation` so storage's `startStorageSpan` doesn't fall back to `trace.SpanFromContext(ctx)` and let `defer span.End()` end the handler's parent span. (That's a real cross-layer footgun in storage when its tracer is nil but the caller's tracer is recording — flagging it here, not fixing in this PR.)
- CHANGELOG entries added under `### Tests`, `### Fixed`, `### Security`.