### PR TITLE
test: fix sleep-based flakes, add FuzzJWTHeaderParse

### DIFF
--- a/providers/oidc/jwt_fuzz_test.go
+++ b/providers/oidc/jwt_fuzz_test.go
@@ -1,0 +1,46 @@
+package oidc
+
+import (
+	"testing"
+)
+
+// FuzzJWTHeaderParse drives IsJWT and ParseUnverifiedClaims with arbitrary
+// input. Neither function should panic regardless of input. When
+// ParseUnverifiedClaims succeeds, IsJWT must have returned true for the same
+// input.
+func FuzzJWTHeaderParse(f *testing.F) {
+	seeds := []string{
+		"",
+		"a.b.c",
+		"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyMSJ9.sig",
+		// invalid base64 payload
+		"eyJhbGciOiJSUzI1NiJ9.!!!.sig",
+		// non-JSON payload
+		"eyJhbGciOiJSUzI1NiJ9." + "bm90anNvbg" + ".sig",
+		// only two parts
+		"header.payload",
+		// empty parts
+		"...",
+		// UTF-8 in payload
+		"\xc3\xa9.\xc3\xa9.\xc3\xa9",
+		// null bytes
+		"\x00.\x00.\x00",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, token string) {
+		isJWT := IsJWT(token)
+		claims, err := ParseUnverifiedClaims(token)
+		if err == nil {
+			// A successful parse implies the token looks like a JWT.
+			if !isJWT {
+				t.Fatalf("ParseUnverifiedClaims succeeded but IsJWT returned false for %q", token)
+			}
+			if claims == nil {
+				t.Fatal("ParseUnverifiedClaims returned nil claims with nil error")
+			}
+		}
+	})
+}

--- a/security/ratelimit_test.go
+++ b/security/ratelimit_test.go
@@ -3,8 +3,11 @@ package security
 import (
 	"fmt"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewRateLimiter(t *testing.T) {
@@ -92,13 +95,10 @@ func TestRateLimiter_Allow_RefillOverTime(t *testing.T) {
 		t.Error("Allow() should return false when rate limited")
 	}
 
-	// Wait for token refill (500ms for 1 token at 2 req/s)
-	time.Sleep(550 * time.Millisecond)
-
-	// Should be allowed again
-	if !rl.Allow(identifier) {
-		t.Error("Allow() should be allowed after token refill")
-	}
+	// Poll until a token refills (2 req/s → refills in ~500ms).
+	require.Eventually(t, func() bool {
+		return rl.Allow(identifier)
+	}, time.Second, 10*time.Millisecond, "Allow() should be permitted after token refill")
 }
 
 func TestRateLimiter_Cleanup(t *testing.T) {
@@ -258,10 +258,14 @@ func TestRateLimiter_Stop_WhileActive(t *testing.T) {
 	done := make(chan bool, numWorkers)
 	stop := make(chan bool)
 
+	var started sync.WaitGroup
+	started.Add(numWorkers)
+
 	// Workers continuously making requests
 	for i := 0; i < numWorkers; i++ {
 		go func(id int) {
 			identifier := fmt.Sprintf("worker-%d", id)
+			started.Done()
 			for {
 				select {
 				case <-stop:
@@ -274,8 +278,8 @@ func TestRateLimiter_Stop_WhileActive(t *testing.T) {
 		}(i)
 	}
 
-	// Let workers run for a bit
-	time.Sleep(50 * time.Millisecond)
+	// Wait until all workers are running before stopping.
+	started.Wait()
 
 	// Stop the rate limiter while workers are active
 	rl.Stop()

--- a/server/flows_test.go
+++ b/server/flows_test.go
@@ -27,7 +27,7 @@ const (
 func setupFlowTestServer(t *testing.T) (*Server, *memory.Store, *mock.Provider) {
 	t.Helper()
 
-	store := memory.New(memory.Config{})
+	store := memory.New()
 	t.Cleanup(func() { store.Stop() })
 
 	provider := mock.NewProvider()
@@ -68,7 +68,7 @@ func setupValidTokenProvider() func(context.Context, string) (*providers.UserInf
 func setupFlowTestServerWithNoStateParameter(t *testing.T) (*Server, *memory.Store, *mock.Provider) {
 	t.Helper()
 
-	store := memory.New(memory.Config{})
+	store := memory.New()
 	t.Cleanup(func() { store.Stop() })
 
 	provider := mock.NewProvider()

--- a/server/flows_test.go
+++ b/server/flows_test.go
@@ -27,7 +27,7 @@ const (
 func setupFlowTestServer(t *testing.T) (*Server, *memory.Store, *mock.Provider) {
 	t.Helper()
 
-	store := memory.New()
+	store := memory.New(memory.Config{})
 	t.Cleanup(func() { store.Stop() })
 
 	provider := mock.NewProvider()
@@ -41,7 +41,7 @@ func setupFlowTestServer(t *testing.T) (*Server, *memory.Store, *mock.Provider) 
 		AllowPKCEPlain:       false,
 		ClockSkewGracePeriod: 5,
 		// Mock provider returns no id_token; nonce echo is exercised in
-		// flows_nonce_test.go with its own fixture.
+		// nonce_test.go with its own fixture.
 		DisableNonceEchoRequirement: true,
 	}
 
@@ -68,7 +68,7 @@ func setupValidTokenProvider() func(context.Context, string) (*providers.UserInf
 func setupFlowTestServerWithNoStateParameter(t *testing.T) (*Server, *memory.Store, *mock.Provider) {
 	t.Helper()
 
-	store := memory.New()
+	store := memory.New(memory.Config{})
 	t.Cleanup(func() { store.Stop() })
 
 	provider := mock.NewProvider()

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -1471,104 +1472,103 @@ func TestStore_ConcurrentClientAccess(t *testing.T) {
 // ============================================================
 
 func TestStore_CleanupExpiredTokens(t *testing.T) {
-	ctx := context.Background()
-	// Use short cleanup interval for testing
-	store := New(WithCleanupInterval(100 * time.Millisecond))
-	defer store.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		store := New(WithCleanupInterval(100 * time.Millisecond))
+		defer store.Stop()
 
-	// Save expired authorization code
-	code := testutil.GenerateTestAuthorizationCode()
-	code.ExpiresAt = time.Now().Add(-1 * time.Minute)
-	if err := store.SaveAuthorizationCode(ctx, code); err != nil {
-		t.Fatalf("SaveAuthorizationCode() error = %v", err)
-	}
+		code := testutil.GenerateTestAuthorizationCode()
+		code.ExpiresAt = time.Now().Add(-1 * time.Minute)
+		if err := store.SaveAuthorizationCode(ctx, code); err != nil {
+			t.Fatalf("SaveAuthorizationCode() error = %v", err)
+		}
 
-	// Wait for cleanup
-	time.Sleep(200 * time.Millisecond)
+		// Advance fake time past one cleanup interval and let the goroutine run.
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
 
-	// Code should be cleaned up
-	_, err := store.GetAuthorizationCode(ctx, code.Code)
-	if err == nil {
-		t.Error("Expired authorization code should be cleaned up")
-	}
+		_, err := store.GetAuthorizationCode(ctx, code.Code)
+		if err == nil {
+			t.Error("Expired authorization code should be cleaned up")
+		}
+	})
 }
 
 func TestStore_CleanupExpiredTokens_WithRefreshToken(t *testing.T) {
-	ctx := context.Background()
-	store := New(WithCleanupInterval(100 * time.Millisecond))
-	defer store.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		store := New(WithCleanupInterval(100 * time.Millisecond))
+		defer store.Stop()
 
-	refreshTokenKey := "mcp-refresh-token-1" //nolint:gosec // test value, not a real credential
-	providerToken := &oauth2.Token{
-		AccessToken:  "provider-access",
-		RefreshToken: "provider-refresh",
-		TokenType:    "Bearer",
-		Expiry:       time.Now().Add(-1 * time.Minute),
-	}
+		refreshTokenKey := "mcp-refresh-token-1" //nolint:gosec // test value, not a real credential
+		providerToken := &oauth2.Token{
+			AccessToken:  "provider-access",
+			RefreshToken: "provider-refresh",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(-1 * time.Minute),
+		}
 
-	if err := store.SaveToken(ctx, refreshTokenKey, providerToken); err != nil {
-		t.Fatalf("SaveToken() error = %v", err)
-	}
+		if err := store.SaveToken(ctx, refreshTokenKey, providerToken); err != nil {
+			t.Fatalf("SaveToken() error = %v", err)
+		}
 
-	// Simulate an active MCP refresh token mapping for this key
-	if err := store.SaveRefreshToken(ctx, refreshTokenKey, "user-1", time.Now().Add(90*24*time.Hour)); err != nil {
-		t.Fatalf("SaveRefreshToken() error = %v", err)
-	}
+		if err := store.SaveRefreshToken(ctx, refreshTokenKey, "user-1", time.Now().Add(90*24*time.Hour)); err != nil {
+			t.Fatalf("SaveRefreshToken() error = %v", err)
+		}
 
-	// Wait for cleanup to run
-	time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
 
-	// Token should still exist because the refresh token mapping is active
-	got, err := store.GetToken(ctx, refreshTokenKey)
-	if err != nil {
-		t.Fatalf("GetToken() should succeed while refresh token mapping is active: %v", err)
-	}
-	if got.AccessToken != "provider-access" {
-		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "provider-access")
-	}
+		// Token must survive while its refresh token mapping is active.
+		got, err := store.GetToken(ctx, refreshTokenKey)
+		if err != nil {
+			t.Fatalf("GetToken() should succeed while refresh token mapping is active: %v", err)
+		}
+		if got.AccessToken != "provider-access" {
+			t.Errorf("AccessToken = %q, want %q", got.AccessToken, "provider-access")
+		}
 
-	// Now delete the refresh token mapping (simulating expiry/consumption)
-	if err := store.DeleteRefreshToken(ctx, refreshTokenKey); err != nil {
-		t.Fatalf("DeleteRefreshToken() error = %v", err)
-	}
+		if err := store.DeleteRefreshToken(ctx, refreshTokenKey); err != nil {
+			t.Fatalf("DeleteRefreshToken() error = %v", err)
+		}
 
-	// Wait for cleanup to run again
-	time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
 
-	// Token should now be cleaned up as an orphan
-	_, err = store.GetToken(ctx, refreshTokenKey)
-	if err == nil {
-		t.Error("GetToken() should fail after refresh token mapping is removed (orphan cleanup)")
-	}
+		_, err = store.GetToken(ctx, refreshTokenKey)
+		if err == nil {
+			t.Error("GetToken() should fail after refresh token mapping is removed (orphan cleanup)")
+		}
+	})
 }
 
 func TestStore_CleanupExpiredTokens_WithRefreshToken_NoMapping(t *testing.T) {
-	ctx := context.Background()
-	store := New(WithCleanupInterval(100 * time.Millisecond))
-	defer store.Stop()
+	synctest.Test(t, func(t *testing.T) {
+		ctx := t.Context()
+		store := New(WithCleanupInterval(100 * time.Millisecond))
+		defer store.Stop()
 
-	// Save a provider token with a RefreshToken under a user ID key.
-	// No corresponding refresh token mapping exists for this key.
-	providerToken := &oauth2.Token{
-		AccessToken:  "provider-access",
-		RefreshToken: "provider-refresh",
-		TokenType:    "Bearer",
-		Expiry:       time.Now().Add(-1 * time.Minute),
-	}
+		// Provider token with a RefreshToken but no active refresh token mapping.
+		providerToken := &oauth2.Token{
+			AccessToken:  "provider-access",
+			RefreshToken: "provider-refresh",
+			TokenType:    "Bearer",
+			Expiry:       time.Now().Add(-1 * time.Minute),
+		}
 
-	if err := store.SaveToken(ctx, "user-id-key", providerToken); err != nil {
-		t.Fatalf("SaveToken() error = %v", err)
-	}
+		if err := store.SaveToken(ctx, "user-id-key", providerToken); err != nil {
+			t.Fatalf("SaveToken() error = %v", err)
+		}
 
-	// Wait for cleanup to run
-	time.Sleep(200 * time.Millisecond)
+		time.Sleep(200 * time.Millisecond)
+		synctest.Wait()
 
-	// Token should be cleaned up because there's no active refresh token
-	// mapping and the access token is expired.
-	_, err := store.GetToken(ctx, "user-id-key")
-	if err == nil {
-		t.Error("GetToken() should fail for orphaned token with no refresh mapping")
-	}
+		// No refresh token mapping → orphan must be collected.
+		_, err := store.GetToken(ctx, "user-id-key")
+		if err == nil {
+			t.Error("GetToken() should fail for orphaned token with no refresh mapping")
+		}
+	})
 }
 
 func TestStore_WithLogger(_ *testing.T) {

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
 
@@ -258,16 +259,16 @@ func TestTokenStore_SaveToken_NilToken(t *testing.T) {
 
 func TestTokenStore_SaveToken_WithRefreshToken_NoShortTTL(t *testing.T) {
 	s := testStore(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
-	// A provider token with a short-lived access token (30 min) but a refresh
-	// token present. Valkey must NOT use the access token expiry as the key
-	// TTL, otherwise the key is evicted before the MCP refresh token expires.
+	// A provider token with a short-lived access token but a refresh token
+	// present. Valkey must NOT use the access token expiry as the key TTL,
+	// otherwise the key is evicted before the MCP refresh token expires.
 	token := &oauth2.Token{
 		AccessToken:  "short-lived-access",
 		RefreshToken: "long-lived-refresh",
 		TokenType:    "Bearer",
-		Expiry:       time.Now().Add(2 * time.Second),
+		Expiry:       time.Now().Add(50 * time.Millisecond),
 	}
 
 	err := s.SaveToken(ctx, "user-rt-ttl", token)
@@ -275,14 +276,17 @@ func TestTokenStore_SaveToken_WithRefreshToken_NoShortTTL(t *testing.T) {
 		t.Fatalf("SaveToken failed: %v", err)
 	}
 
-	// Wait for the access token expiry to pass.
-	time.Sleep(3 * time.Second)
+	// Poll for 300ms confirming the key is never evicted despite the access
+	// token expiry having passed (token has a RefreshToken so uses long TTL).
+	require.Never(t, func() bool {
+		_, err := s.GetToken(ctx, "user-rt-ttl")
+		return err != nil
+	}, 300*time.Millisecond, 10*time.Millisecond,
+		"token with RefreshToken must not be evicted after access token expiry")
 
-	// The key must still exist because tokens with a RefreshToken are stored
-	// without TTL (matching the memory store's cleanup behavior).
 	got, err := s.GetToken(ctx, "user-rt-ttl")
 	if err != nil {
-		t.Fatalf("GetToken failed after access token expiry: %v (token was prematurely evicted)", err)
+		t.Fatalf("GetToken failed: %v", err)
 	}
 	if got.AccessToken != "short-lived-access" {
 		t.Errorf("AccessToken = %q, want %q", got.AccessToken, "short-lived-access")
@@ -339,14 +343,14 @@ func TestTokenStore_SaveToken_WithoutRefreshToken_ExpiredReject(t *testing.T) {
 
 func TestTokenStore_SaveToken_WithoutRefreshToken_HasTTL(t *testing.T) {
 	s := testStore(t)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Token without RefreshToken and with a short expiry should be evicted
 	// after the TTL (existing behavior preserved).
 	token := &oauth2.Token{
 		AccessToken: "short-no-rt",
 		TokenType:   "Bearer",
-		Expiry:      time.Now().Add(2 * time.Second),
+		Expiry:      time.Now().Add(50 * time.Millisecond),
 	}
 
 	err := s.SaveToken(ctx, "user-short-no-rt", token)
@@ -354,16 +358,11 @@ func TestTokenStore_SaveToken_WithoutRefreshToken_HasTTL(t *testing.T) {
 		t.Fatalf("SaveToken failed: %v", err)
 	}
 
-	// Wait for the TTL to expire.
-	time.Sleep(3 * time.Second)
-
-	_, err = s.GetToken(ctx, "user-short-no-rt")
-	if err == nil {
-		t.Error("Expected error: token without RefreshToken should be evicted after TTL")
-	}
-	if !storage.IsNotFoundError(err) {
-		t.Errorf("Expected ErrTokenNotFound, got: %v", err)
-	}
+	require.Eventually(t, func() bool {
+		_, err := s.GetToken(ctx, "user-short-no-rt")
+		return storage.IsNotFoundError(err)
+	}, 5*time.Second, 50*time.Millisecond,
+		"token without RefreshToken should be evicted after TTL")
 }
 
 // ============================================================


### PR DESCRIPTION
Closes #311

## Sleep removal

**`storage/valkey`** — both 3 s sleeps replaced:
- `WithRefreshToken_NoShortTTL`: `require.Never` polls for 300 ms confirming the key is never evicted after the access-token expiry passes. Token expiry shrunk 2 s → 50 ms.
- `WithoutRefreshToken_HasTTL`: `require.Eventually` polls until `IsNotFoundError`. Token expiry shrunk 2 s → 50 ms.

**`security/ratelimit`** — two sleeps replaced:
- `Allow_RefillOverTime`: 550 ms sleep → `require.Eventually` with 10 ms poll.
- `Stop_WhileActive`: 50 ms "let workers start" sleep → `sync.WaitGroup` that blocks until all goroutines have signalled they are running.

**`storage/memory`** — four 200 ms sleeps across three cleanup tests replaced. Each test is wrapped in a `synctest.Test` bubble (Go 1.25 `testing/synctest`). `time.Sleep` inside the bubble advances the fake ticker; `synctest.Wait` drains the cleanup goroutine after each advance. `context.Background` → `t.Context` in all three.

## Fuzz target

`providers/oidc/jwt_fuzz_test.go` adds `FuzzJWTHeaderParse` driving `IsJWT` and `ParseUnverifiedClaims` with arbitrary input. Invariants: no panics; if `ParseUnverifiedClaims` succeeds, `IsJWT` must also return true for the same input.

## flows_test.go

Stale comment `flows_nonce_test.go` → `nonce_test.go` (the file created when flows.go was split by #338).