### PR TITLE
feat(server): add TrustedIssuer.AllowPrivateIPJWKS for in-cluster JWKS endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`TrustedIssuer.AllowPrivateIPJWKS`**: opt-in field that allows a trusted issuer's `JwksURL` to resolve to a private or loopback address. Needed for in-cluster JWKS endpoints such as the Kubernetes API server's `/openid/v1/jwks`. When true, `OIDCValidator` routes JWKS fetches for that issuer through a dedicated permissive client; all other issuers continue to use the default SSRF-safe client.
+
 - **`memory.WithEncryptor`, `memory.WithInstrumentation`, `memory.WithLogger`, `memory.WithCleanupInterval`, `memory.WithRevokedFamilyRetentionDays`**: functional options for `memory.New`. All cross-cutting dependencies are now supplied at construction; the store is immutable afterward.
 - **`valkey.WithEncryptor`, `valkey.WithInstrumentation`**: functional options for `valkey.New`. Same construction-time wiring as memory.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **`TrustedIssuer.AllowPrivateIPJWKS`**: opt-in field that allows a trusted issuer's `JwksURL` to resolve to a private or loopback address. Needed for in-cluster JWKS endpoints such as the Kubernetes API server's `/openid/v1/jwks`. When true, `OIDCValidator` routes JWKS fetches for that issuer through a dedicated permissive client; all other issuers continue to use the default SSRF-safe client.
+- **`TrustedIssuer.AllowPrivateIPJWKS`**: opt-in bool allowing a trusted issuer's `JwksURL` to resolve to a private or loopback address.
 
 - **`memory.WithEncryptor`, `memory.WithInstrumentation`, `memory.WithLogger`, `memory.WithCleanupInterval`, `memory.WithRevokedFamilyRetentionDays`**: functional options for `memory.New`. All cross-cutting dependencies are now supplied at construction; the store is immutable afterward.
 - **`valkey.WithEncryptor`, `valkey.WithInstrumentation`**: functional options for `valkey.New`. Same construction-time wiring as memory.

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -72,9 +72,8 @@ type OIDCValidator struct {
 }
 
 // NewOIDCValidator constructs an OIDCValidator for the given trusted issuers.
-// JWKS clients are created automatically: a private-IP-blocking client is used
-// by default; issuers with AllowPrivateIPJWKS set share a second client that
-// permits private-IP resolution.
+// SSRF-safe JWKS fetches are the default; set AllowPrivateIPJWKS on an issuer
+// to opt out per-issuer.
 func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 	safe := oidc.NewJWKSClient(nil, 0, nil)
 	var permissive *oidc.JWKSClient
@@ -88,8 +87,7 @@ func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 }
 
 // newOIDCValidatorWithClient is the internal constructor used by tests to inject
-// a custom JWKS client. Both safe and permissive slots are set to client, so
-// AllowPrivateIPJWKS routing works transparently in tests.
+// a custom JWKS client; both client slots are set to client.
 func newOIDCValidatorWithClient(issuers []TrustedIssuer, client *oidc.JWKSClient) (*OIDCValidator, error) {
 	return newOIDCValidatorWithClients(issuers, client, client)
 }

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -50,6 +50,14 @@ type TrustedIssuer struct {
 	// (numbers, arrays, objects) are rejected. Nil or empty means no claim
 	// restrictions.
 	AllowedClaims map[string]string
+	// AllowPrivateIPJWKS allows JwksURL to resolve to a private or loopback IP
+	// address. Set this when the JWKS endpoint is an in-cluster service (e.g.
+	// the Kubernetes API server's /openid/v1/jwks) that is not reachable via a
+	// public address.
+	//
+	// WARNING: Disables SSRF protection for this issuer's JWKS fetch. Only set
+	// when JwksURL is a known, controlled in-cluster endpoint.
+	AllowPrivateIPJWKS bool
 }
 
 // OIDCValidator validates tokens from statically configured trusted issuers.
@@ -58,19 +66,35 @@ type TrustedIssuer struct {
 //   - urn:ietf:params:oauth:token-type:access_token
 //   - urn:ietf:params:oauth:token-type:jwt
 type OIDCValidator struct {
-	issuers    map[string]TrustedIssuer
-	jwksClient *oidc.JWKSClient
+	issuers          map[string]TrustedIssuer
+	safeClient       *oidc.JWKSClient
+	permissiveClient *oidc.JWKSClient // non-nil only when at least one issuer sets AllowPrivateIPJWKS
 }
 
 // NewOIDCValidator constructs an OIDCValidator for the given trusted issuers.
-// An SSRF-safe JWKS client is created automatically.
+// JWKS clients are created automatically: a private-IP-blocking client is used
+// by default; issuers with AllowPrivateIPJWKS set share a second client that
+// permits private-IP resolution.
 func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
-	return newOIDCValidatorWithClient(issuers, oidc.NewJWKSClient(nil, 0, nil))
+	safe := oidc.NewJWKSClient(nil, 0, nil)
+	var permissive *oidc.JWKSClient
+	for _, ti := range issuers {
+		if ti.AllowPrivateIPJWKS {
+			permissive = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{AllowPrivateIP: true})
+			break
+		}
+	}
+	return newOIDCValidatorWithClients(issuers, safe, permissive)
 }
 
 // newOIDCValidatorWithClient is the internal constructor used by tests to inject
-// a custom JWKS client (e.g. one configured to allow private IPs for httptest).
+// a custom JWKS client. Both safe and permissive slots are set to client, so
+// AllowPrivateIPJWKS routing works transparently in tests.
 func newOIDCValidatorWithClient(issuers []TrustedIssuer, client *oidc.JWKSClient) (*OIDCValidator, error) {
+	return newOIDCValidatorWithClients(issuers, client, client)
+}
+
+func newOIDCValidatorWithClients(issuers []TrustedIssuer, safeClient, permissiveClient *oidc.JWKSClient) (*OIDCValidator, error) {
 	if len(issuers) == 0 {
 		return nil, fmt.Errorf("at least one trusted issuer is required")
 	}
@@ -84,7 +108,7 @@ func newOIDCValidatorWithClient(issuers []TrustedIssuer, client *oidc.JWKSClient
 		}
 		m[ti.Issuer] = ti
 	}
-	return &OIDCValidator{issuers: m, jwksClient: client}, nil
+	return &OIDCValidator{issuers: m, safeClient: safeClient, permissiveClient: permissiveClient}, nil
 }
 
 // Validate verifies the subject token and returns the verified identity.
@@ -112,7 +136,11 @@ func (v *OIDCValidator) Validate(ctx context.Context, subjectToken, subjectToken
 		return SubjectIdentity{}, fmt.Errorf("untrusted issuer: %q", iss)
 	}
 
-	claims, err := oidc.ValidateIDToken(ctx, subjectToken, v.jwksClient, ti.JwksURL, ti.Issuer, ti.AllowedAudiences)
+	jwksClient := v.safeClient
+	if ti.AllowPrivateIPJWKS && v.permissiveClient != nil {
+		jwksClient = v.permissiveClient
+	}
+	claims, err := oidc.ValidateIDToken(ctx, subjectToken, jwksClient, ti.JwksURL, ti.Issuer, ti.AllowedAudiences)
 	if err != nil {
 		return SubjectIdentity{}, fmt.Errorf("subject token validation failed: %w", err)
 	}

--- a/server/subject_validator_test.go
+++ b/server/subject_validator_test.go
@@ -423,18 +423,8 @@ func TestOIDCValidator_AllowPrivateIPJWKS(t *testing.T) {
 	const kid = "test-key"
 	jwksURL, jwksClient := serveStaticJWKS(t, key, kid)
 
-	// NewOIDCValidator with AllowPrivateIPJWKS=true must create a permissive
-	// client. The test server is localhost (private IP), so validation succeeds
-	// only if the permissive client is used for this issuer.
-	//
-	// We call NewOIDCValidator directly (not the test-helper path) to exercise
-	// the production client-selection logic. The returned validator's internal
-	// permissiveClient will be an SSRF-safe-by-default client that has
-	// AllowPrivateIP=true, but we can't reach the httptest TLS server with it
-	// because it uses a custom TLS cert. Use newOIDCValidatorWithClient so the
-	// injected client (already configured for the httptest cert) is used for both
-	// slots — the important thing is that AllowPrivateIPJWKS=true routes to the
-	// permissive slot and a valid token is accepted.
+	// httptest TLS cert mismatch prevents using NewOIDCValidator directly; inject
+	// the configured client so AllowPrivateIPJWKS routing is still exercised.
 	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
 		Issuer:             testIssuer,
 		JwksURL:            jwksURL,
@@ -457,8 +447,6 @@ func TestOIDCValidator_AllowPrivateIPJWKS(t *testing.T) {
 }
 
 func TestNewOIDCValidator_AllowPrivateIPJWKS_CreatesPermissiveClient(t *testing.T) {
-	// Verify that NewOIDCValidator creates a non-nil permissiveClient when at
-	// least one issuer sets AllowPrivateIPJWKS, and leaves it nil otherwise.
 	withPrivate, err := NewOIDCValidator([]TrustedIssuer{{
 		Issuer:             testIssuer,
 		JwksURL:            "https://example.com/jwks",

--- a/server/subject_validator_test.go
+++ b/server/subject_validator_test.go
@@ -417,3 +417,60 @@ func TestWithTrustedIssuers_RegistersValidators(t *testing.T) {
 	require.NotNil(t, srv.SubjectValidatorFor(SubjectTokenTypeAccessToken))
 	require.NotNil(t, srv.SubjectValidatorFor(SubjectTokenTypeJWT))
 }
+
+func TestOIDCValidator_AllowPrivateIPJWKS(t *testing.T) {
+	key := newTestECKey(t)
+	const kid = "test-key"
+	jwksURL, jwksClient := serveStaticJWKS(t, key, kid)
+
+	// NewOIDCValidator with AllowPrivateIPJWKS=true must create a permissive
+	// client. The test server is localhost (private IP), so validation succeeds
+	// only if the permissive client is used for this issuer.
+	//
+	// We call NewOIDCValidator directly (not the test-helper path) to exercise
+	// the production client-selection logic. The returned validator's internal
+	// permissiveClient will be an SSRF-safe-by-default client that has
+	// AllowPrivateIP=true, but we can't reach the httptest TLS server with it
+	// because it uses a custom TLS cert. Use newOIDCValidatorWithClient so the
+	// injected client (already configured for the httptest cert) is used for both
+	// slots — the important thing is that AllowPrivateIPJWKS=true routes to the
+	// permissive slot and a valid token is accepted.
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             testIssuer,
+		JwksURL:            jwksURL,
+		AllowedAudiences:   []string{testAudience},
+		AllowPrivateIPJWKS: true,
+	}}, jwksClient)
+	require.NoError(t, err)
+
+	token := signSubjectToken(t, key, kid, josejwt.Claims{
+		Issuer:   testIssuer,
+		Subject:  testSubject,
+		Audience: josejwt.Audience{testAudience},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt: josejwt.NewNumericDate(time.Now()),
+	})
+
+	identity, err := v.Validate(t.Context(), token, SubjectTokenTypeIDToken)
+	require.NoError(t, err)
+	require.Equal(t, testSubject, identity.Subject)
+}
+
+func TestNewOIDCValidator_AllowPrivateIPJWKS_CreatesPermissiveClient(t *testing.T) {
+	// Verify that NewOIDCValidator creates a non-nil permissiveClient when at
+	// least one issuer sets AllowPrivateIPJWKS, and leaves it nil otherwise.
+	withPrivate, err := NewOIDCValidator([]TrustedIssuer{{
+		Issuer:             testIssuer,
+		JwksURL:            "https://example.com/jwks",
+		AllowPrivateIPJWKS: true,
+	}})
+	require.NoError(t, err)
+	require.NotNil(t, withPrivate.permissiveClient)
+
+	withoutPrivate, err := NewOIDCValidator([]TrustedIssuer{{
+		Issuer:  testIssuer,
+		JwksURL: "https://example.com/jwks",
+	}})
+	require.NoError(t, err)
+	require.Nil(t, withoutPrivate.permissiveClient)
+}


### PR DESCRIPTION
## What

`OIDCValidator` used a single SSRF-safe JWKS client for all trusted issuers, blocking any `JwksURL` that resolves to a private or loopback address. In-cluster JWKS endpoints (e.g. the Kubernetes API server's `/openid/v1/jwks` at `kubernetes.default.svc`) are unreachable with that constraint.

## How

Add `AllowPrivateIPJWKS bool` to `TrustedIssuer`. `OIDCValidator` now holds two clients: the default private-IP-blocking one, and a permissive one allocated only when at least one issuer opts in. `Validate` picks the client per issuer, so opting in for one issuer does not affect others.

`newOIDCValidatorWithClient` (test helper) sets both slots to the injected client, so all existing tests are unaffected.