### PR TITLE
refactor: StartAuthorizationFlow takes *url.URL (#328)

### DIFF
--- a/handler/authorize.go
+++ b/handler/authorize.go
@@ -414,8 +414,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 		attribute.String(instrumentation.AttrScope, scope),
 	)
 
-	// Start authorization flow with client state (server also validates for defense in depth)
-	authURL, err := h.server.StartAuthorizationFlow(r.Context(), clientID, redirectURI, scope, resource, codeChallenge, codeChallengeMethod, state, authOpts)
+	authURL, err := h.server.StartAuthorizationFlow(r.Context(), clientID, canonicalRedirectURI, scope, resource, codeChallenge, codeChallengeMethod, state, authOpts)
 	if err != nil {
 		h.logger.Error("Failed to start authorization flow", "error", err)
 		instrumentation.RecordError(span, err)

--- a/handler/authorize_test.go
+++ b/handler/authorize_test.go
@@ -680,7 +680,7 @@ func TestHandler_ServeCallback(t *testing.T) {
 	authURL, err := handler.server.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		challenge,
@@ -1499,7 +1499,7 @@ func TestHandler_ServeCallback_CustomURLScheme(t *testing.T) {
 	_, err = handler.server.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"cursor://oauth/callback",
+		mustParseURL(t, "cursor://oauth/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		challenge,
@@ -1613,7 +1613,7 @@ func TestHandler_ServeCallback_HTTPScheme(t *testing.T) {
 	_, err = handler.server.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		challenge,
@@ -1690,7 +1690,7 @@ func TestHandler_ServeCallback_VSCodeScheme(t *testing.T) {
 	_, err = handler.server.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"vscode://example.extension/callback",
+		mustParseURL(t, "vscode://example.extension/callback"),
 		"openid",
 		"",
 		challenge,
@@ -2080,7 +2080,7 @@ func TestHandler_ServeCallback_CustomURLScheme_WithBranding(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"cursor://oauth/callback",
+		mustParseURL(t, "cursor://oauth/callback"),
 		"openid email",
 		"",
 		challenge,

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -310,3 +310,12 @@ func seedOpaqueIntrospectionToken(t *testing.T, store *memory.Store, accessToken
 	}
 	return meta.IssuedAt
 }
+
+func mustParseURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", s, err)
+	}
+	return u
+}

--- a/server/audit_test.go
+++ b/server/audit_test.go
@@ -91,7 +91,7 @@ func TestServer_AuditLoggingClientIDMismatch(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -193,7 +193,7 @@ func TestServer_AuditLoggingRedirectURIMismatch(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -443,7 +443,7 @@ func TestServer_AuditEventAuthorizationCodeReuse(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,

--- a/server/authcode.go
+++ b/server/authcode.go
@@ -242,10 +242,13 @@ func (s *Server) ValidateRedirectURIForAuthorization(ctx context.Context, client
 }
 
 // StartAuthorizationFlow starts a new OAuth authorization flow.
+// redirectURI must be a canonical, registered URI obtained from [ValidateRedirectURIForAuthorization].
+// This function re-runs the registered-URI check as defense-in-depth but the canonical value is what
+// is stored in the authorization state and used as the redirect target.
 // clientState is the state parameter from the client (REQUIRED for CSRF protection).
 // resource is the target resource server identifier per RFC 8707 (optional for backward compatibility).
 // authOpts contains optional OIDC parameters (prompt, login_hint, id_token_hint) for upstream IdP forwarding.
-func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectURI, scope, resource, codeChallenge, codeChallengeMethod, clientState string, authOpts *providers.AuthorizationURLOptions) (string, error) {
+func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID string, redirectURI *url.URL, scope, resource, codeChallenge, codeChallengeMethod, clientState string, authOpts *providers.AuthorizationURLOptions) (string, error) {
 	// CRITICAL SECURITY: Validate state parameter from client for CSRF protection
 	if err := s.validateClientStateParameter(clientState); err != nil {
 		s.logAuthFailure(ctx, "", clientID, "invalid_state_parameter")
@@ -271,17 +274,19 @@ func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectU
 		return "", fmt.Errorf("%s: %w", ErrorCodeInvalidRequest, err)
 	}
 
+	redirectURIStr := redirectURI.String()
+
 	// Validate redirect URI
-	if err := s.validateRedirectURI(client, redirectURI); err != nil {
+	if err := s.validateRedirectURI(client, redirectURIStr); err != nil {
 		s.logAuthFailure(ctx, "", clientID, ErrorCodeInvalidRedirectURI)
 		return "", fmt.Errorf("%s: %w", ErrorCodeInvalidRequest, err)
 	}
 
 	// SECURITY: Authorization-time redirect URI validation (TOCTOU protection)
-	if err := s.ValidateRedirectURIAtAuthorizationTime(ctx, redirectURI); err != nil {
+	if err := s.ValidateRedirectURIAtAuthorizationTime(ctx, redirectURIStr); err != nil {
 		s.logAuthFailure(ctx, "", clientID, "redirect_uri_security_violation")
 		s.Logger.Warn("Redirect URI failed authorization-time security validation",
-			"client_id", clientID, "redirect_uri", sanitizeURIForLogging(redirectURI), "error", err.Error())
+			"client_id", clientID, "redirect_uri", sanitizeURIForLogging(redirectURIStr), "error", err.Error())
 		return "", fmt.Errorf("%s: redirect URI failed security validation", ErrorCodeInvalidRequest)
 	}
 
@@ -309,7 +314,7 @@ func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectU
 
 	effectiveNonce, authOpts := s.resolveAuthorizationNonce(clientID, scope, authOpts)
 
-	s.logAuthorizationFlowStarted(ctx, clientID, redirectURI, scope, codeChallengeMethod, resource, authOpts)
+	s.logAuthorizationFlowStarted(ctx, clientID, redirectURIStr, scope, codeChallengeMethod, resource, authOpts)
 
 	// Save authorization state with both client and server PKCE parameters and resource binding
 	// Use trackingState (which may be server-generated if client didn't provide state)
@@ -317,7 +322,7 @@ func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID, redirectU
 		StateID:              trackingState,
 		OriginalClientState:  clientState, // Empty if client didn't provide state
 		ClientID:             clientID,
-		RedirectURI:          redirectURI,
+		RedirectURI:          redirectURIStr,
 		Scope:                scope,
 		Resource:             resource, // RFC 8707: Bind authorization to target resource server
 		CodeChallenge:        codeChallenge,

--- a/server/authcode_test.go
+++ b/server/authcode_test.go
@@ -130,7 +130,7 @@ func TestServer_StartAuthorizationFlow(t *testing.T) {
 			authURL, err := srv.StartAuthorizationFlow(
 				ctx,
 				tt.clientID,
-				tt.redirectURI,
+				mustParseURL(t, tt.redirectURI),
 				tt.scope,
 				"", // resource parameter (optional)
 				tt.codeChallenge,
@@ -313,7 +313,7 @@ func TestStartAuthorizationFlow_OIDCParameterForwarding(t *testing.T) {
 			authURL, err := srv.StartAuthorizationFlow(
 				ctx,
 				client.ClientID,
-				"https://example.com/callback",
+				mustParseURL(t, "https://example.com/callback"),
 				"openid email",
 				"", // resource parameter
 				validChallenge,
@@ -426,7 +426,7 @@ func TestServer_HandleProviderCallback(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		validChallenge,
@@ -554,7 +554,7 @@ func TestServer_HandleProviderCallback_EmailLookup(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		validChallenge,
@@ -699,7 +699,7 @@ func TestServer_HandleProviderCallback_ShortLivedToken(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		validChallenge,
@@ -1726,7 +1726,7 @@ func TestServer_ConcurrentAuthorizationCodeReuse(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -1844,7 +1844,7 @@ func TestServer_AuthorizationCodeReuseRevokesTokens(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -1991,7 +1991,7 @@ func TestServer_AuthorizationCodeReuseRevokesMultipleTokens(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -2115,7 +2115,7 @@ func TestServer_GenericErrorMessagesNoInfoLeakage(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -2270,7 +2270,7 @@ func TestServer_AuthCodeReuseWithoutSecurityEventRateLimiter(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -2420,7 +2420,7 @@ func TestStartAuthorizationFlow_ClientScopeValidation(t *testing.T) {
 			authURL, err := srv.StartAuthorizationFlow(
 				ctx,
 				client.ClientID,
-				"https://example.com/callback",
+				mustParseURL(t, "https://example.com/callback"),
 				tt.scope,
 				"", // resource parameter (optional)
 				validChallenge,
@@ -2642,7 +2642,7 @@ func TestClientScopeValidation_UnrestrictedClient(t *testing.T) {
 			authURL, err := srv.StartAuthorizationFlow(
 				ctx,
 				client.ClientID,
-				"https://example.com/callback",
+				mustParseURL(t, "https://example.com/callback"),
 				scope,
 				"", // resource parameter (optional)
 				validChallenge,
@@ -2739,7 +2739,7 @@ func TestServer_HandleProviderCallback_PKCEValidationFailure(t *testing.T) {
 	authURL, err := srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		clientChallenge,
@@ -2861,7 +2861,7 @@ func TestStartAuthorizationFlow_ScopeLengthValidation(t *testing.T) {
 			_, err := srv.StartAuthorizationFlow(
 				ctx,
 				client.ClientID,
-				client.RedirectURIs[0],
+				mustParseURL(t, client.RedirectURIs[0]),
 				tt.scope,
 				"", // resource parameter (optional)
 				codeChallenge,
@@ -2961,7 +2961,7 @@ func TestResourceParameter_AudienceValidation(t *testing.T) {
 		_, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid email",
 			"https://mcp.example.com", // Resource matches server's identifier
 			codeChallenge,
@@ -3040,7 +3040,7 @@ func TestResourceParameter_AudienceValidation(t *testing.T) {
 		_, err = srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid email",
 			"https://mcp.example.com", // Resource for first server
 			codeChallenge,
@@ -3100,7 +3100,7 @@ func TestResourceParameter_AudienceValidation(t *testing.T) {
 		_, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid email",
 			"", // No resource parameter (backward compatibility)
 			codeChallenge,
@@ -3217,7 +3217,7 @@ func TestResourceParameter_ConsistencyValidation(t *testing.T) {
 		_, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid email",
 			"https://mcp.example.com", // Resource A
 			codeChallenge,
@@ -3347,7 +3347,7 @@ func TestResourceParameter_InvalidFormat(t *testing.T) {
 			_, err := srv.StartAuthorizationFlow(
 				ctx,
 				client.ClientID,
-				client.RedirectURIs[0],
+				mustParseURL(t, client.RedirectURIs[0]),
 				"openid email",
 				tt.resource,
 				codeChallenge,
@@ -3467,7 +3467,7 @@ func TestResourceParameter_RateLimiting(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		client.RedirectURIs[0],
+		mustParseURL(t, client.RedirectURIs[0]),
 		"openid email",
 		"https://mcp.example.com", // Resource A
 		codeChallenge,
@@ -3539,7 +3539,7 @@ func TestStartAuthorizationFlow_EmptyState(t *testing.T) {
 		authURL, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid",
 			"", // resource
 			validChallenge,
@@ -3561,7 +3561,7 @@ func TestStartAuthorizationFlow_EmptyState(t *testing.T) {
 		_, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid",
 			"",
 			validChallenge,
@@ -3583,7 +3583,7 @@ func TestStartAuthorizationFlow_EmptyState(t *testing.T) {
 		authURL, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid",
 			"",
 			validChallenge,
@@ -3634,7 +3634,7 @@ func TestHandleProviderCallback_EmptyState(t *testing.T) {
 		authURL, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid",
 			"",
 			validChallenge,
@@ -3681,7 +3681,7 @@ func TestHandleProviderCallback_EmptyState(t *testing.T) {
 		authURL, err := srv.StartAuthorizationFlow(
 			ctx,
 			client.ClientID,
-			client.RedirectURIs[0],
+			mustParseURL(t, client.RedirectURIs[0]),
 			"openid",
 			"",
 			validChallenge,
@@ -3923,7 +3923,7 @@ func TestServer_ExchangeAuthorizationCode_FamilyIDInMetadata(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		codeChallenge,
@@ -4031,7 +4031,7 @@ func TestServer_SessionCreationHandler_CalledOnExchange(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		codeChallenge,
@@ -4112,7 +4112,7 @@ func TestServer_SessionCreationHandler_NotCalledWithoutHandler(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		codeChallenge,

--- a/server/flows_test.go
+++ b/server/flows_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
@@ -171,4 +172,13 @@ func TestCapTokenExpiry(t *testing.T) {
 			t.Errorf("expiry = %v, want close to %v (diff: %v)", expiry, expected, diff)
 		}
 	})
+}
+
+func mustParseURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", s, err)
+	}
+	return u
 }

--- a/server/nonce_test.go
+++ b/server/nonce_test.go
@@ -122,7 +122,7 @@ func (f *nonceFlowFixture) startOIDCFlow(t *testing.T) (providerState, expectedN
 	_, err := f.srv.StartAuthorizationFlow(
 		ctx,
 		f.clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		challenge,
@@ -151,7 +151,7 @@ func (f *nonceFlowFixture) startNonOIDCFlow(t *testing.T) string {
 	_, err := f.srv.StartAuthorizationFlow(
 		ctx,
 		f.clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"email",
 		"",
 		challenge,
@@ -300,7 +300,7 @@ func TestNonce_ClientNonceTooShort_ReplacedAndWarned(t *testing.T) {
 	_, err := fix.srv.StartAuthorizationFlow(
 		context.Background(),
 		fix.clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		challenge,
@@ -384,7 +384,7 @@ func TestNonce_ForwardedToProviderURL(t *testing.T) {
 	authURL, err := fix.srv.StartAuthorizationFlow(
 		context.Background(),
 		fix.clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		challenge,
@@ -416,7 +416,7 @@ func TestNonce_ClientSuppliedPassesThrough(t *testing.T) {
 	_, err := fix.srv.StartAuthorizationFlow(
 		context.Background(),
 		fix.clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"",
 		challenge,

--- a/server/refresh_test.go
+++ b/server/refresh_test.go
@@ -54,7 +54,7 @@ func TestServer_RefreshTokenRotation(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -189,7 +189,7 @@ func TestServer_RefreshTokenReuseDetection(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -401,7 +401,7 @@ func TestServer_RefreshTokenReuseMultipleRotations(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -531,7 +531,7 @@ func TestServer_ConcurrentRefreshTokenReuse(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -684,7 +684,7 @@ func TestServer_RefreshTokenReuseWithoutSecurityEventRateLimiter(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,
@@ -1404,7 +1404,7 @@ func TestServer_RefreshAccessToken_FamilyIDInMetadata(t *testing.T) {
 	codeChallenge := base64.RawURLEncoding.EncodeToString(hash[:])
 
 	clientState := testutil.GenerateRandomString(43)
-	_, err = srv.StartAuthorizationFlow(ctx, clientID, "https://example.com/callback", "openid email", "", codeChallenge, PKCEMethodS256, clientState, nil)
+	_, err = srv.StartAuthorizationFlow(ctx, clientID, mustParseURL(t, "https://example.com/callback"), "openid email", "", codeChallenge, PKCEMethodS256, clientState, nil)
 	if err != nil {
 		t.Fatalf("StartAuthorizationFlow() error = %v", err)
 	}
@@ -1489,7 +1489,7 @@ func TestServer_RefreshAccessToken_PreservesScopesAndAudience(t *testing.T) {
 	codeChallenge := base64.RawURLEncoding.EncodeToString(hash[:])
 
 	clientState := testutil.GenerateRandomString(43)
-	_, err = srv.StartAuthorizationFlow(ctx, clientID, "https://example.com/callback", "openid email profile", "", codeChallenge, PKCEMethodS256, clientState, nil)
+	_, err = srv.StartAuthorizationFlow(ctx, clientID, mustParseURL(t, "https://example.com/callback"), "openid email profile", "", codeChallenge, PKCEMethodS256, clientState, nil)
 	if err != nil {
 		t.Fatalf("StartAuthorizationFlow() error = %v", err)
 	}

--- a/server/revoke_test.go
+++ b/server/revoke_test.go
@@ -445,7 +445,7 @@ func TestServer_ConcurrentReuseAndRevocation(t *testing.T) {
 	_, err = srv.StartAuthorizationFlow(
 		ctx,
 		clientID,
-		"https://example.com/callback",
+		mustParseURL(t, "https://example.com/callback"),
 		"openid email",
 		"", // resource parameter (optional)
 		codeChallenge,

--- a/server/scope_test.go
+++ b/server/scope_test.go
@@ -77,7 +77,7 @@ func TestServer_StartAuthorizationFlow_EmptyScope(t *testing.T) {
 	authURL, err := srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"http://localhost:3000/callback",
+		mustParseURL(t, "http://localhost:3000/callback"),
 		"", // NO SCOPE PROVIDED - this is the key test case
 		"", // resource parameter (optional)
 		validChallenge,
@@ -197,7 +197,7 @@ func TestServer_StartAuthorizationFlow_WithExplicitScopes(t *testing.T) {
 	authURL, err := srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"http://localhost:3000/callback",
+		mustParseURL(t, "http://localhost:3000/callback"),
 		requestedScope, // EXPLICIT SCOPES PROVIDED
 		"",
 		validChallenge,
@@ -292,7 +292,7 @@ func TestServer_StartAuthorizationFlow_ScopeIntersection(t *testing.T) {
 	authURL, err := srv.StartAuthorizationFlow(
 		ctx,
 		client.ClientID,
-		"http://localhost:3000/callback",
+		mustParseURL(t, "http://localhost:3000/callback"),
 		"", // NO SCOPE PROVIDED
 		"",
 		validChallenge,


### PR DESCRIPTION
## What

`StartAuthorizationFlow` now accepts `redirectURI *url.URL` instead of `redirectURI string`.

The `/authorize` handler already calls `ValidateRedirectURIForAuthorization` to resolve and verify the redirect URI before any error-redirect can happen (RFC 6749 §3.1.2.4). That call fetches the client and matches the URI against the registered list, returning a `*url.URL` from server-controlled storage. Passing that value directly to `StartAuthorizationFlow` removes the redundant `getOrFetchClient` + `validateRedirectURI` round-trip that the flow was doing on the same raw string.

## What is preserved

`StartAuthorizationFlow` still runs `validateRedirectURI` and `ValidateRedirectURIAtAuthorizationTime` internally, so callers that invoke the flow directly (tests, future non-HTTP entry points) remain safe without a prior pre-validation step.

## Call site changes

All `StartAuthorizationFlow` call sites in test files now pass `mustParseURL(t, "...")` — a small helper added to the `server` and `handler` test packages.

Closes #328