### PR TITLE
docs: DPoP, token exchange, and client management (#390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ go get github.com/giantswarm/mcp-oauth
 | [MCP 2025-11-25](./docs/mcp-2025-11-25.md) | New specification features and migration |
 | [Silent Authentication](./docs/silent-authentication.md) | OIDC prompt parameter for seamless re-authentication |
 | [Client ID Metadata Documents](./docs/cimd.md) | URL-based client IDs with dynamic metadata discovery |
+| [DPoP (RFC 9449)](./docs/dpop.md) | Sender-constraint setup, middleware wiring, multi-pod replay cache |
+| [Token Exchange (RFC 8693)](./docs/token-exchange.md) | Service-to-service and Kubernetes SA token exchange |
+| [Client Management (RFC 7592)](./docs/client-management.md) | Per-client read/update/delete for dynamically registered clients |
 | [Security Architecture](./SECURITY_ARCHITECTURE.md) | Deep-dive into security implementation |
 
 ## Examples

--- a/SECURITY_ARCHITECTURE.md
+++ b/SECURITY_ARCHITECTURE.md
@@ -13,8 +13,9 @@ This document provides a deep technical reference for the security implementatio
 5. [Client Authentication](#client-authentication)
 6. [Client ID Metadata Documents Security](#client-id-metadata-documents-security)
 7. [Token Security](#token-security)
-8. [Attack Mitigation](#attack-mitigation)
-9. [Security Checklist](#security-checklist)
+8. [DPoP Sender-Constraint (RFC 9449)](#dpop-sender-constraint-rfc-9449)
+9. [Attack Mitigation](#attack-mitigation)
+10. [Security Checklist](#security-checklist)
 
 ## Overview
 
@@ -918,6 +919,24 @@ func validateToken(token, expectedResource string) error {
 - `token_audience_mismatch`: Token used for wrong resource
 - `token_validation_failed`: General validation failure
 - `invalid_issuer`: Token from unknown issuer
+
+## DPoP Sender-Constraint (RFC 9449)
+
+DPoP binds access tokens to the client's private key. The implementation enforces two independent properties:
+
+**1. Key binding at `ValidateToken`** — when a token's `cnf.jkt` claim (or `storage.TokenMetadata.JKT` for opaque tokens) is non-empty, the token must be presented as `Authorization: DPoP <token>`, not `Authorization: Bearer`. A bound token presented as Bearer is rejected with `401 invalid_token`. This closes the sender-constraint bypass where a stolen JWT could be replayed as a plain Bearer token.
+
+**2. Proof key matching at `ValidateToken`** — after `DPoPMiddleware` validates the proof and stores the proof JKT in the request context, `ValidateToken` compares it against the token's bound JKT. A mismatch (attacker uses their own key to produce a valid proof for a stolen token) is rejected with `401 invalid_token`. This closes the key-substitution attack that the `ath` claim alone does not prevent.
+
+**Middleware pipeline:**
+
+```
+DPoPMiddleware → ValidateToken → handler
+```
+
+`DPoPMiddleware` normalises `Authorization: DPoP <token>` to `Authorization: Bearer <token>` after proof validation, and stores the proof JKT in the request context. `ValidateToken` reads it. Reversing the order breaks sender-constraint.
+
+**Multi-pod replay protection** — use `server.WithDPoPReplayCache(sharedStore)` to back the replay cache with the distributed store (e.g., Valkey). Without a shared cache each pod maintains an independent JTI set, so a proof replayed to a different pod succeeds. See [DPoP guide](./docs/dpop.md).
 
 ## Attack Mitigation
 

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -57,6 +57,9 @@ This checklist should be completed for all pull requests that modify security-se
 - [ ] Refresh token rotation implemented correctly
 - [ ] Token revocation works as expected
 - [ ] Session fixation attacks prevented
+- [ ] DPoP-bound tokens rejected when presented as plain Bearer (sender-constraint bypass)
+- [ ] DPoP proof key matches token `cnf.jkt` (key-substitution attack)
+- [ ] DPoP replay cache is shared across all pods (not per-process) in multi-pod deployments
 
 ### 7. Cryptography ✓
 

--- a/docs/client-management.md
+++ b/docs/client-management.md
@@ -1,0 +1,101 @@
+# Client Management (RFC 7592)
+
+RFC 7592 extends Dynamic Client Registration (RFC 7591) with a per-client management endpoint. Clients that registered dynamically can read, update, or delete their own registration without operator involvement.
+
+## Enabling
+
+```go
+&oauth.ServerConfig{
+    Issuer:                        "https://example.com",
+    EnableClientManagementEndpoint: true,
+}
+```
+
+When enabled, `RegisterOAuthRoutes` mounts `ServeClientManagement` at `/oauth/register/{client_id}`. The base URL is advertised in the authorization server metadata as `registration_management_endpoint`.
+
+## Registration access token
+
+Each dynamically registered client receives a **registration access token (RAT)** at registration time:
+
+```json
+{
+  "client_id": "abc123",
+  "client_secret": "...",
+  "registration_access_token": "rat-<high-entropy-random>",
+  "registration_client_uri": "https://example.com/oauth/register/abc123"
+}
+```
+
+The RAT is returned **exactly once** in the registration response. It is stored as a hash (`RegistrationAccessTokenHash`) — the plaintext is never retrievable again. Treat it like a bearer token: store it securely on the client side.
+
+## Endpoints
+
+All management requests authenticate with `Authorization: Bearer <registration-access-token>`.
+
+### GET /oauth/register/{client_id}
+
+Returns the current client metadata:
+
+```
+GET /oauth/register/abc123
+Authorization: Bearer rat-<token>
+```
+
+```json
+{
+  "client_id": "abc123",
+  "client_name": "My App",
+  "redirect_uris": ["https://app.example.com/callback"],
+  "token_endpoint_auth_method": "client_secret_basic",
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "scope": "openid email"
+}
+```
+
+### PUT /oauth/register/{client_id}
+
+Replaces the client metadata and **rotates the registration access token**. The response includes a new `registration_access_token`; the old one is invalidated immediately.
+
+Updatable fields: `client_name`, `redirect_uris`, `scope`, `token_endpoint_auth_method`. Fields absent from the request body retain their current values.
+
+```
+PUT /oauth/register/abc123
+Authorization: Bearer rat-<old-token>
+Content-Type: application/json
+
+{
+  "client_name": "My App v2",
+  "redirect_uris": ["https://app.example.com/callback", "https://app.example.com/callback2"]
+}
+```
+
+Response includes a new `registration_access_token` — store it immediately.
+
+### DELETE /oauth/register/{client_id}
+
+Deletes the client. All tokens issued to the client remain valid until they expire; revoke them explicitly via `/oauth/revoke` if immediate invalidation is required.
+
+```
+DELETE /oauth/register/abc123
+Authorization: Bearer rat-<token>
+```
+
+Returns `204 No Content` on success.
+
+## Token rotation
+
+Every successful PUT rotates the RAT. This is mandatory per RFC 7592 §2.3. Clients must:
+
+1. Send the PUT request.
+2. Extract `registration_access_token` from the response.
+3. Replace their stored RAT with the new value before making any further management calls.
+
+A race condition where the old RAT is used after a successful PUT will result in `401 Unauthorized`.
+
+## Security considerations
+
+- Management tokens authenticate with the same `Authorization: Bearer` scheme as access tokens, but they are validated separately against the per-client `RegistrationAccessTokenHash` — they are not OAuth access tokens and cannot be used to call protected resources.
+- Rate limiting is applied on the management endpoint per client IP, using the same IP rate limiter as the rest of the OAuth endpoints.
+- Keep management endpoints behind your ingress auth layer or restrict access by IP if clients should not be able to self-manage.
+- The endpoint is opt-in (`EnableClientManagementEndpoint: false` by default) to avoid exposing it unintentionally.

--- a/docs/dpop.md
+++ b/docs/dpop.md
@@ -1,0 +1,102 @@
+# DPoP (RFC 9449)
+
+DPoP (Demonstrating Proof of Possession) binds access tokens to a client's private key. Even if a token is stolen from a log, a header, or in transit, it cannot be replayed without the corresponding private key.
+
+## How it works
+
+At issuance, when the client includes a `DPoP` proof header in the token request, the server:
+
+1. Validates the proof (signature, `htm`, `htu`, `iat`, `jti`, `ath` claims).
+2. Computes the JWK thumbprint (`jkt`) of the proof key.
+3. Embeds `cnf: { jkt: "<thumbprint>" }` in the issued JWT access token, or stores the JKT in `storage.TokenMetadata` for opaque tokens.
+
+At every subsequent API call, the `DPoPMiddleware` enforces that:
+
+- The request carries `Authorization: DPoP <token>` (not `Bearer`).
+- The `DPoP` proof header is present, valid, and its key thumbprint matches the `cnf.jkt` in the token.
+- The proof JTI has not been seen before (replay protection).
+
+If a DPoP-bound token is presented as plain `Authorization: Bearer`, `ValidateToken` rejects it with `401 invalid_token`.
+
+## Server setup
+
+```go
+import (
+    "github.com/giantswarm/mcp-oauth/server"
+    "github.com/giantswarm/mcp-oauth/storage/valkey"
+)
+
+// Single-process: use the built-in memory cache.
+// Multi-pod: back it with the shared Valkey store (same instance used for tokens).
+valkeyStore := valkey.New(...)
+srv, _ := oauth.NewServer(
+    provider, valkeyStore, valkeyStore, valkeyStore,
+    &oauth.ServerConfig{Issuer: "https://example.com"},
+    logger,
+    server.WithDPoPReplayCache(valkeyStore),           // shared replay cache
+    server.WithDPoPNonceProvider(                       // optional: enforce nonces
+        server.NewHMACNonceProvider(nonceSecret, 5*time.Minute, time.Now),
+    ),
+)
+```
+
+`WithDPoPReplayCache` is optional for single-process deployments — `NewMemoryDPoPReplayCache()` is the default. It is **required** for multi-pod deployments to prevent per-pod replay-cache split-brain.
+
+## Wiring the middleware
+
+Use `Handler.DPoPMiddleware()` (the method form). It reads the replay cache, nonce provider, and trusted proxy CIDRs from the server, so the issuance path and resource path always share the same cache instance:
+
+```go
+h := handler.New(srv, nil)
+
+mux := http.NewServeMux()
+h.RegisterOAuthRoutes(mux, handler.OAuthRoutesOptions{IncludeMetadata: true})
+
+// DPoP enforcement on the protected resource.
+mux.Handle("/mcp", h.DPoPMiddleware()(h.ValidateToken(mcpHandler)))
+
+http.ListenAndServe(":8080", mux)
+```
+
+The standalone `handler.DPoPMiddleware(replayCache, nonceProvider, trustedProxies)` function is also available for callers that do not use `handler.Handler`. When `replayCache` is `nil` it falls back to an in-process cache and logs a warning — safe for single-process deployments, not for multi-pod.
+
+### Middleware ordering
+
+`DPoPMiddleware` **must wrap** `ValidateToken`. It normalises `Authorization: DPoP <token>` to `Authorization: Bearer <token>` and stores the validated proof JKT in the request context. `ValidateToken` reads that JKT to enforce sender-constraint.
+
+```
+DPoPMiddleware → ValidateToken → your handler
+```
+
+Reversing the order breaks sender-constraint enforcement.
+
+## Nonce enforcement (RFC 9449 §8)
+
+When a `DPoPNonceProvider` is configured, every DPoP proof must carry a currently valid server-issued nonce. Clients that present a proof without a nonce (or with an expired one) receive:
+
+```
+HTTP 401
+WWW-Authenticate: DPoP error="use_dpop_nonce", ...
+DPoP-Nonce: <new-nonce>
+```
+
+The client retries with the supplied nonce. `NewHMACNonceProvider` rotates nonces on a configurable window (e.g., 5 minutes) and accepts proofs from either the current or the previous window to tolerate clock skew and in-flight requests.
+
+## Supported algorithms
+
+```
+RS256 RS384 RS512 ES256 ES384 ES512 PS256 PS384 PS512
+```
+
+EC keys are recommended for performance. RSA is supported for compatibility.
+
+## Multi-pod deployments
+
+The replay cache and nonce provider must be **shared** across all pods. Use `valkey.New(...)` (the same store instance used for tokens) as the `DPoPReplayCache`:
+
+```go
+// valkeyStore implements DPoPReplayCache, TokenStore, ClientStore, FlowStore.
+server.WithDPoPReplayCache(valkeyStore)
+```
+
+For the nonce provider, share a common HMAC secret across pods (e.g., from a Kubernetes Secret mounted as an env var). Each pod computes and validates nonces independently from the same key.

--- a/docs/token-exchange.md
+++ b/docs/token-exchange.md
@@ -1,0 +1,111 @@
+# Token Exchange (RFC 8693)
+
+Token exchange lets a client present an external token (an OIDC ID token, an access token from another issuer, or a Kubernetes ServiceAccount token) and receive a new access token issued by this server. The issued token carries an `act` claim recording the original identity as the acting party.
+
+## When to use it
+
+- Service-to-service calls where the caller already holds a token from a trusted issuer (Dex, Google Workspace, another cluster's OIDC provider).
+- Kubernetes workloads that have a projected ServiceAccount token and need an mcp-oauth-issued access token.
+- M2M flows where a headless process cannot perform the interactive authorization code flow.
+
+## Server setup
+
+### Trusting external OIDC issuers
+
+```go
+import "github.com/giantswarm/mcp-oauth/server"
+
+srv, _ := oauth.NewServer(
+    provider, store, store, store,
+    &oauth.ServerConfig{Issuer: "https://example.com"},
+    logger,
+    server.WithTrustedIssuers([]server.TrustedIssuer{
+        {
+            Issuer:           "https://dex.example.com",
+            JwksURL:          "https://dex.example.com/keys",
+            AllowedAudiences: []string{"mcp-server"},   // empty = any audience accepted
+            AllowedScopes:    []string{"openid", "email", "groups"}, // caps issued scopes
+        },
+        {
+            Issuer:           "https://accounts.google.com",
+            JwksURL:          "https://www.googleapis.com/oauth2/v3/certs",
+            AllowedAudiences: []string{"my-client-id.apps.googleusercontent.com"},
+        },
+    }),
+)
+```
+
+`WithTrustedIssuers` registers an `OIDCValidator` for both `urn:ietf:params:oauth:token-type:id_token` and `urn:ietf:params:oauth:token-type:access_token`. The `Issuer` and `JwksURL` are independent — set `JwksURL` explicitly when the issuer's discovery document is unavailable or its JWKS is hosted separately.
+
+`AllowedScopes` caps the scopes the server will include in the issued token for this issuer. `nil` means no restriction.
+
+### Trusting Kubernetes ServiceAccount tokens
+
+```go
+server.WithKubernetesSATrust([]server.KubernetesSATrust{
+    {
+        Issuer:                 "https://kubernetes.default.svc",
+        JwksURL:                "https://kubernetes.default.svc/openid/v1/jwks",
+        AllowedNamespaces:      []string{"my-namespace"},      // optional; nil = any
+        AllowedServiceAccounts: []string{"my-sa"},             // optional; nil = any
+    },
+})
+```
+
+K8s SA tokens use `subject_token_type=urn:ietf:params:oauth:token-type:jwt`.
+
+### Custom validators
+
+Implement `server.SubjectTokenValidator` and register it for a specific URN:
+
+```go
+server.WithSubjectTokenValidator("urn:example:custom-token-type", myValidator)
+```
+
+## Token type URNs
+
+| `subject_token_type` | Validator | Notes |
+|---|---|---|
+| `urn:ietf:params:oauth:token-type:id_token` | `OIDCValidator` | OIDC ID token |
+| `urn:ietf:params:oauth:token-type:access_token` | `OIDCValidator` | Opaque or JWT access token |
+| `urn:ietf:params:oauth:token-type:jwt` | `K8sSAValidator` | Kubernetes projected SA token |
+
+## Client request
+
+```
+POST /oauth/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token=<external-token>
+&subject_token_type=urn:ietf:params:oauth:token-type:id_token
+&scope=openid email
+```
+
+Optional parameters:
+- `resource` (RFC 8707): target resource server URI to bind the issued token's `aud`.
+- `scope`: requested scope subset; intersected with the issuer's `AllowedScopes`.
+- `DPoP` header: if present, the issued token is DPoP-bound (see [DPoP guide](./dpop.md)).
+
+## Issued token
+
+The issued access token contains an `act` claim per RFC 8693 §4.4:
+
+```json
+{
+  "sub": "user@example.com",
+  "act": {
+    "iss": "https://dex.example.com",
+    "sub": "user@example.com"
+  },
+  "scope": "openid email",
+  "iss": "https://example.com",
+  "aud": ["https://resource.example.com"]
+}
+```
+
+`act.iss` records the original issuer; `act.sub` records the original subject. The delegation chain is preserved if the issued token is exchanged again.
+
+## Route registration
+
+Token exchange is handled by `ServeToken` — no separate route is required. It activates automatically when the `grant_type` is `urn:ietf:params:oauth:grant-type:token-exchange` and at least one `SubjectTokenValidator` is registered. No `SubjectTokenValidator` = token exchange returns `unsupported_grant_type`.


### PR DESCRIPTION
Closes #390.

## What changed

Three new docs and updates to two existing files.

**docs/dpop.md** — DPoP sender-constraint (RFC 9449): what JKT binding means, `WithDPoPReplayCache` / `WithDPoPNonceProvider` setup, `Handler.DPoPMiddleware()` vs standalone `DPoPMiddleware`, required middleware ordering (`DPoPMiddleware → ValidateToken`), nonce enforcement, supported algorithms, multi-pod replay cache wiring.

**docs/token-exchange.md** — RFC 8693 token exchange: `WithTrustedIssuers`, `WithKubernetesSATrust`, `WithSubjectTokenValidator`, token type URNs, `act` claim in issued tokens, client request format, how the grant activates automatically.

**docs/client-management.md** — RFC 7592 client management: `EnableClientManagementEndpoint`, registration access token lifecycle (issued once, stored as hash), GET/PUT/DELETE semantics, mandatory token rotation on PUT, security notes.

**README.md** — adds the three new docs to the documentation table.

**SECURITY_ARCHITECTURE.md** — new "DPoP Sender-Constraint" section covering Bearer bypass protection, key-substitution protection, middleware ordering invariant, and multi-pod replay cache requirement. ToC updated.

**SECURITY_CHECKLIST.md** — three DPoP checklist items: Bearer bypass, key-substitution, multi-pod replay cache.