### PR TITLE
refactor: replace setter injection with functional options (#309)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`memory.WithEncryptor`, `memory.WithInstrumentation`, `memory.WithLogger`, `memory.WithCleanupInterval`, `memory.WithRevokedFamilyRetentionDays`**: functional options for `memory.New`. All cross-cutting dependencies are now supplied at construction; the store is immutable afterward.
+- **`valkey.WithEncryptor`, `valkey.WithInstrumentation`**: functional options for `valkey.New`. Same construction-time wiring as memory.
+
+### Changed
+
+- **BREAKING — `memory.New` now accepts `...Option`** (was `func New() *Store`). Pass `memory.WithEncryptor(enc)`, `memory.WithInstrumentation(inst)`, etc. at construction instead of calling `SetX` after the fact.
+- **BREAKING — `valkey.New` now accepts `...Option`** (was `func New(cfg Config) (*Store, error)`). Signature is now `func New(cfg Config, opts ...Option) (*Store, error)`.
+- **BREAKING — `oauthconfig.StorageFromEnv` and `StorageFromEnvWithPrefix` signatures changed.** Both now accept `enc *security.Encryptor, inst *instrumentation.Instrumentation` before the `logger` argument, and wire them into the constructed store.
+- Encryption at rest is wired on the store (`memory.WithEncryptor` / `valkey.WithEncryptor`), not the server. Remove any `server.WithEncryptor` / `oauth.WithEncryptor` calls and pass the encryptor directly to the store constructor.
+- `server.Config.RevokedFamilyRetentionDays` removed; set the retention period on the memory store via `memory.WithRevokedFamilyRetentionDays` instead.
+
+### Removed
+
+- `memory.SetEncryptor`, `memory.SetInstrumentation`, `memory.SetLogger`, `memory.SetRevokedFamilyRetentionDays` — replaced by construction-time options.
+- `memory.NewWithInterval` — replaced by `memory.New(memory.WithCleanupInterval(d))`.
+- `valkey.SetEncryptor`, `valkey.SetInstrumentation`, `valkey.SetLogger` — replaced by construction-time options.
+- `server.WithEncryptor` / `oauth.WithEncryptor` — the server no longer holds an encryptor; wire it on the store.
+- `server.Server.Encryptor` field — removed alongside `WithEncryptor`.
+- `server.Config.RevokedFamilyRetentionDays` — moved to `memory.WithRevokedFamilyRetentionDays`.
+
 ### Security
 
 - **Startup `WARN` for development-only overrides.** `AllowInsecureHTTP`, `AllowPrivateIPClientMetadata`, and `AllowPrivateIPJWKS` now emit a `slog.LevelWarn` entry at server initialisation when set, making it harder to accidentally leave these flags enabled in production. `AllowPrivateIPClientMetadata` and `AllowPrivateIPJWKS` previously logged from `server.New` only; the warnings are now unified under `logCoreSecurityWarnings` alongside all other security-posture checks. All three flags are documented in `docs/security.md` under a new "Development-only overrides" subsection. Closes #342.

--- a/doc.go
+++ b/doc.go
@@ -28,7 +28,7 @@
 //     [handler.Handler.RegisterProtectedResourceMetadataRoutes].
 //   - This root package — protocol-level types ([Error], [TokenResponse],
 //     [ProtectedResourceMetadata], …) and thin re-exports / convenience
-//     constructors for [server.Server] ([NewServer], [WithEncryptor], …).
+//     constructors for [server.Server] ([NewServer], …).
 //
 // # Security defaults
 //
@@ -40,8 +40,8 @@
 //   - Per-IP and per-user rate limiters guard hot endpoints.
 //   - Bearer-token comparisons are constant-time.
 //   - Token-at-rest encryption available via [security.NewEncryptor] +
-//     [server.WithEncryptor]; the ciphertext envelope is versioned with a
-//     1-byte `kid` for future rotation.
+//     [memory.WithEncryptor] / [valkey.WithEncryptor]; the ciphertext
+//     envelope is versioned with a 1-byte `kid` for future rotation.
 //   - OIDC `nonce` is required end-to-end when scoped `openid` (CWE-294).
 //   - SSRF protection on the client-metadata-document and discovery
 //     fetchers.
@@ -110,8 +110,8 @@
 //			log.Fatal(err)
 //		}
 //
-//		store := memory.New()
-//		srv, err := server.New(provider, store, store, store, cfg, slog.Default(), server.WithEncryptor(enc))
+//		store := memory.New(memory.WithEncryptor(enc))
+//		srv, err := server.New(provider, store, store, store, cfg, slog.Default())
 //		if err != nil {
 //			log.Fatal(err)
 //		}

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,7 +52,7 @@ Before deploying to production, verify these settings:
 
 ### Recommended
 
-- [ ] **Token Encryption**: Pass `server.WithEncryptor(enc)` at construction for at-rest encryption
+- [ ] **Token Encryption**: Pass `memory.WithEncryptor(enc)` / `valkey.WithEncryptor(enc)` to the store constructor for at-rest encryption
 - [ ] **Audit Logging**: Set up `Auditor` for security event logging
 - [ ] **Rate Limiting**: Configure IP, user, and client registration limits
 - [ ] **Registration Protected**: Set `RegistrationAccessToken` or disable registration
@@ -94,8 +94,9 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Pass at server construction (functional option).
-srv, err := server.New(provider, store, store, store, cfg, logger, server.WithEncryptor(encryptor))
+// Wire into the store at construction.
+store := memory.New(memory.WithEncryptor(encryptor))
+srv, err := server.New(provider, store, store, store, cfg, logger)
 ```
 
 The ciphertext envelope is versioned (`0x01 || kid || nonce || ct`); legacy

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -36,26 +36,18 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// 2. Create storage (in-memory for simplicity)
-	store := memory.New()
-	defer store.Stop()
-
 	// 3. Create logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	}))
 
 	// 4. Construct optional dependencies. Build everything first so we can
-	// pass them as functional options to NewServer in a single call.
+	// pass them as functional options to the store and NewServer.
 	auditor := security.NewAuditor(logger, true)
 	rateLimiter := security.NewRateLimiter(10, 20, logger)
 	defer rateLimiter.Stop() // Important: cleanup background goroutines
 
-	opts := []oauth.ServerOption{
-		oauth.WithAuditor(auditor),
-		oauth.WithRateLimiter(rateLimiter),
-	}
-
+	var storeOpts []memory.Option
 	encKeyB64 := os.Getenv("OAUTH_ENCRYPTION_KEY")
 	if encKeyB64 != "" {
 		encKey, err := security.KeyFromBase64(encKeyB64)
@@ -63,8 +55,17 @@ func main() {
 			log.Fatalf("Invalid encryption key: %v", err)
 		}
 		encryptor, _ := security.NewEncryptor(encKey)
-		opts = append(opts, oauth.WithEncryptor(encryptor))
+		storeOpts = append(storeOpts, memory.WithEncryptor(encryptor))
 		logger.Info("Token encryption enabled")
+	}
+
+	// 2. Create storage (in-memory for simplicity)
+	store := memory.New(storeOpts...)
+	defer store.Stop()
+
+	opts := []oauth.ServerOption{
+		oauth.WithAuditor(auditor),
+		oauth.WithRateLimiter(rateLimiter),
 	}
 
 	// 5. Create OAuth server with secure defaults plus optional dependencies.

--- a/examples/production/main.go
+++ b/examples/production/main.go
@@ -53,11 +53,7 @@ func main() {
 		log.Fatalf("Failed to create Google provider: %v", err)
 	}
 
-	// 2. Create storage (in-memory with custom cleanup interval for production)
-	store := memory.NewWithInterval(1 * time.Minute)
-	defer store.Stop()
-
-	// 3. Build security dependencies before server construction so they are
+	// 2. Build security dependencies before store construction so they can be
 	// passed via functional options. Secure-by-default applies regardless;
 	// these options layer additional defense (encryption at rest, audit
 	// logging, multi-tier rate limiting).
@@ -81,9 +77,8 @@ func main() {
 	clientRegRateLimiter := security.NewClientRegistrationRateLimiter(logger)
 	defer clientRegRateLimiter.Stop()
 
-	// 5. OpenTelemetry instrumentation. Built outside the constructor so
-	// the same pipeline can be shared with other components in the
-	// process; pass via WithInstrumentation.
+	// 3. OpenTelemetry instrumentation. Built outside the constructors so
+	// the same pipeline can be shared with both the store and the server.
 	inst, err := instrumentation.New(instrumentation.Config{
 		Enabled:         getBoolEnv("ENABLE_INSTRUMENTATION", true),
 		ServiceName:     getEnvOrDefault("SERVICE_NAME", "mcp-oauth-production"),
@@ -96,7 +91,15 @@ func main() {
 		log.Fatalf("Failed to initialize instrumentation: %v", err)
 	}
 
-	// 6. Create OAuth server with production-grade security configuration
+	// 4. Create storage with all cross-cutting deps wired at construction.
+	store := memory.New(
+		memory.WithCleanupInterval(time.Minute),
+		memory.WithEncryptor(encryptor),
+		memory.WithInstrumentation(inst),
+	)
+	defer store.Stop()
+
+	// 5. Create OAuth server with production-grade security configuration
 	server, err := oauth.NewServer(
 		googleProvider,
 		store, // TokenStore
@@ -149,7 +152,6 @@ func main() {
 			// },
 		},
 		logger,
-		oauth.WithEncryptor(encryptor),
 		oauth.WithAuditor(auditor),
 		oauth.WithRateLimiter(rateLimiter),
 		oauth.WithUserRateLimiter(userRateLimiter),
@@ -161,7 +163,7 @@ func main() {
 		log.Fatalf("Failed to create OAuth server: %v", err)
 	}
 
-	// 5. Create HTTP handler
+	// 6. Create HTTP handler
 	handler := oauthhandler.New(server, logger)
 
 	// Setup HTTP routes

--- a/examples/prometheus/main.go
+++ b/examples/prometheus/main.go
@@ -42,10 +42,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// 2. Create storage (in-memory for simplicity)
-	store := memory.New()
-	defer store.Stop()
-
 	// 3. Create logger
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
@@ -55,23 +51,8 @@ func main() {
 	rateLimiter := security.NewRateLimiter(1, 10, logger)
 	defer rateLimiter.Stop()
 	auditor := security.NewAuditor(logger, true)
-
-	opts := []oauth.ServerOption{
-		oauth.WithRateLimiter(rateLimiter),
-		oauth.WithAuditor(auditor),
-	}
 	logger.Info("Rate limiting enabled", "requests_per_second", 1, "burst", 10)
 	logger.Info("Audit logging enabled")
-
-	if encKeyB64 := os.Getenv("OAUTH_ENCRYPTION_KEY"); encKeyB64 != "" {
-		encKey, err := security.KeyFromBase64(encKeyB64)
-		if err != nil {
-			log.Fatalf("Invalid encryption key: %v", err)
-		}
-		encryptor, _ := security.NewEncryptor(encKey)
-		opts = append(opts, oauth.WithEncryptor(encryptor))
-		logger.Info("Token encryption enabled")
-	}
 
 	// IMPORTANT: OpenTelemetry instrumentation with Prometheus metrics
 	inst, err := instrumentation.New(instrumentation.Config{
@@ -84,7 +65,28 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to initialize instrumentation: %v", err)
 	}
-	opts = append(opts, oauth.WithInstrumentation(inst))
+
+	var storeOpts []memory.Option
+	storeOpts = append(storeOpts, memory.WithInstrumentation(inst))
+	if encKeyB64 := os.Getenv("OAUTH_ENCRYPTION_KEY"); encKeyB64 != "" {
+		encKey, err := security.KeyFromBase64(encKeyB64)
+		if err != nil {
+			log.Fatalf("Invalid encryption key: %v", err)
+		}
+		encryptor, _ := security.NewEncryptor(encKey)
+		storeOpts = append(storeOpts, memory.WithEncryptor(encryptor))
+		logger.Info("Token encryption enabled")
+	}
+
+	// 2. Create storage (in-memory for simplicity)
+	store := memory.New(storeOpts...)
+	defer store.Stop()
+
+	opts := []oauth.ServerOption{
+		oauth.WithRateLimiter(rateLimiter),
+		oauth.WithAuditor(auditor),
+		oauth.WithInstrumentation(inst),
+	}
 
 	// 5. Create OAuth server
 	server, err := oauth.NewServer(

--- a/oauthconfig/storage.go
+++ b/oauthconfig/storage.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/giantswarm/mcp-oauth/instrumentation"
 	"github.com/giantswarm/mcp-oauth/oauthconfig/internal/valkeytls"
+	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 	"github.com/giantswarm/mcp-oauth/storage/valkey"
@@ -21,6 +23,9 @@ import (
 // for valkey. It is always safe to call and always returns nil (close errors
 // are swallowed and logged by the backend).
 //
+// enc and inst are wired into the store at construction. Both may be nil:
+// omitting enc leaves tokens unencrypted, omitting inst disables OTel.
+//
 // Valkey-specific variables (read only when OAUTH_STORAGE_BACKEND=valkey):
 //
 //   - OAUTH_VALKEY_ADDR                   (required when OAUTH_STORAGE_BACKEND=valkey)
@@ -34,17 +39,17 @@ import (
 //     range [64 KiB, 8 MiB])
 //
 // Pass the returned [storage.Combined] to [server.NewWithCombined].
-func StorageFromEnv(logger *slog.Logger) (storage.Combined, func() error, error) {
-	return StorageFromEnvWithPrefix("OAUTH_", logger)
+func StorageFromEnv(enc *security.Encryptor, inst *instrumentation.Instrumentation, logger *slog.Logger) (storage.Combined, func() error, error) {
+	return StorageFromEnvWithPrefix("OAUTH_", enc, inst, logger)
 }
 
 // StorageFromEnvWithPrefix is [StorageFromEnv] with a caller-supplied prefix
 // applied to STORAGE_BACKEND and VALKEY_*. The prefix is applied verbatim;
 // include a trailing underscore if you want one. Useful for consumers that
 // scope their env vars to their product name, e.g.
-// StorageFromEnvWithPrefix("MUSTER_OAUTH_", logger) reads
+// StorageFromEnvWithPrefix("MUSTER_OAUTH_", enc, inst, logger) reads
 // MUSTER_OAUTH_STORAGE_BACKEND and MUSTER_OAUTH_VALKEY_*.
-func StorageFromEnvWithPrefix(prefix string, logger *slog.Logger) (storage.Combined, func() error, error) {
+func StorageFromEnvWithPrefix(prefix string, enc *security.Encryptor, inst *instrumentation.Instrumentation, logger *slog.Logger) (storage.Combined, func() error, error) {
 	backend := os.Getenv(prefix + "STORAGE_BACKEND")
 	if backend == "" {
 		backend = storage.BackendMemory
@@ -52,10 +57,10 @@ func StorageFromEnvWithPrefix(prefix string, logger *slog.Logger) (storage.Combi
 
 	switch backend {
 	case storage.BackendMemory:
-		store := memory.New()
+		store := memory.New(memory.WithEncryptor(enc), memory.WithInstrumentation(inst))
 		return store, func() error { store.Stop(); return nil }, nil
 	case storage.BackendValkey:
-		return newValkeyFromEnv(prefix, logger)
+		return newValkeyFromEnv(prefix, enc, inst, logger)
 	default:
 		return nil, nil, fmt.Errorf("%sSTORAGE_BACKEND: unknown backend %q (want %q or %q)", prefix, backend, storage.BackendMemory, storage.BackendValkey)
 	}
@@ -65,7 +70,7 @@ func StorageFromEnvWithPrefix(prefix string, logger *slog.Logger) (storage.Combi
 // variables. Returns a close func that invokes Store.Close and always returns
 // nil (Valkey close errors are logged by the backend; surfacing them would
 // complicate caller shutdown flows).
-func newValkeyFromEnv(prefix string, logger *slog.Logger) (storage.Combined, func() error, error) {
+func newValkeyFromEnv(prefix string, enc *security.Encryptor, inst *instrumentation.Instrumentation, logger *slog.Logger) (storage.Combined, func() error, error) {
 	addr := os.Getenv(prefix + "VALKEY_ADDR")
 	if addr == "" {
 		return nil, nil, fmt.Errorf("%sVALKEY_ADDR is required when %sSTORAGE_BACKEND=valkey", prefix, prefix)
@@ -110,7 +115,7 @@ func newValkeyFromEnv(prefix string, logger *slog.Logger) (storage.Combined, fun
 		RefreshTokenTTL:  refreshTTL,
 		MaxTokenDataSize: maxTokenDataSize,
 	}
-	store, err := valkey.New(cfg)
+	store, err := valkey.New(cfg, valkey.WithEncryptor(enc), valkey.WithInstrumentation(inst))
 	if err != nil {
 		return nil, nil, fmt.Errorf("valkey.New: %w", err)
 	}

--- a/oauthconfig/storage_test.go
+++ b/oauthconfig/storage_test.go
@@ -34,7 +34,7 @@ func clearStorageEnv(t *testing.T) {
 
 func TestStorageFromEnv_DefaultIsMemory(t *testing.T) {
 	clearStorageEnv(t)
-	store, closeFn, err := oauthconfig.StorageFromEnv(slog.Default())
+	store, closeFn, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("StorageFromEnv: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestStorageFromEnv_MemoryExplicit(t *testing.T) {
 	clearStorageEnv(t)
 	t.Setenv("OAUTH_STORAGE_BACKEND", "memory")
 
-	store, closeFn, err := oauthconfig.StorageFromEnv(slog.Default())
+	store, closeFn, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("StorageFromEnv: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestStorageFromEnv_UnknownBackend(t *testing.T) {
 	clearStorageEnv(t)
 	t.Setenv("OAUTH_STORAGE_BACKEND", "postgres")
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "unknown backend") {
 		t.Fatalf("expected unknown-backend error, got %v", err)
 	}
@@ -74,7 +74,7 @@ func TestStorageFromEnv_ValkeyMissingAddress(t *testing.T) {
 	clearStorageEnv(t)
 	t.Setenv("OAUTH_STORAGE_BACKEND", "valkey")
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "VALKEY_ADDR") {
 		t.Fatalf("expected VALKEY_ADDR required error, got %v", err)
 	}
@@ -86,7 +86,7 @@ func TestStorageFromEnv_ValkeyBadDB(t *testing.T) {
 	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
 	t.Setenv("OAUTH_VALKEY_DB", "not-a-number")
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "VALKEY_DB") {
 		t.Fatalf("expected VALKEY_DB parse error, got %v", err)
 	}
@@ -98,7 +98,7 @@ func TestStorageFromEnv_ValkeyBadTLSBool(t *testing.T) {
 	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
 	t.Setenv("OAUTH_VALKEY_TLS", "maybe")
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "VALKEY_TLS") {
 		t.Fatalf("expected VALKEY_TLS bool parse error, got %v", err)
 	}
@@ -110,7 +110,7 @@ func TestStorageFromEnv_ValkeyBadMaxTokenDataSize(t *testing.T) {
 	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
 	t.Setenv("OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE", "not-an-int")
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "VALKEY_MAX_TOKEN_DATA_SIZE") {
 		t.Fatalf("expected VALKEY_MAX_TOKEN_DATA_SIZE parse error, got %v", err)
 	}
@@ -122,7 +122,7 @@ func TestStorageFromEnv_ValkeyMaxTokenDataSizeOutOfRange(t *testing.T) {
 	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
 	t.Setenv("OAUTH_VALKEY_MAX_TOKEN_DATA_SIZE", "1024") // below MinMaxTokenDataSize
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "MaxTokenDataSize") {
 		t.Fatalf("expected MaxTokenDataSize range error, got %v", err)
 	}
@@ -134,7 +134,7 @@ func TestStorageFromEnv_ValkeyBadRefreshTTL(t *testing.T) {
 	t.Setenv("OAUTH_VALKEY_ADDR", "unreachable:0")
 	t.Setenv("OAUTH_VALKEY_REFRESH_TOKEN_TTL", "not-a-duration")
 
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil || !strings.Contains(err.Error(), "VALKEY_REFRESH_TOKEN_TTL") {
 		t.Fatalf("expected VALKEY_REFRESH_TOKEN_TTL parse error, got %v", err)
 	}
@@ -155,7 +155,7 @@ func TestStorageFromEnv_ValkeyPasswordFilePrecedence(t *testing.T) {
 
 	// Connection will fail — we only care that the loader accepted the _FILE
 	// variant without erroring on password parsing.
-	_, _, err := oauthconfig.StorageFromEnv(slog.Default())
+	_, _, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err == nil {
 		t.Fatal("expected connection error against unreachable address")
 	}
@@ -170,7 +170,7 @@ func TestStorageFromEnvWithPrefix(t *testing.T) {
 	clearStorageEnv(t)
 	t.Setenv("MUSTER_OAUTH_STORAGE_BACKEND", "memory")
 
-	store, closeFn, err := oauthconfig.StorageFromEnvWithPrefix("MUSTER_OAUTH_", slog.Default())
+	store, closeFn, err := oauthconfig.StorageFromEnvWithPrefix("MUSTER_OAUTH_", nil, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("StorageFromEnvWithPrefix: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestStorageFromEnv_ValkeyLive(t *testing.T) {
 	t.Setenv("OAUTH_VALKEY_KEY_PREFIX", "oauthconfigtest:")
 	t.Setenv("OAUTH_VALKEY_REFRESH_TOKEN_TTL", "1h")
 
-	store, closeFn, err := oauthconfig.StorageFromEnv(slog.Default())
+	store, closeFn, err := oauthconfig.StorageFromEnv(nil, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("StorageFromEnv against live valkey: %v", err)
 	}

--- a/oauthconfig/turnkey_test.go
+++ b/oauthconfig/turnkey_test.go
@@ -58,7 +58,7 @@ func TestTurnkeyWiring(t *testing.T) {
 		t.Fatal("NewEncryptorFromEnv returned nil despite ENCRYPTION_KEY set")
 	}
 
-	store, closeFn, err := oauthconfig.StorageFromEnv(slog.Default())
+	store, closeFn, err := oauthconfig.StorageFromEnv(encryptor, nil, slog.Default())
 	if err != nil {
 		t.Fatalf("StorageFromEnv: %v", err)
 	}
@@ -69,12 +69,8 @@ func TestTurnkeyWiring(t *testing.T) {
 		t.Fatalf("ProviderFromEnv: %v", err)
 	}
 
-	// Attaching the encryptor via the WithEncryptor option is the documented
-	// path; prove it wires through without a panic, since the whole point of
-	// NewEncryptorFromEnv is to be composable with the server constructor.
 	srv, err := server.NewWithCombined(
 		provider, store, cfg, slog.Default(),
-		server.WithEncryptor(encryptor),
 	)
 	if err != nil {
 		t.Fatalf("server.NewWithCombined: %v", err)

--- a/server.go
+++ b/server.go
@@ -28,12 +28,6 @@ type ForwardedIDTokenAcceptance = server.ForwardedIDTokenAcceptance
 // Config.TrustedAudiences. Callers typically respond with 401.
 var ErrTrustedAudienceMismatch = server.ErrTrustedAudienceMismatch
 
-// WithEncryptor configures the token encryptor and propagates it to the
-// token store. See [server.WithEncryptor].
-func WithEncryptor(enc *security.Encryptor) ServerOption {
-	return server.WithEncryptor(enc)
-}
-
 // WithAuditor configures the security auditor. See [server.WithAuditor].
 func WithAuditor(aud *security.Auditor) ServerOption { return server.WithAuditor(aud) }
 

--- a/server/config.go
+++ b/server/config.go
@@ -257,12 +257,6 @@ type Config struct {
 	// Default: 0.5 (50% - at least half must succeed)
 	ProviderRevocationFailureThreshold float64 // default: 0.5
 
-	// RevokedFamilyRetentionDays is the number of days to retain revoked token family metadata
-	// for forensics and security auditing. After this period, revoked family metadata is deleted.
-	// Longer retention enables better security incident investigation but uses more memory.
-	// Default: 90 days (recommended for security compliance and forensics)
-	RevokedFamilyRetentionDays int64 // days, default: 90
-
 	// SupportedScopes lists the scopes that are allowed for clients
 	// If empty, all scopes are allowed
 	SupportedScopes []string

--- a/server/config_test.go
+++ b/server/config_test.go
@@ -337,14 +337,13 @@ func TestApplySecureDefaults(t *testing.T) {
 
 func TestValidateProviderRevocationConfig(t *testing.T) {
 	tests := []struct {
-		name                  string
-		config                *Config
-		expectWarning         bool
-		expectedWarningText   string
-		expectedTimeout       int64
-		expectedRetries       int
-		expectedThreshold     float64
-		expectedRetentionDays int64
+		name                string
+		config              *Config
+		expectWarning       bool
+		expectedWarningText string
+		expectedTimeout     int64
+		expectedRetries     int
+		expectedThreshold   float64
 	}{
 		{
 			name: "valid configuration - no warnings",
@@ -352,13 +351,11 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 				ProviderRevocationTimeout:          10,
 				ProviderRevocationMaxRetries:       3,
 				ProviderRevocationFailureThreshold: 0.5,
-				RevokedFamilyRetentionDays:         90,
 			},
-			expectWarning:         false,
-			expectedTimeout:       10,
-			expectedRetries:       3,
-			expectedThreshold:     0.5,
-			expectedRetentionDays: 90,
+			expectWarning:     false,
+			expectedTimeout:   10,
+			expectedRetries:   3,
+			expectedThreshold: 0.5,
 		},
 		{
 			name: "invalid timeout - too low",
@@ -366,14 +363,12 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 				ProviderRevocationTimeout:          -5,
 				ProviderRevocationMaxRetries:       3,
 				ProviderRevocationFailureThreshold: 0.5,
-				RevokedFamilyRetentionDays:         90,
 			},
-			expectWarning:         true,
-			expectedWarningText:   "Invalid ProviderRevocationTimeout",
-			expectedTimeout:       -5, // Should be caught and corrected later by applyTimeDefaults
-			expectedRetries:       3,
-			expectedThreshold:     0.5,
-			expectedRetentionDays: 90,
+			expectWarning:       true,
+			expectedWarningText: "Invalid ProviderRevocationTimeout",
+			expectedTimeout:     -5, // Should be caught and corrected later by applyTimeDefaults
+			expectedRetries:     3,
+			expectedThreshold:   0.5,
 		},
 		{
 			name: "invalid retries - negative",
@@ -381,14 +376,12 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 				ProviderRevocationTimeout:          10,
 				ProviderRevocationMaxRetries:       -1,
 				ProviderRevocationFailureThreshold: 0.5,
-				RevokedFamilyRetentionDays:         90,
 			},
-			expectWarning:         true,
-			expectedWarningText:   "Invalid ProviderRevocationMaxRetries",
-			expectedTimeout:       10,
-			expectedRetries:       -1,
-			expectedThreshold:     0.5,
-			expectedRetentionDays: 90,
+			expectWarning:       true,
+			expectedWarningText: "Invalid ProviderRevocationMaxRetries",
+			expectedTimeout:     10,
+			expectedRetries:     -1,
+			expectedThreshold:   0.5,
 		},
 		{
 			name: "invalid threshold - too high",
@@ -396,14 +389,12 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 				ProviderRevocationTimeout:          10,
 				ProviderRevocationMaxRetries:       3,
 				ProviderRevocationFailureThreshold: 1.5,
-				RevokedFamilyRetentionDays:         90,
 			},
-			expectWarning:         true,
-			expectedWarningText:   "Invalid ProviderRevocationFailureThreshold",
-			expectedTimeout:       10,
-			expectedRetries:       3,
-			expectedThreshold:     1.5,
-			expectedRetentionDays: 90,
+			expectWarning:       true,
+			expectedWarningText: "Invalid ProviderRevocationFailureThreshold",
+			expectedTimeout:     10,
+			expectedRetries:     3,
+			expectedThreshold:   1.5,
 		},
 		{
 			name: "invalid threshold - negative",
@@ -411,29 +402,12 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 				ProviderRevocationTimeout:          10,
 				ProviderRevocationMaxRetries:       3,
 				ProviderRevocationFailureThreshold: -0.5,
-				RevokedFamilyRetentionDays:         90,
 			},
-			expectWarning:         true,
-			expectedWarningText:   "Invalid ProviderRevocationFailureThreshold",
-			expectedTimeout:       10,
-			expectedRetries:       3,
-			expectedThreshold:     -0.5,
-			expectedRetentionDays: 90,
-		},
-		{
-			name: "invalid retention - negative",
-			config: &Config{
-				ProviderRevocationTimeout:          10,
-				ProviderRevocationMaxRetries:       3,
-				ProviderRevocationFailureThreshold: 0.5,
-				RevokedFamilyRetentionDays:         -10,
-			},
-			expectWarning:         true,
-			expectedWarningText:   "Invalid RevokedFamilyRetentionDays",
-			expectedTimeout:       10,
-			expectedRetries:       3,
-			expectedThreshold:     0.5,
-			expectedRetentionDays: -10,
+			expectWarning:       true,
+			expectedWarningText: "Invalid ProviderRevocationFailureThreshold",
+			expectedTimeout:     10,
+			expectedRetries:     3,
+			expectedThreshold:   -0.5,
 		},
 	}
 
@@ -456,8 +430,6 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 				}
 			}
 
-			// Note: Values are not corrected in validateProviderRevocationConfig
-			// They are corrected later in applyTimeDefaults
 			if tt.config.ProviderRevocationTimeout != tt.expectedTimeout {
 				t.Errorf("ProviderRevocationTimeout = %d, want %d", tt.config.ProviderRevocationTimeout, tt.expectedTimeout)
 			}
@@ -466,9 +438,6 @@ func TestValidateProviderRevocationConfig(t *testing.T) {
 			}
 			if tt.config.ProviderRevocationFailureThreshold != tt.expectedThreshold {
 				t.Errorf("ProviderRevocationFailureThreshold = %f, want %f", tt.config.ProviderRevocationFailureThreshold, tt.expectedThreshold)
-			}
-			if tt.config.RevokedFamilyRetentionDays != tt.expectedRetentionDays {
-				t.Errorf("RevokedFamilyRetentionDays = %d, want %d", tt.config.RevokedFamilyRetentionDays, tt.expectedRetentionDays)
 			}
 		})
 	}

--- a/server/config_validation.go
+++ b/server/config_validation.go
@@ -107,11 +107,6 @@ func applyProviderRevocationDefaults(config *Config) {
 		config.ProviderRevocationFailureThreshold = 0.5
 	}
 
-	if config.RevokedFamilyRetentionDays == 0 {
-		config.RevokedFamilyRetentionDays = 90 // 90 days
-	} else if config.RevokedFamilyRetentionDays < 1 {
-		config.RevokedFamilyRetentionDays = 7 // Minimum 1 week
-	}
 }
 
 // applyRateLimitDefaults sets defaults for rate limiting configuration.
@@ -152,7 +147,6 @@ func validateProviderRevocationConfig(config *Config, logger *slog.Logger) {
 	origTimeout := config.ProviderRevocationTimeout
 	origRetries := config.ProviderRevocationMaxRetries
 	origThreshold := config.ProviderRevocationFailureThreshold
-	origRetention := config.RevokedFamilyRetentionDays
 
 	hasInvalidValues := false
 
@@ -183,22 +177,12 @@ func validateProviderRevocationConfig(config *Config, logger *slog.Logger) {
 		hasInvalidValues = true
 	}
 
-	// Validate and correct retention
-	if origRetention != 0 && origRetention < 1 {
-		logger.Warn("CONFIGURATION WARNING: Invalid RevokedFamilyRetentionDays corrected",
-			"provided_value", origRetention,
-			"corrected_to", config.RevokedFamilyRetentionDays,
-			"reason", "retention must be at least 1 day")
-		hasInvalidValues = true
-	}
-
 	// Log final configuration if everything is valid
 	if !hasInvalidValues {
 		logger.Debug("Provider revocation configuration validated",
 			"timeout_seconds", config.ProviderRevocationTimeout,
 			"max_retries", config.ProviderRevocationMaxRetries,
-			"failure_threshold", config.ProviderRevocationFailureThreshold,
-			"retention_days", config.RevokedFamilyRetentionDays)
+			"failure_threshold", config.ProviderRevocationFailureThreshold)
 	}
 }
 

--- a/server/logvalue.go
+++ b/server/logvalue.go
@@ -11,17 +11,17 @@ import (
 //
 //	logger.Info("oauth server initialized", "server", srv)
 //
-// Fields are limited to state that is either derived (encryption-enabled,
-// instrumentation-wired) or mutated by [applySecureDefaults] (production
-// mode, redirect-URI validation flags) — i.e. state the caller's
-// pre-build Config does not faithfully reflect.
+// Fields are limited to state that is either derived (instrumentation-wired)
+// or mutated by [applySecureDefaults] (production mode, redirect-URI
+// validation flags) — i.e. state the caller's pre-build Config does not
+// faithfully reflect. Encryption status is reported by the store's own
+// LogValue; the server no longer holds the encryptor.
 func (s *Server) LogValue() slog.Value {
 	cfg := s.Config
 	attrs := []slog.Attr{
 		slog.String("issuer", cfg.Issuer),
 		slog.Bool("production_mode", cfg.ProductionMode),
 		slog.String("access_token_format", string(cfg.AccessTokenFormat)),
-		slog.Bool("encryption_at_rest", s.Encryptor != nil && s.Encryptor.IsEnabled()),
 		slog.Bool("instrumentation_on", s.Instrumentation.IsEnabled()),
 		slog.Group(
 			"redirect_uri_policy",

--- a/server/logvalue_test.go
+++ b/server/logvalue_test.go
@@ -76,7 +76,6 @@ func TestServer_LogValue_ExposesEffectiveConfig(t *testing.T) {
 	require.True(t, ok, "expected server group in log payload, got %v", payload)
 	require.Equal(t, "https://oauth.example.com", server["issuer"])
 	require.Equal(t, true, server["production_mode"], "applySecureDefaults should flip production_mode on")
-	require.Equal(t, false, server["encryption_at_rest"])
 	require.Equal(t, false, server["instrumentation_on"])
 
 	policy, ok := server["redirect_uri_policy"].(map[string]any)

--- a/server/options.go
+++ b/server/options.go
@@ -8,28 +8,8 @@ import (
 	"github.com/giantswarm/mcp-oauth/storage"
 )
 
-// Option configures a Server during construction. Options are applied
-// after the server has been wired with stores, the access-token issuer,
-// and the metadata support goroutine — so option functions that propagate
-// state to the storage backend (WithEncryptor, WithInstrumentation) can
-// rely on the store being attached.
+// Option configures a Server during construction.
 type Option func(*Server)
-
-// WithEncryptor sets the token encryptor on the server and propagates it
-// to the token store when the store implements an SetEncryptor hook.
-// Token-at-rest encryption applies to upstream provider tokens stored in
-// TokenStore — the bearer the client holds is never the encrypted payload.
-func WithEncryptor(enc *security.Encryptor) Option {
-	return func(s *Server) {
-		s.Encryptor = enc
-		type encryptorSetter interface {
-			SetEncryptor(*security.Encryptor)
-		}
-		if setter, ok := s.tokenStore.(encryptorSetter); ok {
-			setter.SetEncryptor(enc)
-		}
-	}
-}
 
 // WithAuditor sets the security auditor used for OAuth audit events.
 // Passing nil panics; use security.NewAuditor(nil, false) for a noop.
@@ -194,10 +174,9 @@ func WithTrustedProxyCIDRs(cidrs []*net.IPNet) Option {
 
 // WithInstrumentation installs an OpenTelemetry pipeline on the server.
 // Build the *instrumentation.Instrumentation with instrumentation.New and
-// pass it here. The same instance can be shared with other components in
-// the process — that's the reason the OAuth library does not own the
-// pipeline construction. Propagates the instrumentation to storage
-// backends that implement SetInstrumentation.
+// pass it here. The same instance should be passed to the storage constructor
+// (memory.WithInstrumentation / valkey.WithInstrumentation) so both the
+// server and the store share one pipeline.
 func WithInstrumentation(inst *instrumentation.Instrumentation) Option {
 	return func(s *Server) {
 		s.Instrumentation = inst
@@ -205,18 +184,5 @@ func WithInstrumentation(inst *instrumentation.Instrumentation) Option {
 			return
 		}
 		s.tracer = inst.Tracer("server")
-
-		type instrumentationSetter interface {
-			SetInstrumentation(*instrumentation.Instrumentation)
-		}
-		if setter, ok := s.tokenStore.(instrumentationSetter); ok {
-			setter.SetInstrumentation(inst)
-		}
-		if setter, ok := s.clientStore.(instrumentationSetter); ok {
-			setter.SetInstrumentation(inst)
-		}
-		if setter, ok := s.flowStore.(instrumentationSetter); ok {
-			setter.SetInstrumentation(inst)
-		}
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,6 @@ type Server struct {
 	sessionCreationHandler        SessionCreationHandler
 	sessionRevocationHandler      SessionRevocationHandler
 	tokenRefreshHandler           TokenRefreshHandler
-	Encryptor                     *security.Encryptor
 	Auditor                       *security.Auditor
 	RateLimiter                   *security.RateLimiter                   // IP-based rate limiter
 	UserRateLimiter               *security.RateLimiter                   // User-based rate limiter (authenticated requests)
@@ -186,7 +185,6 @@ func New(
 
 	srv.attachRevokedTokenStore(tokenStore)
 
-	configureStorageRetention(tokenStore, config)
 	srv.initializeMetadataSupport()
 	srv.validateProviderDefaultScopes(logger)
 	srv.logForwardedSessionIDKeyFingerprint()
@@ -281,16 +279,6 @@ func applyDefaults(config *Config, logger *slog.Logger) (*Config, *slog.Logger) 
 		logger = slog.Default()
 	}
 	return applySecureDefaults(config, logger), logger
-}
-
-// configureStorageRetention sets retention days on storage if it supports it.
-func configureStorageRetention(tokenStore storage.TokenStore, config *Config) {
-	type retentionSetter interface {
-		SetRevokedFamilyRetentionDays(days int64)
-	}
-	if setter, ok := tokenStore.(retentionSetter); ok {
-		setter.SetRevokedFamilyRetentionDays(config.RevokedFamilyRetentionDays)
-	}
 }
 
 // initializeMetadataSupport initializes client ID metadata document support if enabled.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -126,23 +126,12 @@ func TestNew_MissingFlowStore(t *testing.T) {
 }
 
 // TestServer_OptionsAreAppliedAndPropagate verifies the With* constructor
-// options install dependencies on the server and, where applicable,
-// propagate them to the storage backend. Replaces the per-setter tests
-// that were tautological after Set* methods were converted to options.
+// options install dependencies on the server.
 func TestServer_OptionsAreAppliedAndPropagate(t *testing.T) {
 	store := memory.New()
 	defer store.Stop()
 
 	provider := mock.NewProvider()
-
-	key, err := security.GenerateKey()
-	if err != nil {
-		t.Fatalf("GenerateKey() error = %v", err)
-	}
-	enc, err := security.NewEncryptor(key)
-	if err != nil {
-		t.Fatalf("NewEncryptor() error = %v", err)
-	}
 
 	auditor := security.NewAuditor(nil, true)
 	rl := security.NewRateLimiter(10, 20, nil)
@@ -154,7 +143,6 @@ func TestServer_OptionsAreAppliedAndPropagate(t *testing.T) {
 
 	srv, err := New(
 		provider, store, store, store, &Config{Issuer: "https://test.example.com"}, nil,
-		WithEncryptor(enc),
 		WithAuditor(auditor),
 		WithRateLimiter(rl),
 		WithUserRateLimiter(userRL),
@@ -164,9 +152,6 @@ func TestServer_OptionsAreAppliedAndPropagate(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	if srv.Encryptor != enc {
-		t.Error("WithEncryptor: server Encryptor not set to the option value")
-	}
 	if srv.Auditor != auditor {
 		t.Error("WithAuditor: server Auditor not set to the option value")
 	}
@@ -178,19 +163,6 @@ func TestServer_OptionsAreAppliedAndPropagate(t *testing.T) {
 	}
 	if srv.SecurityEventRateLimiter != secEventRL {
 		t.Error("WithSecurityEventRateLimiter: server SecurityEventRateLimiter not set to the option value")
-	}
-
-	// WithEncryptor also propagates to a storage backend that exposes
-	// SetEncryptor — the memory store does. The propagation hook is
-	// the only behavior the deleted Set* methods had beyond a field
-	// write, so it gets explicit coverage here.
-	type encryptorReader interface {
-		Encryptor() *security.Encryptor
-	}
-	if reader, ok := any(store).(encryptorReader); ok {
-		if reader.Encryptor() != enc {
-			t.Error("WithEncryptor: encryptor not propagated to the token store")
-		}
 	}
 }
 
@@ -226,9 +198,6 @@ func TestServer_ProviderRevocationConfigDefaults(t *testing.T) {
 		t.Errorf("ProviderRevocationFailureThreshold = %f, want 0.5 (default)", srv.Config.ProviderRevocationFailureThreshold)
 	}
 
-	if srv.Config.RevokedFamilyRetentionDays != 90 {
-		t.Errorf("RevokedFamilyRetentionDays = %d, want 90 (default)", srv.Config.RevokedFamilyRetentionDays)
-	}
 }
 
 // TestServer_ProviderRevocationConfigCustomValues tests custom values are preserved
@@ -245,7 +214,6 @@ func TestServer_ProviderRevocationConfigCustomValues(t *testing.T) {
 		ProviderRevocationTimeout:          30,
 		ProviderRevocationMaxRetries:       5,
 		ProviderRevocationFailureThreshold: 0.3,
-		RevokedFamilyRetentionDays:         180,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -266,36 +234,8 @@ func TestServer_ProviderRevocationConfigCustomValues(t *testing.T) {
 		t.Errorf("ProviderRevocationFailureThreshold = %f, want 0.3 (custom)", srv.Config.ProviderRevocationFailureThreshold)
 	}
 
-	if srv.Config.RevokedFamilyRetentionDays != 180 {
-		t.Errorf("RevokedFamilyRetentionDays = %d, want 180 (custom)", srv.Config.RevokedFamilyRetentionDays)
-	}
 }
 
-// TestServer_RevokedFamilyRetentionPropagation tests retention period propagates to storage
-// P2: Feature integration test
-func TestServer_RevokedFamilyRetentionPropagation(t *testing.T) {
-	store := memory.New()
-	defer store.Stop()
-
-	provider := mock.NewProvider()
-
-	config := &Config{
-		Issuer:                     "https://auth.example.com",
-		RevokedFamilyRetentionDays: 120,
-	}
-
-	_, err := New(provider, store, store, store, config, nil)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-
-	// Memory store implements the retention setter interface
-	// Verify it was called (we can't directly check private field, but can verify no error)
-	// The actual retention behavior is tested in memory store tests
-
-	// If we get here without panic, the type assertion and call succeeded
-	t.Log("Retention period propagation test passed - no error during setup")
-}
 
 // TestGenerateRandomToken_Length validates that generated tokens meet minimum length requirements
 // This ensures sufficient entropy for security-critical tokens.

--- a/storage/memory/doc.go
+++ b/storage/memory/doc.go
@@ -16,9 +16,16 @@
 //
 // Example usage:
 //
+//	// Plain store (no encryption, default 1m cleanup interval):
 //	store := memory.New()
 //	defer store.Stop()
 //
-//	// Use store for TokenStore, ClientStore, and FlowStore interfaces
+//	// With encryption at rest and a custom cleanup interval:
+//	key, _ := security.GenerateKey()
+//	enc, _ := security.NewEncryptor(key)
+//	store := memory.New(memory.WithEncryptor(enc), memory.WithCleanupInterval(30*time.Second))
+//	defer store.Stop()
+//
+//	// Use store for TokenStore, ClientStore, and FlowStore interfaces:
 //	server, _ := oauth.NewServer(provider, store, store, store, config, logger)
 package memory

--- a/storage/memory/logvalue_test.go
+++ b/storage/memory/logvalue_test.go
@@ -40,16 +40,16 @@ func TestStore_Construction_EmitsNoInfo(t *testing.T) {
 	h := &captureHandler{}
 	logger := slog.New(h)
 
-	store := New()
-	store.SetLogger(logger)
-	store.SetRevokedFamilyRetentionDays(30)
-
 	key, err := security.GenerateKey()
 	require.NoError(t, err)
 	enc, err := security.NewEncryptor(key)
 	require.NoError(t, err)
-	store.SetEncryptor(enc)
-	store.SetInstrumentation(nil) // nil-safe path
+
+	_ = New(
+		WithLogger(logger),
+		WithRevokedFamilyRetentionDays(30),
+		WithEncryptor(enc),
+	)
 
 	if got := h.infoLines(); len(got) != 0 {
 		t.Fatalf("store construction emitted %d INFO record(s); want 0:\n%s",
@@ -73,15 +73,16 @@ func TestStore_LogValue_ReflectsPosture(t *testing.T) {
 	require.Equal(t, false, got["encryption_at_rest"])
 	require.Equal(t, false, got["instrumentation_on"])
 
-	// Enable encryption and verify the snapshot updates.
+	// A store built with an encryptor reports encryption_at_rest=true.
 	key, err := security.GenerateKey()
 	require.NoError(t, err)
 	enc, err := security.NewEncryptor(key)
 	require.NoError(t, err)
-	store.SetEncryptor(enc)
+	storeWithEnc := New(WithEncryptor(enc))
+	defer storeWithEnc.Stop()
 
 	buf.Reset()
-	logger.Info("snapshot", "store", store)
+	logger.Info("snapshot", "store", storeWithEnc)
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &payload))
 	got = payload["store"].(map[string]any)
 	require.Equal(t, true, got["encryption_at_rest"])

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -120,32 +120,46 @@ var (
 	_ storage.ActiveRefreshTokenByFamilyStore = (*Store)(nil)
 )
 
-// New creates a new in-memory store with default cleanup interval (1 minute)
-// and default revoked family retention (90 days)
-func New() *Store {
-	return NewWithInterval(time.Minute)
+// Option configures a Store at construction time.
+type Option func(*Store)
+
+// WithEncryptor enables AES-256-GCM encryption at rest for all stored tokens.
+// Encryption is optional; omit to store tokens in plaintext.
+func WithEncryptor(enc *security.Encryptor) Option {
+	return func(s *Store) { s.encryptor = enc }
 }
 
-// SetRevokedFamilyRetentionDays sets the retention period for revoked token family metadata.
-// This should be called after New() and before starting the server.
-// The retention period is used for forensics and security auditing.
-// Default: 90 days (if not set)
-func (s *Store) SetRevokedFamilyRetentionDays(days int64) {
-	s.mu.Lock()
-	s.revokedFamilyRetentionDays = days
-	s.mu.Unlock()
-	s.logger.Debug("revoked family retention period set",
-		"retention_days", days,
-		"store", s)
+// WithInstrumentation wires OpenTelemetry tracing and metrics into the store.
+func WithInstrumentation(inst *instrumentation.Instrumentation) Option {
+	return func(s *Store) { s.instrumentation = inst }
 }
 
-// NewWithInterval creates a new in-memory store with custom cleanup interval.
-// If cleanupInterval is 0 or negative, uses default of 1 minute.
-func NewWithInterval(cleanupInterval time.Duration) *Store {
-	if cleanupInterval <= 0 {
-		cleanupInterval = time.Minute
+// WithLogger replaces the default slog.Default() logger.
+func WithLogger(logger *slog.Logger) Option {
+	return func(s *Store) { s.logger = logger }
+}
+
+// WithCleanupInterval sets the background cleanup tick interval.
+// Values ≤ 0 are clamped to 1 minute.
+func WithCleanupInterval(d time.Duration) Option {
+	return func(s *Store) {
+		if d <= 0 {
+			d = time.Minute
+		}
+		s.cleanupInterval = d
 	}
+}
 
+// WithRevokedFamilyRetentionDays sets how long revoked token family metadata
+// is kept for security forensics. Default is 90 days.
+func WithRevokedFamilyRetentionDays(days int64) Option {
+	return func(s *Store) { s.revokedFamilyRetentionDays = days }
+}
+
+// New creates a new in-memory store. All dependencies (encryptor,
+// instrumentation, logger) are supplied at construction via options and are
+// immutable afterward.
+func New(opts ...Option) *Store {
 	s := &Store{
 		tokens:                     make(map[string]*oauth2.Token),
 		userInfo:                   make(map[string]*providers.UserInfo),
@@ -157,68 +171,36 @@ func NewWithInterval(cleanupInterval time.Duration) *Store {
 		clientsPerIP:               make(map[string]int),
 		authStates:                 make(map[string]*storage.AuthorizationState),
 		authCodes:                  make(map[string]*storage.AuthorizationCode),
-		cleanupInterval:            cleanupInterval,
-		revokedFamilyRetentionDays: 90, // default: 90 days for security auditing
+		cleanupInterval:            time.Minute,
+		revokedFamilyRetentionDays: 90,
 		stopCleanup:                make(chan struct{}),
 		logger:                     slog.Default(),
 	}
 
-	// Start background cleanup
-	go s.cleanupLoop()
-
-	return s
-}
-
-// SetLogger sets a custom logger
-func (s *Store) SetLogger(logger *slog.Logger) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.logger = logger
-}
-
-// SetEncryptor sets the token encryptor for encryption at rest
-func (s *Store) SetEncryptor(enc *security.Encryptor) {
-	s.mu.Lock()
-	s.encryptor = enc
-	s.mu.Unlock()
-	if enc != nil && enc.IsEnabled() {
-		s.logger.Debug("token encryption at rest enabled", "store", s)
-	}
-}
-
-// SetInstrumentation sets OpenTelemetry instrumentation for the store
-func (s *Store) SetInstrumentation(inst *instrumentation.Instrumentation) {
-	s.mu.Lock()
-	s.instrumentation = inst
-	if inst != nil {
-		s.tracer = inst.Tracer("storage")
-		s.meter = inst.Meter("storage")
+	for _, opt := range opts {
+		opt(s)
 	}
 
-	// Initialize atomic counters with current counts
-	s.tokensCountAtomic.Store(int64(len(s.tokens)))
-	s.clientsCountAtomic.Store(int64(len(s.clients)))
-	s.authStatesCountAtomic.Store(int64(len(s.authStates)))
-	s.familiesCountAtomic.Store(int64(len(s.refreshTokenFamilies)))
-	s.refreshTokensCountAtomic.Store(int64(len(s.refreshTokens)))
-	s.mu.Unlock()
-
-	if inst != nil {
-		// Register storage size callbacks using atomic counters (lock-free)
-		// These callbacks provide real-time visibility into storage size for
-		// capacity planning, memory leak detection, and DoS attack monitoring
-		err := inst.RegisterStorageSizeCallbacks(
+	if s.instrumentation != nil {
+		s.tracer = s.instrumentation.Tracer("storage")
+		s.meter = s.instrumentation.Meter("storage")
+		if err := s.instrumentation.RegisterStorageSizeCallbacks(
 			func() int64 { return s.tokensCountAtomic.Load() },
 			func() int64 { return s.clientsCountAtomic.Load() },
 			func() int64 { return s.authStatesCountAtomic.Load() },
 			func() int64 { return s.familiesCountAtomic.Load() },
 			func() int64 { return s.refreshTokensCountAtomic.Load() },
-		)
-		if err != nil {
+		); err != nil {
 			s.logger.Warn("Failed to register storage size callbacks", "error", err)
 		}
 		s.logger.Debug("storage instrumentation enabled", "store", s)
 	}
+	if s.encryptor != nil && s.encryptor.IsEnabled() {
+		s.logger.Debug("token encryption at rest enabled", "store", s)
+	}
+
+	go s.cleanupLoop()
+	return s
 }
 
 // Stop gracefully stops the cleanup goroutine

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -995,21 +995,18 @@ func TestStore_DeleteAuthorizationCode(t *testing.T) {
 
 func TestStore_TokenEncryption(t *testing.T) {
 	ctx := context.Background()
-	store := New()
-	defer store.Stop()
 
-	// Set up encryption
 	key, err := security.GenerateKey()
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-
 	encryptor, err := security.NewEncryptor(key)
 	if err != nil {
 		t.Fatalf("NewEncryptor() error = %v", err)
 	}
 
-	store.SetEncryptor(encryptor)
+	store := New(WithEncryptor(encryptor))
+	defer store.Stop()
 
 	// Save token
 	token := testutil.GenerateTestToken()
@@ -1037,21 +1034,18 @@ func TestStore_TokenEncryption(t *testing.T) {
 // This is a regression test for issue #133.
 func TestStore_TokenEncryption_PreservesExtraField(t *testing.T) {
 	ctx := context.Background()
-	store := New()
-	defer store.Stop()
 
-	// Set up encryption
 	key, err := security.GenerateKey()
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-
 	encryptor, err := security.NewEncryptor(key)
 	if err != nil {
 		t.Fatalf("NewEncryptor() error = %v", err)
 	}
 
-	store.SetEncryptor(encryptor)
+	store := New(WithEncryptor(encryptor))
+	defer store.Stop()
 
 	// Create token with Extra fields (simulating OIDC provider response)
 	baseToken := testutil.GenerateTestToken()
@@ -1350,21 +1344,18 @@ func TestEncryptExtraFields_DisabledEncryptor(t *testing.T) {
 // encrypted in storage, not just preserved. This is a security test.
 func TestStore_TokenEncryption_IDTokenIsEncrypted(t *testing.T) {
 	ctx := context.Background()
-	store := New()
-	defer store.Stop()
 
-	// Set up encryption
 	key, err := security.GenerateKey()
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-
 	encryptor, err := security.NewEncryptor(key)
 	if err != nil {
 		t.Fatalf("NewEncryptor() error = %v", err)
 	}
 
-	store.SetEncryptor(encryptor)
+	store := New(WithEncryptor(encryptor))
+	defer store.Stop()
 
 	// Create token with id_token
 	baseToken := testutil.GenerateTestToken()
@@ -1482,7 +1473,7 @@ func TestStore_ConcurrentClientAccess(t *testing.T) {
 func TestStore_CleanupExpiredTokens(t *testing.T) {
 	ctx := context.Background()
 	// Use short cleanup interval for testing
-	store := NewWithInterval(100 * time.Millisecond)
+	store := New(WithCleanupInterval(100 * time.Millisecond))
 	defer store.Stop()
 
 	// Save expired authorization code
@@ -1504,7 +1495,7 @@ func TestStore_CleanupExpiredTokens(t *testing.T) {
 
 func TestStore_CleanupExpiredTokens_WithRefreshToken(t *testing.T) {
 	ctx := context.Background()
-	store := NewWithInterval(100 * time.Millisecond)
+	store := New(WithCleanupInterval(100 * time.Millisecond))
 	defer store.Stop()
 
 	refreshTokenKey := "mcp-refresh-token-1" //nolint:gosec // test value, not a real credential
@@ -1553,7 +1544,7 @@ func TestStore_CleanupExpiredTokens_WithRefreshToken(t *testing.T) {
 
 func TestStore_CleanupExpiredTokens_WithRefreshToken_NoMapping(t *testing.T) {
 	ctx := context.Background()
-	store := NewWithInterval(100 * time.Millisecond)
+	store := New(WithCleanupInterval(100 * time.Millisecond))
 	defer store.Stop()
 
 	// Save a provider token with a RefreshToken under a user ID key.
@@ -1580,14 +1571,10 @@ func TestStore_CleanupExpiredTokens_WithRefreshToken_NoMapping(t *testing.T) {
 	}
 }
 
-func TestStore_SetLogger(_ *testing.T) {
-	store := New()
-	defer store.Stop()
-
+func TestStore_WithLogger(_ *testing.T) {
 	logger := &slog.Logger{}
-	store.SetLogger(logger)
-
-	// Logger should be set (we can't easily test this without reflection)
+	store := New(WithLogger(logger))
+	defer store.Stop()
 	// Just verify no panic
 }
 

--- a/storage/valkey/doc.go
+++ b/storage/valkey/doc.go
@@ -73,7 +73,7 @@
 //   - Constant-time bcrypt comparison prevents timing attacks in client validation
 //   - TLS support enables encrypted connections to Valkey servers
 //   - Family metadata is retained for configurable period for security forensics
-//   - Optional token encryption at rest via SetEncryptor() using AES-256-GCM
+//   - Optional token encryption at rest via WithEncryptor() using AES-256-GCM
 //   - Input size validation prevents DoS attacks via oversized payloads
 //   - Generic error messages prevent information leakage
 //
@@ -84,7 +84,7 @@
 //
 //	key, _ := security.GenerateKey()
 //	encryptor, _ := security.NewEncryptor(key)
-//	store.SetEncryptor(encryptor)
+//	store, err := valkey.New(cfg, valkey.WithEncryptor(encryptor))
 //
 // When enabled, tokens are encrypted with AES-256-GCM before storage and
 // automatically decrypted when retrieved.

--- a/storage/valkey/logvalue.go
+++ b/storage/valkey/logvalue.go
@@ -11,17 +11,9 @@ import (
 //
 //	logger.Info("storage initialized", "store", store)
 func (s *Store) LogValue() slog.Value {
-	s.encryptorMu.RLock()
-	enc := s.encryptor
-	s.encryptorMu.RUnlock()
-
-	s.instMu.RLock()
-	inst := s.inst
-	s.instMu.RUnlock()
-
 	return slog.GroupValue(
 		slog.String("backend", storage.BackendValkey),
-		slog.Bool("encryption_at_rest", enc != nil && enc.IsEnabled()),
-		slog.Bool("instrumentation_on", inst != nil),
+		slog.Bool("encryption_at_rest", s.encryptor != nil && s.encryptor.IsEnabled()),
+		slog.Bool("instrumentation_on", s.inst != nil),
 	)
 }

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -179,21 +179,7 @@ func New(cfg Config, opts ...Option) (*Store, error) {
 		return nil, fmt.Errorf("MaxTokenDataSize=%d out of range [%d,%d]", maxTokenDataSize, MinMaxTokenDataSize, MaxMaxTokenDataSize)
 	}
 
-	// Build client options
-	clientOpts := valkeygo.ClientOption{
-		InitAddress: []string{cfg.Address},
-		SelectDB:    cfg.DB,
-	}
-
-	if cfg.Password != "" {
-		clientOpts.Password = cfg.Password
-	}
-
-	if cfg.TLS != nil {
-		clientOpts.TLSConfig = cfg.TLS
-	}
-
-	client, err := valkeygo.NewClient(clientOpts)
+	client, err := valkeygo.NewClient(buildClientOpts(cfg))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create valkey client: %w", err)
 	}
@@ -220,23 +206,7 @@ func New(cfg Config, opts ...Option) (*Store, error) {
 		opt(s)
 	}
 
-	if s.inst != nil {
-		s.tracer = s.inst.Tracer("storage")
-		s.meter = s.inst.Meter("storage")
-		if err := s.inst.RegisterStorageSizeCallbacks(
-			func() int64 { return s.countKeysByPattern(s.prefix + "token:*") },
-			func() int64 { return s.countKeysByPattern(s.prefix + "client:*") },
-			func() int64 { return s.countKeysByPattern(s.prefix + "state:*") },
-			func() int64 { return s.countKeysByPattern(s.prefix + "family:*") },
-			func() int64 { return s.countKeysByPattern(s.prefix + "refresh:*") },
-		); err != nil {
-			logger.Warn("Failed to register storage size callbacks", "error", err)
-		}
-		logger.Debug("storage instrumentation enabled", "store", s)
-	}
-	if s.encryptor != nil && s.encryptor.IsEnabled() {
-		logger.Debug("token encryption at rest enabled", "store", s)
-	}
+	s.wireInstrumentation(logger)
 
 	logger.Debug("storage connected", "store", s)
 	return s, nil
@@ -260,6 +230,43 @@ func WithEncryptor(enc *security.Encryptor) Option {
 // WithInstrumentation wires OpenTelemetry tracing and metrics into the store.
 func WithInstrumentation(inst *instrumentation.Instrumentation) Option {
 	return func(s *Store) { s.inst = inst }
+}
+
+// buildClientOpts converts a Config into the valkey-go client option struct.
+func buildClientOpts(cfg Config) valkeygo.ClientOption {
+	opts := valkeygo.ClientOption{
+		InitAddress: []string{cfg.Address},
+		SelectDB:    cfg.DB,
+	}
+	if cfg.Password != "" {
+		opts.Password = cfg.Password
+	}
+	if cfg.TLS != nil {
+		opts.TLSConfig = cfg.TLS
+	}
+	return opts
+}
+
+// wireInstrumentation activates OTel tracing/metrics and logs initial state.
+// Called once at the end of New after all options have been applied.
+func (s *Store) wireInstrumentation(logger *slog.Logger) {
+	if s.inst != nil {
+		s.tracer = s.inst.Tracer("storage")
+		s.meter = s.inst.Meter("storage")
+		if err := s.inst.RegisterStorageSizeCallbacks(
+			func() int64 { return s.countKeysByPattern(s.prefix + "token:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "client:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "state:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "family:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "refresh:*") },
+		); err != nil {
+			logger.Warn("Failed to register storage size callbacks", "error", err)
+		}
+		logger.Debug("storage instrumentation enabled", "store", s)
+	}
+	if s.encryptor != nil && s.encryptor.IsEnabled() {
+		logger.Debug("token encryption at rest enabled", "store", s)
+	}
 }
 
 // countKeysByPattern counts keys matching a glob pattern using SCAN.

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 	"time"
 
 	valkeygo "github.com/valkey-io/valkey-go"
@@ -122,17 +121,13 @@ type Store struct {
 	refreshTokenTTL            time.Duration
 	maxTokenDataSize           int
 
-	// encryptor provides optional token encryption at rest
-	// Access must be synchronized via encryptorMu
-	encryptor   *security.Encryptor
-	encryptorMu sync.RWMutex
+	// encryptor provides optional token encryption at rest; immutable after New.
+	encryptor *security.Encryptor
 
-	// Instrumentation for metrics and tracing
-	// Access must be synchronized via instMu
+	// Instrumentation fields; immutable after New.
 	inst   *instrumentation.Instrumentation
 	tracer trace.Tracer
 	meter  metric.Meter
-	instMu sync.RWMutex
 }
 
 // Compile-time interface checks to ensure Store implements all storage interfaces
@@ -148,9 +143,10 @@ var (
 	_ storage.ActiveRefreshTokenByFamilyStore = (*Store)(nil)
 )
 
-// New creates a new Valkey-backed storage instance.
-// Returns an error if the connection cannot be established.
-func New(cfg Config) (*Store, error) {
+// New creates a new Valkey-backed storage instance. All dependencies
+// (encryptor, instrumentation) are supplied at construction via options and
+// are immutable afterward. Returns an error if the connection cannot be established.
+func New(cfg Config, opts ...Option) (*Store, error) {
 	if cfg.Address == "" {
 		return nil, fmt.Errorf("valkey address is required")
 	}
@@ -184,20 +180,20 @@ func New(cfg Config) (*Store, error) {
 	}
 
 	// Build client options
-	opts := valkeygo.ClientOption{
+	clientOpts := valkeygo.ClientOption{
 		InitAddress: []string{cfg.Address},
 		SelectDB:    cfg.DB,
 	}
 
 	if cfg.Password != "" {
-		opts.Password = cfg.Password
+		clientOpts.Password = cfg.Password
 	}
 
 	if cfg.TLS != nil {
-		opts.TLSConfig = cfg.TLS
+		clientOpts.TLSConfig = cfg.TLS
 	}
 
-	client, err := valkeygo.NewClient(opts)
+	client, err := valkeygo.NewClient(clientOpts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create valkey client: %w", err)
 	}
@@ -219,6 +215,29 @@ func New(cfg Config) (*Store, error) {
 		refreshTokenTTL:            refreshTokenTTL,
 		maxTokenDataSize:           maxTokenDataSize,
 	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	if s.inst != nil {
+		s.tracer = s.inst.Tracer("storage")
+		s.meter = s.inst.Meter("storage")
+		if err := s.inst.RegisterStorageSizeCallbacks(
+			func() int64 { return s.countKeysByPattern(s.prefix + "token:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "client:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "state:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "family:*") },
+			func() int64 { return s.countKeysByPattern(s.prefix + "refresh:*") },
+		); err != nil {
+			logger.Warn("Failed to register storage size callbacks", "error", err)
+		}
+		logger.Debug("storage instrumentation enabled", "store", s)
+	}
+	if s.encryptor != nil && s.encryptor.IsEnabled() {
+		logger.Debug("token encryption at rest enabled", "store", s)
+	}
+
 	logger.Debug("storage connected", "store", s)
 	return s, nil
 }
@@ -229,58 +248,18 @@ func (s *Store) Close() {
 	s.logger.Debug("storage connection closed", "store", s)
 }
 
-// SetLogger sets a custom logger for the store.
-func (s *Store) SetLogger(logger *slog.Logger) {
-	s.logger = logger
+// Option configures a Store at construction time.
+type Option func(*Store)
+
+// WithEncryptor enables AES-256-GCM encryption at rest for all stored tokens.
+// Encryption is optional; omit to store tokens in plaintext.
+func WithEncryptor(enc *security.Encryptor) Option {
+	return func(s *Store) { s.encryptor = enc }
 }
 
-// SetEncryptor sets the token encryptor for encryption at rest.
-// When set, oauth2.Token access and refresh tokens will be encrypted
-// before storing in Valkey and decrypted when retrieved.
-func (s *Store) SetEncryptor(enc *security.Encryptor) {
-	s.encryptorMu.Lock()
-	s.encryptor = enc
-	s.encryptorMu.Unlock()
-	if enc != nil && enc.IsEnabled() {
-		s.logger.Debug("token encryption at rest enabled", "store", s)
-	}
-}
-
-// getEncryptor returns the current encryptor (thread-safe)
-func (s *Store) getEncryptor() *security.Encryptor {
-	s.encryptorMu.RLock()
-	defer s.encryptorMu.RUnlock()
-	return s.encryptor
-}
-
-// SetInstrumentation sets OpenTelemetry instrumentation for the store.
-// This enables tracing and metrics for storage operations.
-// This method should be called once during initialization before any storage operations.
-func (s *Store) SetInstrumentation(inst *instrumentation.Instrumentation) {
-	if inst == nil {
-		return
-	}
-
-	s.instMu.Lock()
-	s.inst = inst
-	s.tracer = inst.Tracer("storage")
-	s.meter = inst.Meter("storage")
-	s.instMu.Unlock()
-
-	// Register storage size callbacks for Prometheus gauges.
-	// These callbacks use SCAN operations to count keys, which is efficient
-	// for periodic metrics scraping but not for high-frequency access.
-	err := inst.RegisterStorageSizeCallbacks(
-		func() int64 { return s.countKeysByPattern(s.prefix + "token:*") },
-		func() int64 { return s.countKeysByPattern(s.prefix + "client:*") },
-		func() int64 { return s.countKeysByPattern(s.prefix + "state:*") },
-		func() int64 { return s.countKeysByPattern(s.prefix + "family:*") },
-		func() int64 { return s.countKeysByPattern(s.prefix + "refresh:*") },
-	)
-	if err != nil {
-		s.logger.Warn("Failed to register storage size callbacks", "error", err)
-	}
-	s.logger.Debug("storage instrumentation enabled", "store", s)
+// WithInstrumentation wires OpenTelemetry tracing and metrics into the store.
+func WithInstrumentation(inst *instrumentation.Instrumentation) Option {
+	return func(s *Store) { s.inst = inst }
 }
 
 // countKeysByPattern counts keys matching a glob pattern using SCAN.
@@ -332,11 +311,7 @@ func (t *tracedOp) end(errPtr *error) {
 		t.span.End()
 	}
 
-	t.store.instMu.RLock()
-	inst := t.store.inst
-	t.store.instMu.RUnlock()
-
-	if inst == nil {
+	if t.store.inst == nil {
 		return
 	}
 
@@ -353,7 +328,7 @@ func (t *tracedOp) end(errPtr *error) {
 		t.span.SetStatus(codes.Ok, "")
 	}
 
-	inst.Metrics().RecordStorageOperation(t.ctx, t.operation, result, durationMs)
+	t.store.inst.Metrics().RecordStorageOperation(t.ctx, t.operation, result, durationMs)
 }
 
 // startTracedOp starts a traced storage operation with span and timing.
@@ -368,10 +343,6 @@ func (t *tracedOp) end(errPtr *error) {
 //	    return nil
 //	}
 func (s *Store) startTracedOp(ctx context.Context, operation string) *tracedOp {
-	s.instMu.RLock()
-	tracer := s.tracer
-	s.instMu.RUnlock()
-
 	op := &tracedOp{
 		ctx:       ctx,
 		operation: operation,
@@ -379,12 +350,12 @@ func (s *Store) startTracedOp(ctx context.Context, operation string) *tracedOp {
 		store:     s,
 	}
 
-	if tracer == nil {
+	if s.tracer == nil {
 		op.span = trace.SpanFromContext(ctx)
 		return op
 	}
 
-	ctx, span := tracer.Start(ctx, "storage."+operation,
+	ctx, span := s.tracer.Start(ctx, "storage."+operation,
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("operation", operation),
@@ -408,7 +379,7 @@ type tokenTransformFuncs struct {
 // Returns a new token with transformed fields, leaving the original unchanged.
 // IMPORTANT: Preserves the Extra field (id_token, scope) which is critical for OIDC flows.
 func (s *Store) transformTokenFields(token *oauth2.Token, funcs tokenTransformFuncs) (*oauth2.Token, error) {
-	enc := s.getEncryptor()
+	enc := s.encryptor
 	if enc == nil || !enc.IsEnabled() {
 		return token, nil
 	}
@@ -452,7 +423,7 @@ func (s *Store) transformTokenFields(token *oauth2.Token, funcs tokenTransformFu
 // Returns a new token with encrypted fields, leaving the original unchanged.
 func (s *Store) encryptToken(token *oauth2.Token) (*oauth2.Token, error) {
 	return s.transformTokenFields(token, tokenTransformFuncs{
-		transformString: s.getEncryptor().Encrypt,
+		transformString: s.encryptor.Encrypt,
 		transformExtra:  storage.EncryptExtraFields,
 		accessErrFmt:    "failed to encrypt access token: %w",
 		refreshErrFmt:   "failed to encrypt refresh token: %w",
@@ -463,7 +434,7 @@ func (s *Store) encryptToken(token *oauth2.Token) (*oauth2.Token, error) {
 // Returns a new token with decrypted fields, leaving the original unchanged.
 func (s *Store) decryptToken(token *oauth2.Token) (*oauth2.Token, error) {
 	return s.transformTokenFields(token, tokenTransformFuncs{
-		transformString: s.getEncryptor().Decrypt,
+		transformString: s.encryptor.Decrypt,
 		transformExtra:  storage.DecryptExtraFields,
 		accessErrFmt:    "failed to decrypt access token: %w",
 		refreshErrFmt:   "failed to decrypt refresh token: %w",

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -57,6 +57,31 @@ func testStore(t *testing.T) *Store {
 	return store
 }
 
+// testStoreWithOpts is like testStore but applies additional options at construction.
+func testStoreWithOpts(t *testing.T, opts ...Option) *Store {
+	t.Helper()
+
+	addr := os.Getenv("VALKEY_TEST_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+
+	prefix := fmt.Sprintf("mcptest:%s:", t.Name())
+
+	store, err := New(Config{Address: addr, KeyPrefix: prefix}, opts...)
+	if err != nil {
+		t.Skipf("Skipping test: could not connect to Valkey at %s: %v", addr, err)
+	}
+
+	t.Cleanup(func() {
+		cleanupTestKeys(t, store)
+		store.Close()
+	})
+
+	cleanupTestKeys(t, store)
+	return store
+}
+
 // cleanupTestKeys removes all test keys from Valkey
 func cleanupTestKeys(t *testing.T, s *Store) {
 	t.Helper()
@@ -1244,21 +1269,18 @@ func TestCalculateTTL(t *testing.T) {
 // ============================================================
 
 func TestTokenStore_Encryption(t *testing.T) {
-	s := testStore(t)
 	ctx := context.Background()
 
-	// Generate encryption key (32 bytes for AES-256)
 	key, err := security.GenerateKey()
 	if err != nil {
 		t.Fatalf("Failed to generate encryption key: %v", err)
 	}
-
 	encryptor, err := security.NewEncryptor(key)
 	if err != nil {
 		t.Fatalf("Failed to create encryptor: %v", err)
 	}
 
-	s.SetEncryptor(encryptor)
+	s := testStoreWithOpts(t, WithEncryptor(encryptor))
 
 	token := &oauth2.Token{
 		AccessToken:  "secret-access-token",
@@ -1289,16 +1311,14 @@ func TestTokenStore_Encryption(t *testing.T) {
 }
 
 func TestTokenStore_EncryptionDisabled(t *testing.T) {
-	s := testStore(t)
 	ctx := context.Background()
 
-	// Create encryptor with nil key (disabled)
 	encryptor, err := security.NewEncryptor(nil)
 	if err != nil {
 		t.Fatalf("Failed to create disabled encryptor: %v", err)
 	}
 
-	s.SetEncryptor(encryptor)
+	s := testStoreWithOpts(t, WithEncryptor(encryptor))
 
 	token := &oauth2.Token{
 		AccessToken:  "plaintext-access-token",
@@ -1329,21 +1349,18 @@ func TestTokenStore_EncryptionDisabled(t *testing.T) {
 // preserves the Extra field (id_token, scope) which is critical for OIDC flows.
 // This is a regression test for issue #133.
 func TestTokenStore_Encryption_PreservesExtraField(t *testing.T) {
-	s := testStore(t)
 	ctx := context.Background()
 
-	// Set up encryption
 	key, err := security.GenerateKey()
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-
 	encryptor, err := security.NewEncryptor(key)
 	if err != nil {
 		t.Fatalf("NewEncryptor() error = %v", err)
 	}
 
-	s.SetEncryptor(encryptor)
+	s := testStoreWithOpts(t, WithEncryptor(encryptor))
 
 	// Create token with Extra fields (simulating OIDC provider response)
 	baseToken := &oauth2.Token{
@@ -1442,21 +1459,18 @@ func TestTokenStore_WithoutEncryption_PreservesExtraField(t *testing.T) {
 // TestTokenStore_Encryption_IDTokenIsEncrypted verifies that id_token is actually
 // encrypted when stored, not just preserved. This is a security test.
 func TestTokenStore_Encryption_IDTokenIsEncrypted(t *testing.T) {
-	s := testStore(t)
 	ctx := context.Background()
 
-	// Set up encryption
 	key, err := security.GenerateKey()
 	if err != nil {
 		t.Fatalf("GenerateKey() error = %v", err)
 	}
-
 	encryptor, err := security.NewEncryptor(key)
 	if err != nil {
 		t.Fatalf("NewEncryptor() error = %v", err)
 	}
 
-	s.SetEncryptor(encryptor)
+	s := testStoreWithOpts(t, WithEncryptor(encryptor))
 
 	// Create token with id_token
 	baseToken := &oauth2.Token{
@@ -1635,25 +1649,16 @@ func TestValidation_GenericErrorMessages(t *testing.T) {
 // Instrumentation Tests
 // ============================================================
 
-func TestStore_SetInstrumentation(t *testing.T) {
-	s := testStore(t)
+func TestStore_WithInstrumentation(t *testing.T) {
 	ctx := context.Background()
 
-	// Create instrumentation with noop provider (instrumentation disabled)
-	inst, err := instrumentation.New(instrumentation.Config{
-		Enabled: false,
-	})
+	inst, err := instrumentation.New(instrumentation.Config{Enabled: false})
 	if err != nil {
 		t.Fatalf("Failed to create instrumentation: %v", err)
 	}
 
-	// Should not panic with nil instrumentation
-	s.SetInstrumentation(nil)
+	s := testStoreWithOpts(t, WithInstrumentation(inst))
 
-	// Should work with valid instrumentation
-	s.SetInstrumentation(inst)
-
-	// Verify storage operations still work with instrumentation enabled
 	token := &oauth2.Token{
 		AccessToken:  "instrumented-token",
 		RefreshToken: "instrumented-refresh",
@@ -1676,11 +1681,9 @@ func TestStore_SetInstrumentation(t *testing.T) {
 	}
 }
 
-func TestStore_SetInstrumentation_WithPrometheus(t *testing.T) {
-	s := testStore(t)
+func TestStore_WithInstrumentation_Prometheus(t *testing.T) {
 	ctx := context.Background()
 
-	// Create instrumentation with Prometheus exporter (real metrics)
 	inst, err := instrumentation.New(instrumentation.Config{
 		Enabled:         true,
 		MetricsExporter: "prometheus",
@@ -1694,10 +1697,8 @@ func TestStore_SetInstrumentation_WithPrometheus(t *testing.T) {
 		}
 	}()
 
-	// Set instrumentation (should register storage size callbacks)
-	s.SetInstrumentation(inst)
+	s := testStoreWithOpts(t, WithInstrumentation(inst))
 
-	// Add some data to the store
 	client := &storage.Client{
 		ClientID:     "metric-client",
 		ClientType:   "public",
@@ -1712,9 +1713,6 @@ func TestStore_SetInstrumentation_WithPrometheus(t *testing.T) {
 	}
 	_ = s.SaveToken(ctx, "metric-user", token)
 
-	// Verify metrics are available (they use SCAN which should find our data)
-	// We can't easily verify the actual metric values, but we can verify
-	// that the instrumentation was set up without errors
 	if s.inst == nil {
 		t.Error("Instrumentation should be set on store")
 	}

--- a/storage/valkey/token.go
+++ b/storage/valkey/token.go
@@ -124,8 +124,7 @@ func (s *Store) SaveToken(ctx context.Context, userID string, token *oauth2.Toke
 		return fmt.Errorf("failed to save token: %w", err)
 	}
 
-	enc := s.getEncryptor()
-	if enc != nil && enc.IsEnabled() {
+	if s.encryptor != nil && s.encryptor.IsEnabled() {
 		s.logger.Debug("Saved encrypted token", "user_id", userID)
 	} else {
 		s.logger.Debug("Saved token", "user_id", userID)


### PR DESCRIPTION
## Summary

Closes #309.

Both storage backends previously accepted cross-cutting dependencies
(`*security.Encryptor`, `*instrumentation.Instrumentation`) via post-construction
setter methods. This left a TOCTOU window where the store was live but not yet
encrypted or instrumented. The memory store's `SetInstrumentation` path also had
an unsynchronized read (data race risk).

### What changed

**`storage/memory`**
- `New(opts ...Option)` replaces `New()`, `NewWithInterval`, and all `SetX` methods
- New options: `WithEncryptor`, `WithInstrumentation`, `WithLogger`, `WithCleanupInterval`, `WithRevokedFamilyRetentionDays`
- Goroutine and OTel callback registration happens after opts are applied, so the chosen interval/instrumentation is in effect from the first tick

**`storage/valkey`**
- `New(cfg Config, opts ...Option)` replaces `New(cfg Config)`
- New options: `WithEncryptor`, `WithInstrumentation`
- `encryptorMu` and `instMu` removed — fields are write-once at construction

**`server`**
- `WithEncryptor` / `oauth.WithEncryptor` removed — the server made no functional use of the encryptor beyond a log attribute; callers wire it on the store instead
- `Server.Encryptor` field removed
- `Config.RevokedFamilyRetentionDays` removed — use `memory.WithRevokedFamilyRetentionDays`
- `configureStorageRetention` removed

**`oauthconfig`** (breaking change for muster)
- `StorageFromEnv` and `StorageFromEnvWithPrefix` gain `enc *security.Encryptor, inst *instrumentation.Instrumentation` before the `logger` arg

### Migration

```go
// Before
store := memory.New()
store.SetEncryptor(enc)
srv, _ := server.New(provider, store, store, store, cfg, logger, server.WithEncryptor(enc))

// After
store := memory.New(memory.WithEncryptor(enc))
srv, _ := server.New(provider, store, store, store, cfg, logger)
```

```go
// oauthconfig callers (muster)
// Before
store, closeFn, err := oauthconfig.StorageFromEnv(logger)
// After
store, closeFn, err := oauthconfig.StorageFromEnv(enc, inst, logger)
```