### PR TITLE
fix(examples): resolve gosec/errcheck/goconst lint debt (#334)

### DIFF
--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	oauth "github.com/giantswarm/mcp-oauth"
 	oauthhandler "github.com/giantswarm/mcp-oauth/handler"
@@ -152,14 +153,14 @@ func main() {
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name())
+		_, _ = fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name())
 	})
 
 	// Start server
 	addr := ":8080"
 	log.Printf("🚀 Starting MCP OAuth Server on %s", addr)
 	log.Printf("📦 Provider: %s", googleProvider.Name())
-	log.Printf("🔐 Security: encryption=%v, audit=%v, ratelimit=%v",
+	log.Printf("🔐 Security: encryption=%v, audit=%v, ratelimit=%v", //nolint:gosec // G706: values are booleans derived from env var presence, not injected strings
 		encKeyB64 != "", true, true)
 	log.Printf("\nEndpoints:")
 	log.Printf("  Discovery (MCP 2025-11-25):")
@@ -177,7 +178,14 @@ func main() {
 	log.Printf("  - Protected Resource Metadata discovery")
 	log.Printf("  - Enhanced WWW-Authenticate headers with scope guidance")
 	log.Printf("  - OAuth 2.1 security (PKCE, token rotation)")
-	log.Fatal(http.ListenAndServe(addr, mux))
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 // mcpResponse represents the JSON response from the MCP endpoint.

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -153,7 +153,9 @@ func main() {
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name())
+		if _, err := fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name()); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Start server

--- a/examples/cimd/main.go
+++ b/examples/cimd/main.go
@@ -126,7 +126,7 @@ func main() {
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "OK - Provider: %s, CIMD: enabled\n", googleProvider.Name())
+		_, _ = fmt.Fprintf(w, "OK - Provider: %s, CIMD: enabled\n", googleProvider.Name())
 	})
 
 	// Start server
@@ -153,7 +153,14 @@ func main() {
 	log.Printf("  - PKCE required for all URL-based clients")
 	log.Printf("\nExample usage with CIMD:")
 	log.Printf("  client_id=https://example.com/oauth/client.json")
-	log.Fatal(http.ListenAndServe(addr, mux))
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 // mcpResponse represents the JSON response from the MCP endpoint.

--- a/examples/cimd/main.go
+++ b/examples/cimd/main.go
@@ -126,7 +126,9 @@ func main() {
 	// Health check
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "OK - Provider: %s, CIMD: enabled\n", googleProvider.Name())
+		if _, err := fmt.Fprintf(w, "OK - Provider: %s, CIMD: enabled\n", googleProvider.Name()); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Start server

--- a/examples/custom-scopes/main.go
+++ b/examples/custom-scopes/main.go
@@ -130,7 +130,9 @@ func setupRoutes(handler *oauthhandler.Handler) {
 
 	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("OK"))
+		if _, err := w.Write([]byte("OK")); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 }
 

--- a/examples/custom-scopes/main.go
+++ b/examples/custom-scopes/main.go
@@ -13,6 +13,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	oauth "github.com/giantswarm/mcp-oauth"
 	oauthhandler "github.com/giantswarm/mcp-oauth/handler"
@@ -93,7 +94,14 @@ func main() {
 	for _, scope := range scopes {
 		log.Printf("  - %s", scope)
 	}
-	log.Fatal(http.ListenAndServe(addr, nil))
+	httpSrv := &http.Server{
+		Addr:         addr,
+		Handler:      http.DefaultServeMux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	log.Fatal(httpSrv.ListenAndServe())
 }
 
 func setupRoutes(handler *oauthhandler.Handler) {
@@ -122,9 +130,16 @@ func setupRoutes(handler *oauthhandler.Handler) {
 
 	http.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("OK"))
+		_, _ = w.Write([]byte("OK"))
 	})
 }
+
+const (
+	keyService = "service"
+	keyUser    = "user"
+	keyMessage = "message"
+	keyExample = "example"
+)
 
 // Handler for Gmail API requests
 func gmailHandler() http.Handler {
@@ -136,10 +151,10 @@ func gmailHandler() http.Handler {
 		// Call Gmail API with token...
 
 		response := map[string]interface{}{
-			"service": "Gmail API",
-			"user":    userInfo.Email,
-			"message": "Access Gmail API here with the user's token",
-			"example": "GET https://gmail.googleapis.com/gmail/v1/users/me/messages",
+			keyService: "Gmail API",
+			keyUser:    userInfo.Email,
+			keyMessage: "Access Gmail API here with the user's token",
+			keyExample: "GET https://gmail.googleapis.com/gmail/v1/users/me/messages",
 		}
 
 		writeJSON(w, response)
@@ -152,10 +167,10 @@ func driveHandler() http.Handler {
 		userInfo, _ := oauthhandler.UserInfoFromContext(r.Context())
 
 		response := map[string]interface{}{
-			"service": "Google Drive API",
-			"user":    userInfo.Email,
-			"message": "Access Google Drive API here with the user's token",
-			"example": "GET https://www.googleapis.com/drive/v3/files",
+			keyService: "Google Drive API",
+			keyUser:    userInfo.Email,
+			keyMessage: "Access Google Drive API here with the user's token",
+			keyExample: "GET https://www.googleapis.com/drive/v3/files",
 		}
 
 		writeJSON(w, response)
@@ -168,10 +183,10 @@ func calendarHandler() http.Handler {
 		userInfo, _ := oauthhandler.UserInfoFromContext(r.Context())
 
 		response := map[string]interface{}{
-			"service": "Google Calendar API",
-			"user":    userInfo.Email,
-			"message": "Access Google Calendar API here with the user's token",
-			"example": "GET https://www.googleapis.com/calendar/v3/calendars/primary/events",
+			keyService: "Google Calendar API",
+			keyUser:    userInfo.Email,
+			keyMessage: "Access Google Calendar API here with the user's token",
+			keyExample: "GET https://www.googleapis.com/calendar/v3/calendars/primary/events",
 		}
 
 		writeJSON(w, response)
@@ -184,10 +199,10 @@ func contactsHandler() http.Handler {
 		userInfo, _ := oauthhandler.UserInfoFromContext(r.Context())
 
 		response := map[string]interface{}{
-			"service": "Google Contacts API",
-			"user":    userInfo.Email,
-			"message": "Access Google Contacts API here with the user's token",
-			"example": "GET https://people.googleapis.com/v1/people/me/connections",
+			keyService: "Google Contacts API",
+			keyUser:    userInfo.Email,
+			keyMessage: "Access Google Contacts API here with the user's token",
+			keyExample: "GET https://people.googleapis.com/v1/people/me/connections",
 		}
 
 		writeJSON(w, response)
@@ -200,8 +215,8 @@ func mcpHandler() http.Handler {
 		userInfo, _ := oauthhandler.UserInfoFromContext(r.Context())
 
 		response := map[string]interface{}{
-			"message": "MCP server with multiple Google API scopes",
-			"user": map[string]string{
+			keyMessage: "MCP server with multiple Google API scopes",
+			keyUser: map[string]string{
 				"email": userInfo.Email,
 				"name":  userInfo.Name,
 				"id":    userInfo.ID,

--- a/examples/dex/main.go
+++ b/examples/dex/main.go
@@ -224,7 +224,9 @@ func main() {
 </body>
 </html>`
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprint(w, html)
+		if _, err := fmt.Fprint(w, html); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Health check endpoint
@@ -235,12 +237,16 @@ func main() {
 		if err := dexProvider.HealthCheck(ctx); err != nil {
 			log.Printf("Health check failed: %v", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = fmt.Fprintf(w, "unhealthy: %v", err)
+			if _, werr := fmt.Fprintf(w, "unhealthy: %v", err); werr != nil {
+				log.Printf("write response: %v", werr)
+			}
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprint(w, "healthy")
+		if _, err := fmt.Fprint(w, "healthy"); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Start server

--- a/examples/dex/main.go
+++ b/examples/dex/main.go
@@ -55,9 +55,9 @@ func main() {
 		log.Fatalf("Failed to create Dex provider: %v", err)
 	}
 
-	log.Printf("Created Dex provider for issuer: %s", issuerURL)
+	log.Printf("Created Dex provider for issuer: %s", issuerURL) //nolint:gosec // G706: issuerURL is operator-supplied config, not user input
 	if connectorID != "" {
-		log.Printf("Using connector: %s (will skip Dex connector selection)", connectorID)
+		log.Printf("Using connector: %s (will skip Dex connector selection)", connectorID) //nolint:gosec // G706: connectorID is operator-supplied config, not user input
 	}
 
 	// Create in-memory storage (use persistent storage in production)
@@ -224,7 +224,7 @@ func main() {
 </body>
 </html>`
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprint(w, html)
+		_, _ = fmt.Fprint(w, html)
 	})
 
 	// Health check endpoint
@@ -235,12 +235,12 @@ func main() {
 		if err := dexProvider.HealthCheck(ctx); err != nil {
 			log.Printf("Health check failed: %v", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprintf(w, "unhealthy: %v", err)
+			_, _ = fmt.Fprintf(w, "unhealthy: %v", err)
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "healthy")
+		_, _ = fmt.Fprint(w, "healthy")
 	})
 
 	// Start server
@@ -250,7 +250,14 @@ func main() {
 	if len(trustedAudiences) > 0 {
 		log.Printf("Forwarded-ID-token acceptance enabled (TrustedAudiences: %v); POST a Dex-issued JWT as Bearer to /api/forwarded", trustedAudiences)
 	}
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/examples/github/main.go
+++ b/examples/github/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	log.Printf("Created GitHub OAuth provider")
 	if len(allowedOrgs) > 0 {
-		log.Printf("Restricting login to organizations: %v", allowedOrgs)
+		log.Printf("Restricting login to organizations: %v", allowedOrgs) //nolint:gosec // G706: allowedOrgs is operator-supplied config, not user input
 	}
 
 	// Create in-memory storage (use persistent storage in production)
@@ -179,7 +179,7 @@ func main() {
 </body>
 </html>`
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprint(w, html)
+		_, _ = fmt.Fprint(w, html)
 	})
 
 	// Health check endpoint
@@ -192,19 +192,26 @@ func main() {
 			// Log error for internal monitoring, but don't expose details to clients
 			log.Printf("Health check failed: %v", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			fmt.Fprint(w, "unhealthy")
+			_, _ = fmt.Fprint(w, "unhealthy")
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprint(w, "healthy")
+		_, _ = fmt.Fprint(w, "healthy")
 	})
 
 	// Start server
 	addr := ":8080"
 	log.Printf("Starting server on http://localhost%s", addr)
 	log.Printf("Visit http://localhost%s to sign in with GitHub", addr)
-	if err := http.ListenAndServe(addr, mux); err != nil {
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/examples/github/main.go
+++ b/examples/github/main.go
@@ -179,7 +179,9 @@ func main() {
 </body>
 </html>`
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprint(w, html)
+		if _, err := fmt.Fprint(w, html); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Health check endpoint
@@ -192,12 +194,16 @@ func main() {
 			// Log error for internal monitoring, but don't expose details to clients
 			log.Printf("Health check failed: %v", err)
 			w.WriteHeader(http.StatusServiceUnavailable)
-			_, _ = fmt.Fprint(w, "unhealthy")
+			if _, err := fmt.Fprint(w, "unhealthy"); err != nil {
+				log.Printf("write response: %v", err)
+			}
 			return
 		}
 
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprint(w, "healthy")
+		if _, err := fmt.Fprint(w, "healthy"); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Start server

--- a/examples/jwt/main.go
+++ b/examples/jwt/main.go
@@ -107,7 +107,9 @@ func main() {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprintf(w, indexHTML, keyID)
+		if _, err := fmt.Fprintf(w, indexHTML, keyID); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	log.Printf("Listening on :8080")

--- a/examples/jwt/main.go
+++ b/examples/jwt/main.go
@@ -113,7 +113,14 @@ func main() {
 	log.Printf("Listening on :8080")
 	log.Printf("JWKS: http://localhost:8080/.well-known/jwks.json (kid=%s)", keyID)
 	log.Printf("Discovery: http://localhost:8080/.well-known/oauth-authorization-server")
-	if err := http.ListenAndServe(":8080", mux); err != nil && !errors.Is(err, http.ErrServerClosed) {
+	httpSrv := &http.Server{
+		Addr:         ":8080",
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Fatalf("Server failed: %v", err)
 	}
 }

--- a/examples/mcp-2025-11-25/main.go
+++ b/examples/mcp-2025-11-25/main.go
@@ -11,12 +11,19 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	oauth "github.com/giantswarm/mcp-oauth"
 	oauthhandler "github.com/giantswarm/mcp-oauth/handler"
 	"github.com/giantswarm/mcp-oauth/providers/google"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+const (
+	scopeFilesRead   = "files:read"
+	scopeFilesWrite  = "files:write"
+	scopeAdminAccess = "admin:access"
 )
 
 func main() {
@@ -65,11 +72,11 @@ func main() {
 			// List all scopes your resource server supports
 			// This appears in Protected Resource Metadata (/.well-known/oauth-protected-resource)
 			SupportedScopes: []string{
-				"mcp:access",   // General MCP access
-				"files:read",   // Read files
-				"files:write",  // Write/modify files
-				"admin:access", // Administrative access
-				"user:profile", // User profile information
+				"mcp:access",      // General MCP access
+				scopeFilesRead,    // Read files
+				scopeFilesWrite,   // Write/modify files
+				scopeAdminAccess,  // Administrative access
+				"user:profile",    // User profile information
 			},
 
 			// Feature 2: WWW-Authenticate Scope Guidance
@@ -90,8 +97,8 @@ func main() {
 			// Define which scopes are required for specific API endpoints
 			// When a token lacks required scopes, server returns 403 with insufficient_scope error
 			EndpointScopeRequirements: map[string][]string{
-				"/api/files/*": {"files:read", "files:write"},
-				"/api/admin/*": {"admin:access"},
+				"/api/files/*": {scopeFilesRead, scopeFilesWrite},
+				"/api/admin/*": {scopeAdminAccess},
 				"/api/profile": {"user:profile"},
 			},
 
@@ -99,10 +106,10 @@ func main() {
 			// Different HTTP methods can require different scopes
 			EndpointMethodScopeRequirements: map[string]map[string][]string{
 				"/api/files/*": {
-					"GET":    {"files:read"},                   // Read-only
-					"POST":   {"files:write"},                  // Create new
-					"PUT":    {"files:write"},                  // Modify existing
-					"DELETE": {"files:delete", "admin:access"}, // Delete requires admin
+					"GET":    {scopeFilesRead},                    // Read-only
+					"POST":   {scopeFilesWrite},                   // Create new
+					"PUT":    {scopeFilesWrite},                   // Modify existing
+					"DELETE": {"files:delete", scopeAdminAccess},  // Delete requires admin
 				},
 			},
 
@@ -170,7 +177,7 @@ func main() {
 	// Health check (unprotected)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name())
+		_, _ = fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name())
 	})
 
 	// Start server
@@ -211,7 +218,14 @@ func main() {
 	log.Println("  curl http://localhost:8080/.well-known/oauth-authorization-server")
 	log.Println()
 
-	log.Fatal(http.ListenAndServe(addr, mux))
+	srv := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  15 * time.Second,
+		WriteTimeout: 15 * time.Second,
+		IdleTimeout:  60 * time.Second,
+	}
+	log.Fatal(srv.ListenAndServe())
 }
 
 func mcpHandler(name string) http.Handler {
@@ -247,7 +261,7 @@ func mcpHandler(name string) http.Handler {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(response))
+		_, _ = w.Write([]byte(response))
 	})
 }
 

--- a/examples/mcp-2025-11-25/main.go
+++ b/examples/mcp-2025-11-25/main.go
@@ -177,7 +177,9 @@ func main() {
 	// Health check (unprotected)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name())
+		if _, err := fmt.Fprintf(w, "OK - Provider: %s\n", googleProvider.Name()); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Start server
@@ -261,7 +263,9 @@ func mcpHandler(name string) http.Handler {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(response))
+		if _, err := w.Write([]byte(response)); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 }
 

--- a/examples/production/main.go
+++ b/examples/production/main.go
@@ -313,22 +313,22 @@ func mcpHandler(logger *slog.Logger) http.Handler {
 func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"ok"}`))
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
 }
 
 func readinessHandler(w http.ResponseWriter, _ *http.Request) {
 	// Add actual readiness checks here (database, external services, etc.)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	w.Write([]byte(`{"status":"ready"}`))
+	_, _ = w.Write([]byte(`{"status":"ready"}`))
 }
 
 func metricsHandler(w http.ResponseWriter, _ *http.Request) {
 	// Implement metrics export (Prometheus, etc.)
 	w.Header().Set("Content-Type", "text/plain")
-	w.Write([]byte("# HELP oauth_requests_total Total OAuth requests\n"))
-	w.Write([]byte("# TYPE oauth_requests_total counter\n"))
-	w.Write([]byte("oauth_requests_total 0\n"))
+	_, _ = w.Write([]byte("# HELP oauth_requests_total Total OAuth requests\n"))
+	_, _ = w.Write([]byte("# TYPE oauth_requests_total counter\n"))
+	_, _ = w.Write([]byte("oauth_requests_total 0\n"))
 }
 
 // Helper functions
@@ -372,7 +372,7 @@ func loadEncryptionKey() ([]byte, error) {
 
 	// Try to load from file
 	if keyFile := os.Getenv("OAUTH_ENCRYPTION_KEY_FILE"); keyFile != "" {
-		data, err := os.ReadFile(keyFile)
+		data, err := os.ReadFile(keyFile) // #nosec G304,G703 — path comes from operator-controlled env var, not user input
 		if err != nil {
 			return nil, fmt.Errorf("read key file: %w", err)
 		}

--- a/examples/production/main.go
+++ b/examples/production/main.go
@@ -313,22 +313,26 @@ func mcpHandler(logger *slog.Logger) http.Handler {
 func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status":"ok"}`))
+	if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+		log.Printf("write response: %v", err)
+	}
 }
 
 func readinessHandler(w http.ResponseWriter, _ *http.Request) {
 	// Add actual readiness checks here (database, external services, etc.)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte(`{"status":"ready"}`))
+	if _, err := w.Write([]byte(`{"status":"ready"}`)); err != nil {
+		log.Printf("write response: %v", err)
+	}
 }
 
 func metricsHandler(w http.ResponseWriter, _ *http.Request) {
 	// Implement metrics export (Prometheus, etc.)
 	w.Header().Set("Content-Type", "text/plain")
-	_, _ = w.Write([]byte("# HELP oauth_requests_total Total OAuth requests\n"))
-	_, _ = w.Write([]byte("# TYPE oauth_requests_total counter\n"))
-	_, _ = w.Write([]byte("oauth_requests_total 0\n"))
+	if _, err := w.Write([]byte("# HELP oauth_requests_total Total OAuth requests\n# TYPE oauth_requests_total counter\noauth_requests_total 0\n")); err != nil {
+		log.Printf("write response: %v", err)
+	}
 }
 
 // Helper functions

--- a/examples/prometheus/main.go
+++ b/examples/prometheus/main.go
@@ -126,13 +126,15 @@ func main() {
 	// Health check endpoint
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = fmt.Fprintf(w, `{"status":"healthy"}`)
+		if _, err := fmt.Fprintf(w, `{"status":"healthy"}`); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// Home page with links
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = fmt.Fprintf(w, `
+		if _, err := fmt.Fprintf(w, `
 <!DOCTYPE html>
 <html>
 <head>
@@ -193,7 +195,9 @@ rate(oauth_http_requests_total[5m])
     </ol>
 </body>
 </html>
-		`)
+		`); err != nil {
+			log.Printf("write response: %v", err)
+		}
 	})
 
 	// 9. Start HTTP server with graceful shutdown

--- a/examples/prometheus/main.go
+++ b/examples/prometheus/main.go
@@ -126,13 +126,13 @@ func main() {
 	// Health check endpoint
 	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		fmt.Fprintf(w, `{"status":"healthy"}`)
+		_, _ = fmt.Fprintf(w, `{"status":"healthy"}`)
 	})
 
 	// Home page with links
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprintf(w, `
+		_, _ = fmt.Fprintf(w, `
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Fixes #334.

The production code is already clean. This clears the remaining gosec/errcheck/goconst findings that `golangci-lint run -E gosec -E goconst ./examples/...` was reporting.

**G114** — replaced bare `http.ListenAndServe` with `*http.Server` carrying explicit `ReadTimeout`/`WriteTimeout`/`IdleTimeout` in all seven affected examples.

**errcheck** — all `fmt.Fprint`/`fmt.Fprintf`/`w.Write` calls inside HTTP handlers now use `_, _ =` to satisfy the checker.

**G304/G703** — `os.ReadFile(keyFile)` in `examples/production` annotated with `#nosec G304,G703`; the path comes from an operator-controlled env var, not user input.

**G706** — `//nolint:gosec // G706:` on `log.Printf` calls that print operator-supplied config values (issuer URL, connector ID, allowed org list). These are not injected from user HTTP requests.

**goconst** — added named constants for repeated string literals: `scopeFilesRead/Write/AdminAccess` in `mcp-2025-11-25`, `keyService/User/Message/Example` in `custom-scopes`.