### PR TITLE
fix(security): eliminate race on SetEncryptionMetricRecorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`security.SetEncryptionMetricRecorder`**: replaced unprotected package-level variable with `atomic.Pointer`, eliminating a data race when multiple goroutines register or clear the hook concurrently (e.g., parallel test suites).
+
 ### Added
 
 - **`memory.WithEncryptor`, `memory.WithInstrumentation`, `memory.WithLogger`, `memory.WithCleanupInterval`, `memory.WithRevokedFamilyRetentionDays`**: functional options for `memory.New`. All cross-cutting dependencies are now supplied at construction; the store is immutable afterward.

--- a/security/encryption_metrics.go
+++ b/security/encryption_metrics.go
@@ -2,6 +2,7 @@ package security
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 )
 
@@ -12,33 +13,35 @@ import (
 // operation is "encrypt" or "decrypt"; result is "ok" or "fail".
 type encryptionMetricRecorder func(ctx context.Context, operation, result string, durationMs float64)
 
-var encryptionMetricFn encryptionMetricRecorder
+var encryptionMetricFn atomic.Pointer[encryptionMetricRecorder]
 
 // SetEncryptionMetricRecorder registers a callback invoked on every
 // completed Encrypt/Decrypt. Setting nil disables the hook (zero overhead
-// when no metrics backend is wired). Intended to be called once at
-// startup from instrumentation wiring code; not safe to swap at request
-// time (no synchronization on the package-level global).
+// when no metrics backend is wired). Safe to call from multiple goroutines.
 //
 // The hook is process-wide. Constructing a second [instrumentation.Instrumentation]
 // re-registers it, so Encrypt/Decrypt calls from any [Encryptor] in the
 // process route to the most recently constructed Instrumentation's meter
 // — even if a different Encryptor is attached to a different Server.
 // Production deployments build one Server; tests that spin up multiple
-// in parallel will see the second one win.
+// in parallel will see the second registration win.
 func SetEncryptionMetricRecorder(fn encryptionMetricRecorder) {
-	encryptionMetricFn = fn
+	if fn == nil {
+		encryptionMetricFn.Store(nil)
+		return
+	}
+	encryptionMetricFn.Store(&fn)
 }
 
 // recordEncryption invokes the configured metric recorder, if any.
 func recordEncryption(operation string, err error, start time.Time) {
-	fn := encryptionMetricFn
-	if fn == nil {
+	fnPtr := encryptionMetricFn.Load()
+	if fnPtr == nil {
 		return
 	}
 	result := "ok"
 	if err != nil {
 		result = "fail"
 	}
-	fn(context.Background(), operation, result, float64(time.Since(start).Microseconds())/1000.0)
+	(*fnPtr)(context.Background(), operation, result, float64(time.Since(start).Microseconds())/1000.0)
 }

--- a/security/encryption_metrics_test.go
+++ b/security/encryption_metrics_test.go
@@ -1,0 +1,27 @@
+package security
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestSetEncryptionMetricRecorderConcurrent(t *testing.T) {
+	t.Cleanup(func() { SetEncryptionMetricRecorder(nil) })
+
+	recorder := func(_ context.Context, _, _ string, _ float64) {}
+
+	var wg sync.WaitGroup
+	for range 64 {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			SetEncryptionMetricRecorder(recorder)
+		}()
+		go func() {
+			defer wg.Done()
+			SetEncryptionMetricRecorder(nil)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What

`security.SetEncryptionMetricRecorder` wrote to a bare package-level variable with no synchronization. Any test suite that constructs two `instrumentation.Instrumentation` values concurrently races on the store and the load in `recordEncryption`.

## How

Replace the `encryptionMetricRecorder` variable with `atomic.Pointer[encryptionMetricRecorder]`. Store takes a pointer-to-func (nil pointer = hook disabled). Load in `recordEncryption` is a single atomic read.

Added `TestSetEncryptionMetricRecorderConcurrent` which exercises 64 concurrent Set/clear pairs under `-race`.