### PR TITLE
feat(security): warn on AllowInsecureHTTP / AllowPrivateIPClientMetadata at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Startup `WARN` for development-only overrides.** `AllowInsecureHTTP` and `AllowPrivateIPClientMetadata` now emit a `slog.LevelWarn` entry at server initialisation when set, making it harder to accidentally leave either flag enabled in production. `AllowPrivateIPClientMetadata` previously logged from `server.New` only; the warning is now unified under `logCoreSecurityWarnings` alongside all other security-posture checks. Both flags are documented in `docs/security.md` under a new "Development-only overrides" subsection. Closes #342.
+
 ### Changed
 
 - **BREAKING — HTTP adapter moved to `handler/` subpackage.** The HTTP layer that lived in the root `oauth` package (handler, middleware, route registration, endpoint serve methods, CORS, rate limit, scope plumbing) now lives in `github.com/giantswarm/mcp-oauth/handler`. The root `oauth` package retains protocol-level types (`Error`, `TokenResponse`, `ProtectedResourceMetadata`, etc.) and convenience constructors for `server.Server`. Migration: `oauth.NewHandler(srv, log)` → `handler.New(srv, log)`; `*oauth.Handler` → `*handler.Handler`; `oauth.OAuthRoutesOptions` → `handler.OAuthRoutesOptions`; `oauth.UserInfoFromContext` / `oauth.SessionIDFromContext` / `oauth.ContextWith*` → `handler.UserInfoFromContext` / `handler.SessionIDFromContext` / `handler.ContextWith*`; `oauth.InterstitialRedirectURL` / `oauth.InterstitialAppName` → `handler.InterstitialRedirectURL` / `handler.InterstitialAppName`. The `oauth.NewHandler` name is also dropped in favour of `handler.New` (idiomatic Go constructor naming in the new package). Closes #292, #343.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Startup `WARN` for development-only overrides.** `AllowInsecureHTTP` and `AllowPrivateIPClientMetadata` now emit a `slog.LevelWarn` entry at server initialisation when set, making it harder to accidentally leave either flag enabled in production. `AllowPrivateIPClientMetadata` previously logged from `server.New` only; the warning is now unified under `logCoreSecurityWarnings` alongside all other security-posture checks. Both flags are documented in `docs/security.md` under a new "Development-only overrides" subsection. Closes #342.
+- **Startup `WARN` for development-only overrides.** `AllowInsecureHTTP`, `AllowPrivateIPClientMetadata`, and `AllowPrivateIPJWKS` now emit a `slog.LevelWarn` entry at server initialisation when set, making it harder to accidentally leave these flags enabled in production. `AllowPrivateIPClientMetadata` and `AllowPrivateIPJWKS` previously logged from `server.New` only; the warnings are now unified under `logCoreSecurityWarnings` alongside all other security-posture checks. All three flags are documented in `docs/security.md` under a new "Development-only overrides" subsection. Closes #342.
 
 ### Changed
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -480,6 +480,25 @@ config := &server.Config{
 
 **WARNING:** These `Disable*` fields significantly weaken security. Only use them in trusted development environments, never in production.
 
+### Development-only overrides
+
+Two additional flags exist for non-production scenarios. Both emit a startup `WARN` log entry when set.
+
+| Field | Risk | Dev use case |
+|---|---|---|
+| `AllowInsecureHTTP` | Bearer tokens transmitted in clear — full credential exposure | Non-loopback HTTP test environments. RFC 8252 §7.3 loopback HTTP (`http://localhost`) is always permitted without this flag. |
+| `AllowPrivateIPClientMetadata` | SSRF into cluster — metadata URLs resolve to private / loopback IPs (CWE-918) | CIMD fetch against internal metadata endpoints during development |
+
+```go
+// Development only — never set in production
+config := &server.Config{
+    AllowInsecureHTTP:            true, // http:// issuer/redirect outside loopback
+    AllowPrivateIPClientMetadata: true, // CIMD fetches to RFC 1918 / loopback addresses
+}
+```
+
+**WARNING:** Both flags bypass production security invariants and must not appear in production deployments.
+
 ### Native App Support (RFC 8252)
 
 For native/CLI apps that need localhost redirects:

--- a/docs/security.md
+++ b/docs/security.md
@@ -482,22 +482,24 @@ config := &server.Config{
 
 ### Development-only overrides
 
-Two additional flags exist for non-production scenarios. Both emit a startup `WARN` log entry when set.
+The following flags exist for non-production scenarios. Each emits a startup `WARN` log entry when set.
 
 | Field | Risk | Dev use case |
 |---|---|---|
 | `AllowInsecureHTTP` | Bearer tokens transmitted in clear — full credential exposure | Non-loopback HTTP test environments. RFC 8252 §7.3 loopback HTTP (`http://localhost`) is always permitted without this flag. |
-| `AllowPrivateIPClientMetadata` | SSRF into cluster — metadata URLs resolve to private / loopback IPs (CWE-918) | CIMD fetch against internal metadata endpoints during development |
+| `AllowPrivateIPClientMetadata` | SSRF into cluster — CIMD metadata URLs resolve to private / loopback IPs (CWE-918) | CIMD fetch against internal metadata endpoints during development |
+| `AllowPrivateIPJWKS` | SSRF into cluster — JWKS endpoints resolve to private / loopback IPs (CWE-918) | Private IdP deployments (e.g., internal Dex) where the JWKS URI is on an RFC 1918 address |
 
 ```go
-// Development only — never set in production
+// Development / private-network only — never set in internet-facing production
 config := &server.Config{
     AllowInsecureHTTP:            true, // http:// issuer/redirect outside loopback
     AllowPrivateIPClientMetadata: true, // CIMD fetches to RFC 1918 / loopback addresses
+    AllowPrivateIPJWKS:           true, // JWKS fetch to RFC 1918 / loopback addresses
 }
 ```
 
-**WARNING:** Both flags bypass production security invariants and must not appear in production deployments.
+**WARNING:** These flags bypass production security invariants and must not appear in internet-facing deployments.
 
 ### Native App Support (RFC 8252)
 

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -247,6 +247,28 @@ func TestLogSecurityWarnings(t *testing.T) {
 				"Public client registration is ENABLED",
 			},
 		},
+		{
+			name: "AllowInsecureHTTP warning",
+			config: &Config{
+				RequirePKCE:             true,
+				RegistrationAccessToken: "token",
+				AllowInsecureHTTP:       true,
+			},
+			expectedWarnings: []string{
+				"SECURITY WARNING: AllowInsecureHTTP is enabled",
+			},
+		},
+		{
+			name: "AllowPrivateIPClientMetadata warning",
+			config: &Config{
+				RequirePKCE:                  true,
+				RegistrationAccessToken:      "token",
+				AllowPrivateIPClientMetadata: true,
+			},
+			expectedWarnings: []string{
+				"SECURITY WARNING: AllowPrivateIPClientMetadata is enabled",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -269,6 +269,17 @@ func TestLogSecurityWarnings(t *testing.T) {
 				"SECURITY WARNING: AllowPrivateIPClientMetadata is enabled",
 			},
 		},
+		{
+			name: "AllowPrivateIPJWKS warning",
+			config: &Config{
+				RequirePKCE:             true,
+				RegistrationAccessToken: "token",
+				AllowPrivateIPJWKS:      true,
+			},
+			expectedWarnings: []string{
+				"SECURITY WARNING: AllowPrivateIPJWKS is enabled",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/config_validation_security.go
+++ b/server/config_validation_security.go
@@ -240,6 +240,12 @@ func logCoreSecurityWarnings(config *Config, logger *slog.Logger) {
 			"cwe", "CWE-918",
 			"note", "Development only")
 	}
+	if config.AllowPrivateIPJWKS {
+		logger.Warn("SECURITY WARNING: AllowPrivateIPJWKS is enabled",
+			"risk", "JWKS endpoints can resolve to private/internal IP addresses — SSRF possible",
+			"recommendation", "Unset for production deployments; use only for private IdP deployments (e.g., internal Dex)",
+			"cwe", "CWE-918")
+	}
 }
 
 // logRedirectURISecurityStatus emits WARN entries for any explicitly

--- a/server/config_validation_security.go
+++ b/server/config_validation_security.go
@@ -228,11 +228,17 @@ func logCoreSecurityWarnings(config *Config, logger *slog.Logger) {
 			"recommendation", "Set RegistrationAccessToken or enable AllowPublicClientRegistration")
 	}
 	if config.AllowInsecureHTTP {
-		logger.Error("CRITICAL SECURITY WARNING: HTTP is explicitly allowed",
-			"risk", "All OAuth tokens and credentials exposed to network interception",
-			"recommendation", "Use HTTPS in all environments",
-			"compliance", "OAuth 2.1 requires HTTPS for all endpoints",
-			"learn_more", "https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-10#section-4.1.1")
+		logger.Warn("SECURITY WARNING: AllowInsecureHTTP is enabled",
+			"risk", "http:// issuer / redirect URIs accepted outside loopback — tokens exposed in clear",
+			"recommendation", "Unset for production deployments",
+			"note", "Development only — RFC 8252 §7.3 loopback HTTP is permitted without this flag")
+	}
+	if config.AllowPrivateIPClientMetadata {
+		logger.Warn("SECURITY WARNING: AllowPrivateIPClientMetadata is enabled",
+			"risk", "CIMD fetches to private-IP / loopback ranges allowed — SSRF into cluster possible",
+			"recommendation", "Unset for production deployments",
+			"cwe", "CWE-918",
+			"note", "Development only")
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -306,15 +306,6 @@ func (s *Server) initializeMetadataSupport() {
 		"burst", 20,
 		"purpose", "DoS protection")
 
-	// SECURITY WARNING: Log when SSRF protection is relaxed for JWKS endpoints
-	if s.Config.AllowPrivateIPJWKS {
-		s.Logger.Warn("SSRF protection reduced: AllowPrivateIPJWKS is enabled",
-			"config", "AllowPrivateIPJWKS=true",
-			"warning", "JWKS endpoints can resolve to private/internal IP addresses",
-			"use_case", "Private IdP deployments (e.g., internal Dex)",
-			"allowed_ranges", "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, ::1, link-local")
-	}
-
 	go s.metadataCacheCleanupLoop()
 	s.Logger.Debug("Started metadata cache cleanup goroutine")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -306,14 +306,6 @@ func (s *Server) initializeMetadataSupport() {
 		"burst", 20,
 		"purpose", "DoS protection")
 
-	// SECURITY WARNING: Log when SSRF protection is relaxed for internal networks
-	if s.Config.AllowPrivateIPClientMetadata {
-		s.Logger.Warn("SSRF protection reduced: AllowPrivateIPClientMetadata is enabled",
-			"config", "AllowPrivateIPClientMetadata=true",
-			"warning", "Client metadata can be fetched from private/internal IP addresses",
-			"allowed_ranges", "10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, ::1, link-local")
-	}
-
 	// SECURITY WARNING: Log when SSRF protection is relaxed for JWKS endpoints
 	if s.Config.AllowPrivateIPJWKS {
 		s.Logger.Warn("SSRF protection reduced: AllowPrivateIPJWKS is enabled",

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -368,19 +368,11 @@ func TestConfigSecurityWarning_AllowInsecureHTTP(t *testing.T) {
 		AllowInsecureHTTP: true,
 	}
 
-	// Apply secure defaults (which includes logging warnings)
 	_ = applySecureDefaults(config, setup.logger)
 
-	// Verify critical security warning was logged
 	logOutput := setup.getLogs()
-	if !strings.Contains(logOutput, "CRITICAL SECURITY WARNING") {
-		t.Errorf("Expected critical warning in config, got: %s", logOutput)
-	}
-	if !strings.Contains(logOutput, "HTTP is explicitly allowed") {
-		t.Errorf("Expected warning about HTTP being allowed, got: %s", logOutput)
-	}
-	if !strings.Contains(logOutput, "OAuth 2.1") {
-		t.Errorf("Expected OAuth 2.1 compliance mention, got: %s", logOutput)
+	if !strings.Contains(logOutput, "SECURITY WARNING: AllowInsecureHTTP is enabled") {
+		t.Errorf("Expected AllowInsecureHTTP security warning, got: %s", logOutput)
 	}
 }
 


### PR DESCRIPTION
## What

Both `AllowInsecureHTTP` and `AllowPrivateIPClientMetadata` are development-only overrides that carry non-trivial production risk but shipped without a startup warning.

| Flag | Risk |
|---|---|
| `AllowInsecureHTTP` | `http://` issuer / redirect URIs accepted outside loopback — tokens in clear |
| `AllowPrivateIPClientMetadata` | CIMD fetches to private-IP / loopback ranges — SSRF into cluster (CWE-918) |

## Changes

- `AllowPrivateIPClientMetadata` warn moved from `server.New` into `logCoreSecurityWarnings` so it fires via `applySecurityDefaults` alongside all other security-posture checks and is reachable by unit tests.
- `AllowInsecureHTTP` downgraded from `logger.Error` to `logger.Warn` for consistency with every other config-time flag.
- Two new `TestLogSecurityWarnings` cases assert both warns fire.
- `docs/security.md` gains a "Development-only overrides" subsection documenting both flags with a risk table and example.

Closes #342.