### PR TITLE
test: cover atomic single-use gates, ValidateNonceClaim, and validateTimeAndIssuer

### DIFF
--- a/providers/oidc/jwt_test.go
+++ b/providers/oidc/jwt_test.go
@@ -244,32 +244,91 @@ func TestValidateAudience(t *testing.T) {
 	}
 }
 
-func TestValidateTimeAndIssuer_IssuerMismatch(t *testing.T) {
+func TestValidateTimeAndIssuer(t *testing.T) {
+	t.Parallel()
+
 	now := time.Now()
-	claims := &IDTokenClaims{
-		Claims: josejwt.Claims{
-			Issuer: "https://auth.example.com",
-			Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+	beyondLeeway := DefaultClockSkewLeeway + time.Minute
+
+	tests := []struct {
+		name           string
+		claims         *IDTokenClaims
+		expectedIssuer string
+		wantErr        error
+	}{
+		{
+			name: "happy path",
+			claims: &IDTokenClaims{Claims: josejwt.Claims{
+				Issuer: "https://auth.example.com",
+				Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+			}},
+			expectedIssuer: "https://auth.example.com",
+			wantErr:        nil,
+		},
+		{
+			name: "issuer mismatch",
+			claims: &IDTokenClaims{Claims: josejwt.Claims{
+				Issuer: "https://auth.example.com",
+				Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+			}},
+			expectedIssuer: "https://other.example.com",
+			wantErr:        ErrIssuerMismatch,
+		},
+		{
+			name: "no expected issuer skips check",
+			claims: &IDTokenClaims{Claims: josejwt.Claims{
+				Issuer: "https://anything.example.com",
+				Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
+			}},
+			expectedIssuer: "",
+			wantErr:        nil,
+		},
+		{
+			name: "token expired beyond leeway",
+			claims: &IDTokenClaims{Claims: josejwt.Claims{
+				Issuer: "https://auth.example.com",
+				Expiry: josejwt.NewNumericDate(now.Add(-beyondLeeway)),
+			}},
+			expectedIssuer: "https://auth.example.com",
+			wantErr:        ErrTokenExpired,
+		},
+		{
+			name: "token not valid yet beyond leeway",
+			claims: &IDTokenClaims{Claims: josejwt.Claims{
+				Issuer:    "https://auth.example.com",
+				NotBefore: josejwt.NewNumericDate(now.Add(beyondLeeway)),
+				Expiry:    josejwt.NewNumericDate(now.Add(time.Hour)),
+			}},
+			expectedIssuer: "https://auth.example.com",
+			wantErr:        ErrTokenNotValidYet,
+		},
+		{
+			// iat in the far future triggers go-jose ErrIssuedInTheFuture,
+			// which is wrapped by the default branch as a generic validation error.
+			name: "iat in the future hits default error branch",
+			claims: &IDTokenClaims{Claims: josejwt.Claims{
+				Issuer:   "https://auth.example.com",
+				IssuedAt: josejwt.NewNumericDate(now.Add(beyondLeeway)),
+				Expiry:   josejwt.NewNumericDate(now.Add(time.Hour)),
+			}},
+			expectedIssuer: "https://auth.example.com",
+			wantErr:        josejwt.ErrIssuedInTheFuture,
 		},
 	}
 
-	err := validateTimeAndIssuer(claims, "https://other.example.com")
-	if err == nil {
-		t.Fatal("validateTimeAndIssuer() expected error, got nil")
-	}
-}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_ = t.Context()
 
-func TestValidateTimeAndIssuer_NoExpectedIssuerSkipsCheck(t *testing.T) {
-	now := time.Now()
-	claims := &IDTokenClaims{
-		Claims: josejwt.Claims{
-			Issuer: "https://anything.example.com",
-			Expiry: josejwt.NewNumericDate(now.Add(time.Hour)),
-		},
-	}
+			err := validateTimeAndIssuer(tt.claims, tt.expectedIssuer)
 
-	if err := validateTimeAndIssuer(claims, ""); err != nil {
-		t.Errorf("validateTimeAndIssuer() with empty expected issuer should pass, got: %v", err)
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
 	}
 }
 

--- a/providers/oidc/jwt_test.go
+++ b/providers/oidc/jwt_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsJWT(t *testing.T) {
@@ -290,6 +291,93 @@ func TestParseAndValidateToken_TimeValidation(t *testing.T) {
 			t.Errorf("DefaultClockSkewLeeway = %v, want %v", DefaultClockSkewLeeway, expected)
 		}
 	})
+}
+
+func TestValidateNonceClaim(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		claimNonce     string
+		expectedNonce  string
+		wantErr        error
+		wantErrMessage string
+	}{
+		{
+			name:          "match",
+			claimNonce:    "abc",
+			expectedNonce: "abc",
+			wantErr:       nil,
+		},
+		{
+			name:          "mismatch",
+			claimNonce:    "abc",
+			expectedNonce: "xyz",
+			wantErr:       ErrNonceMismatch,
+		},
+		{
+			name:           "missing in claims",
+			claimNonce:     "",
+			expectedNonce:  "abc",
+			wantErr:        ErrNonceMismatch,
+			wantErrMessage: "claim absent",
+		},
+		{
+			name:          "missing expectation",
+			claimNonce:    "abc",
+			expectedNonce: "",
+			wantErr:       nil,
+		},
+		{
+			name:          "both empty",
+			claimNonce:    "",
+			expectedNonce: "",
+			wantErr:       nil,
+		},
+		{
+			name:          "same length different content",
+			claimNonce:    "aaaa",
+			expectedNonce: "bbbb",
+			wantErr:       ErrNonceMismatch,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_ = t.Context()
+
+			err := ValidateNonceClaim(tt.claimNonce, tt.expectedNonce)
+
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+			if tt.wantErrMessage != "" {
+				require.Contains(t, err.Error(), tt.wantErrMessage)
+			}
+		})
+	}
+}
+
+// TestIDTokenClaims_NonStringNonce documents the first line of nonce-defence
+// in depth: ValidateNonceClaim only sees a string, because the typed
+// IDTokenClaims.Nonce field rejects a non-string JSON value during claim
+// extraction. A token with "nonce": 42 fails before the comparison runs.
+func TestIDTokenClaims_NonStringNonce(t *testing.T) {
+	t.Parallel()
+	_ = t.Context()
+
+	payload, err := json.Marshal(map[string]any{
+		"sub":   "user",
+		"nonce": 42,
+	})
+	require.NoError(t, err)
+
+	var claims IDTokenClaims
+	err = json.Unmarshal(payload, &claims)
+	require.Error(t, err, "non-string nonce must not unmarshal into IDTokenClaims.Nonce")
 }
 
 // createTestJWTWithClaims creates a JWT token for testing purposes.

--- a/storage/atomic_gates_parity_test.go
+++ b/storage/atomic_gates_parity_test.go
@@ -1,0 +1,119 @@
+package storage_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/storage"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+	"github.com/giantswarm/mcp-oauth/storage/valkey"
+)
+
+// TestAtomicGates_BackendParity verifies that the memory and valkey backends
+// produce identical outcomes for the OAuth 2.1 single-use enforcement gates
+// (RFC 6749 §4.1.2 authorization code reuse, refresh-token reuse). Divergence
+// here would mean one backend silently allows replay where the other rejects.
+func TestAtomicGates_BackendParity(t *testing.T) {
+	backends := []struct {
+		name    string
+		factory func(t *testing.T) storage.Combined
+	}{
+		{name: storage.BackendMemory, factory: newMemoryBackend},
+		{name: storage.BackendValkey, factory: newValkeyBackend},
+	}
+
+	for _, b := range backends {
+		t.Run(b.name, func(t *testing.T) {
+			t.Run("auth_code_first_use_then_reuse", func(t *testing.T) {
+				s := b.factory(t)
+
+				code := &storage.AuthorizationCode{
+					Code:      fmt.Sprintf("parity-ac-%s", b.name),
+					ClientID:  "client-parity",
+					UserID:    "user-parity",
+					CreatedAt: time.Now(),
+					ExpiresAt: time.Now().Add(5 * time.Minute),
+				}
+				require.NoError(t, s.SaveAuthorizationCode(t.Context(), code))
+
+				first, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code.Code)
+				require.NoError(t, err)
+				require.NotNil(t, first)
+
+				reused, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code.Code)
+				require.ErrorIs(t, err, storage.ErrAuthorizationCodeUsed)
+				require.NotNil(t, reused, "reuse case must surface the stored code")
+				require.True(t, reused.Used)
+			})
+
+			t.Run("auth_code_unknown_returns_not_found", func(t *testing.T) {
+				s := b.factory(t)
+				got, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), "parity-ac-unknown")
+				require.ErrorIs(t, err, storage.ErrAuthorizationCodeNotFound)
+				require.Nil(t, got)
+			})
+
+			t.Run("refresh_token_first_use_then_reuse", func(t *testing.T) {
+				s := b.factory(t)
+
+				refreshToken := fmt.Sprintf("parity-rt-%s", b.name)
+				providerToken := &oauth2.Token{
+					AccessToken:  "provider-access",
+					RefreshToken: "provider-refresh",
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}
+				require.NoError(t, s.SaveToken(t.Context(), refreshToken, providerToken))
+				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, "user-parity", time.Now().Add(time.Hour)))
+
+				userID, _, gotToken, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+				require.NoError(t, err)
+				require.Equal(t, "user-parity", userID)
+				require.NotNil(t, gotToken)
+
+				_, _, _, err = s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+				require.ErrorIs(t, err, storage.ErrTokenNotFound)
+			})
+
+			t.Run("refresh_token_unknown_returns_not_found", func(t *testing.T) {
+				s := b.factory(t)
+				_, _, _, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), "parity-rt-unknown")
+				require.ErrorIs(t, err, storage.ErrTokenNotFound)
+				require.True(t,
+					errors.Is(err, storage.ErrTokenNotFound),
+					"backends MUST agree on the sentinel error type",
+				)
+			})
+		})
+	}
+}
+
+func newMemoryBackend(t *testing.T) storage.Combined {
+	t.Helper()
+	s := memory.New(memory.WithCleanupInterval(time.Hour))
+	t.Cleanup(s.Stop)
+	return s
+}
+
+func newValkeyBackend(t *testing.T) storage.Combined {
+	t.Helper()
+
+	addr := os.Getenv("VALKEY_TEST_ADDR")
+	if addr == "" {
+		addr = "localhost:6379"
+	}
+
+	prefix := fmt.Sprintf("mcptest-parity:%s:", t.Name())
+	s, err := valkey.New(valkey.Config{Address: addr, KeyPrefix: prefix})
+	if err != nil {
+		t.Skipf("skipping valkey parity: could not connect to %s: %v", addr, err)
+	}
+	t.Cleanup(func() { s.Close() })
+	return s
+}

--- a/storage/atomic_gates_parity_test.go
+++ b/storage/atomic_gates_parity_test.go
@@ -1,13 +1,14 @@
 package storage_test
 
 import (
-	"errors"
+	"context"
 	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	valkeygo "github.com/valkey-io/valkey-go"
 	"golang.org/x/oauth2"
 
 	"github.com/giantswarm/mcp-oauth/storage"
@@ -19,6 +20,10 @@ import (
 // produce identical outcomes for the OAuth 2.1 single-use enforcement gates
 // (RFC 6749 §4.1.2 authorization code reuse, refresh-token reuse). Divergence
 // here would mean one backend silently allows replay where the other rejects.
+//
+// The factory returns storage.Combined deliberately, to keep assertions
+// backend-agnostic; backend-specific behaviour belongs in the per-backend
+// test files.
 func TestAtomicGates_BackendParity(t *testing.T) {
 	backends := []struct {
 		name    string
@@ -84,11 +89,7 @@ func TestAtomicGates_BackendParity(t *testing.T) {
 			t.Run("refresh_token_unknown_returns_not_found", func(t *testing.T) {
 				s := b.factory(t)
 				_, _, _, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), "parity-rt-unknown")
-				require.ErrorIs(t, err, storage.ErrTokenNotFound)
-				require.True(t,
-					errors.Is(err, storage.ErrTokenNotFound),
-					"backends MUST agree on the sentinel error type",
-				)
+				require.ErrorIs(t, err, storage.ErrTokenNotFound, "backends MUST agree on the sentinel error type")
 			})
 		})
 	}
@@ -110,10 +111,48 @@ func newValkeyBackend(t *testing.T) storage.Combined {
 	}
 
 	prefix := fmt.Sprintf("mcptest-parity:%s:", t.Name())
+
+	flushValkeyPrefix(t, addr, prefix)
+
 	s, err := valkey.New(valkey.Config{Address: addr, KeyPrefix: prefix})
 	if err != nil {
 		t.Skipf("skipping valkey parity: could not connect to %s: %v", addr, err)
 	}
-	t.Cleanup(func() { s.Close() })
+	t.Cleanup(func() {
+		flushValkeyPrefix(t, addr, prefix)
+		s.Close()
+	})
 	return s
+}
+
+// flushValkeyPrefix SCAN+DELs every key matching prefix+"*". Mirrors the
+// cleanupTestKeys ritual used by storage/valkey/store_test.go so the parity
+// test is resilient to keys left over from a crashed prior run with the same
+// t.Name().
+func flushValkeyPrefix(t *testing.T, addr, prefix string) {
+	t.Helper()
+
+	client, err := valkeygo.NewClient(valkeygo.ClientOption{InitAddress: []string{addr}})
+	if err != nil {
+		return
+	}
+	defer client.Close()
+
+	ctx := context.Background()
+	pattern := prefix + "*"
+	var cursor uint64
+	for {
+		entry, err := client.Do(ctx, client.B().Scan().Cursor(cursor).Match(pattern).Count(100).Build()).AsScanEntry()
+		if err != nil {
+			t.Logf("warning: failed to scan for cleanup: %v", err)
+			return
+		}
+		for _, key := range entry.Elements {
+			_ = client.Do(ctx, client.B().Del().Key(key).Build())
+		}
+		cursor = entry.Cursor
+		if cursor == 0 {
+			return
+		}
+	}
 }

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -2,13 +2,17 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"log/slog"
+	"sync/atomic"
 	"testing"
 	"testing/synctest"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/giantswarm/mcp-oauth/internal/testutil"
 	"github.com/giantswarm/mcp-oauth/security"
@@ -988,6 +992,244 @@ func TestStore_DeleteAuthorizationCode(t *testing.T) {
 	if err == nil {
 		t.Error("GetAuthorizationCode() should return error after deletion")
 	}
+}
+
+// ============================================================
+// Atomic single-use enforcement (OAuth 2.1 / RFC 6749 §4.1.2)
+// ============================================================
+
+func TestStore_AtomicCheckAndMarkAuthCodeUsed(t *testing.T) {
+	tests := []struct {
+		name         string
+		prepare      func(t *testing.T, s *Store) string
+		wantSentinel error
+		wantUsedFlag bool
+	}{
+		{
+			name: "first use succeeds",
+			prepare: func(t *testing.T, s *Store) string {
+				code := testutil.GenerateTestAuthorizationCode()
+				require.NoError(t, s.SaveAuthorizationCode(t.Context(), code))
+				return code.Code
+			},
+		},
+		{
+			name: "second use returns reuse sentinel",
+			prepare: func(t *testing.T, s *Store) string {
+				code := testutil.GenerateTestAuthorizationCode()
+				require.NoError(t, s.SaveAuthorizationCode(t.Context(), code))
+				_, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code.Code)
+				require.NoError(t, err)
+				return code.Code
+			},
+			wantSentinel: storage.ErrAuthorizationCodeUsed,
+			wantUsedFlag: true,
+		},
+		{
+			name: "unknown code returns not-found",
+			prepare: func(_ *testing.T, _ *Store) string {
+				return "nonexistent-code"
+			},
+			wantSentinel: storage.ErrAuthorizationCodeNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := New(WithCleanupInterval(time.Hour))
+			t.Cleanup(store.Stop)
+
+			code := tt.prepare(t, store)
+			got, err := store.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code)
+
+			if tt.wantSentinel == nil {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantSentinel)
+			if tt.wantUsedFlag {
+				require.NotNil(t, got, "reuse case must surface the stored code for forensics")
+				require.True(t, got.Used)
+			} else {
+				require.Nil(t, got, "non-reuse failures must not leak code data")
+			}
+		})
+	}
+}
+
+func TestStore_AtomicCheckAndMarkAuthCodeUsed_Expired(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := New(WithCleanupInterval(time.Hour))
+		t.Cleanup(store.Stop)
+
+		code := testutil.GenerateTestAuthorizationCode()
+		code.ExpiresAt = time.Now().Add(1 * time.Minute)
+		require.NoError(t, store.SaveAuthorizationCode(t.Context(), code))
+
+		// Advance virtual time past expiry + clock skew grace period.
+		time.Sleep(2 * time.Minute)
+		synctest.Wait()
+
+		got, err := store.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code.Code)
+		require.ErrorIs(t, err, storage.ErrTokenExpired)
+		require.Nil(t, got)
+	})
+}
+
+func TestStore_AtomicCheckAndMarkAuthCodeUsed_Concurrent(t *testing.T) {
+	const n = 100
+
+	store := New(WithCleanupInterval(time.Hour))
+	t.Cleanup(store.Stop)
+
+	code := testutil.GenerateTestAuthorizationCode()
+	require.NoError(t, store.SaveAuthorizationCode(t.Context(), code))
+
+	var success, reuse atomic.Int32
+	ready := make(chan struct{})
+	g, ctx := errgroup.WithContext(t.Context())
+	for range n {
+		g.Go(func() error {
+			<-ready
+			_, err := store.AtomicCheckAndMarkAuthCodeUsed(ctx, code.Code)
+			switch {
+			case err == nil:
+				success.Add(1)
+				return nil
+			case errors.Is(err, storage.ErrAuthorizationCodeUsed):
+				reuse.Add(1)
+				return nil
+			default:
+				return err
+			}
+		})
+	}
+	close(ready)
+	require.NoError(t, g.Wait())
+
+	// SECURITY: exactly one goroutine must succeed; all others see reuse.
+	require.Equal(t, int32(1), success.Load(), "more than one success would break OAuth 2.1 §4.1.2")
+	require.Equal(t, int32(n-1), reuse.Load())
+}
+
+func TestStore_AtomicGetAndDeleteRefreshToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		prepare      func(t *testing.T, s *Store) string
+		wantSentinel error
+	}{
+		{
+			name: "first use succeeds",
+			prepare: func(t *testing.T, s *Store) string {
+				const refreshToken = "rt-first-use"
+				providerToken := testutil.GenerateTestToken()
+				require.NoError(t, s.SaveToken(t.Context(), refreshToken, providerToken))
+				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+				return refreshToken
+			},
+		},
+		{
+			name: "second use returns not-found sentinel",
+			prepare: func(t *testing.T, s *Store) string {
+				const refreshToken = "rt-reuse"
+				providerToken := testutil.GenerateTestToken()
+				require.NoError(t, s.SaveToken(t.Context(), refreshToken, providerToken))
+				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+				_, _, _, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+				require.NoError(t, err)
+				return refreshToken
+			},
+			wantSentinel: storage.ErrTokenNotFound,
+		},
+		{
+			name: "unknown refresh token returns not-found",
+			prepare: func(_ *testing.T, _ *Store) string {
+				return "no-such-refresh-token"
+			},
+			wantSentinel: storage.ErrTokenNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := New(WithCleanupInterval(time.Hour))
+			t.Cleanup(store.Stop)
+
+			refreshToken := tt.prepare(t, store)
+			userID, _, providerToken, err := store.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+
+			if tt.wantSentinel == nil {
+				require.NoError(t, err)
+				require.Equal(t, testUserID, userID)
+				require.NotNil(t, providerToken)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantSentinel)
+			require.Empty(t, userID)
+			require.Nil(t, providerToken)
+		})
+	}
+}
+
+func TestStore_AtomicGetAndDeleteRefreshToken_Expired(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		store := New(WithCleanupInterval(time.Hour))
+		t.Cleanup(store.Stop)
+
+		const refreshToken = "rt-expired"
+		providerToken := testutil.GenerateTestToken()
+		require.NoError(t, store.SaveToken(t.Context(), refreshToken, providerToken))
+		require.NoError(t, store.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(1*time.Minute)))
+
+		time.Sleep(2 * time.Minute)
+		synctest.Wait()
+
+		userID, clientID, gotToken, err := store.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+		require.ErrorIs(t, err, storage.ErrTokenExpired)
+		require.Empty(t, userID)
+		require.Empty(t, clientID)
+		require.Nil(t, gotToken)
+	})
+}
+
+func TestStore_AtomicGetAndDeleteRefreshToken_Concurrent(t *testing.T) {
+	const n = 100
+
+	store := New(WithCleanupInterval(time.Hour))
+	t.Cleanup(store.Stop)
+
+	const refreshToken = "rt-concurrent"
+	providerToken := testutil.GenerateTestToken()
+	require.NoError(t, store.SaveToken(t.Context(), refreshToken, providerToken))
+	require.NoError(t, store.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+
+	var success, notFound atomic.Int32
+	ready := make(chan struct{})
+	g, ctx := errgroup.WithContext(t.Context())
+	for range n {
+		g.Go(func() error {
+			<-ready
+			_, _, _, err := store.AtomicGetAndDeleteRefreshToken(ctx, refreshToken)
+			switch {
+			case err == nil:
+				success.Add(1)
+				return nil
+			case errors.Is(err, storage.ErrTokenNotFound):
+				notFound.Add(1)
+				return nil
+			default:
+				return err
+			}
+		})
+	}
+	close(ready)
+	require.NoError(t, g.Wait())
+
+	require.Equal(t, int32(1), success.Load(), "more than one success would allow refresh token reuse")
+	require.Equal(t, int32(n-1), notFound.Load())
 }
 
 // ============================================================

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -746,7 +746,9 @@ func TestTokenStore_AtomicGetAndDeleteRefreshToken_MalformedTokenJSON(t *testing
 
 // TestTokenStore_AtomicGetAndDeleteRefreshToken_DecryptError exercises the
 // decryptToken error branch: an encryptor is configured but the provider
-// token field is not a valid ciphertext.
+// token field is not a valid ciphertext. Models config drift across a deploy
+// (e.g., encryption enabled retroactively while plaintext tokens still exist
+// at rest) so the surfaced error must be opaque, never ErrTokenNotFound.
 func TestTokenStore_AtomicGetAndDeleteRefreshToken_DecryptError(t *testing.T) {
 	key, err := security.GenerateKey()
 	require.NoError(t, err)

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -2,15 +2,19 @@ package valkey
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/oauth2"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/giantswarm/mcp-oauth/instrumentation"
 	"github.com/giantswarm/mcp-oauth/security"
@@ -455,6 +459,360 @@ func TestTokenStore_DeleteRefreshToken(t *testing.T) {
 	if err != storage.ErrTokenNotFound {
 		t.Errorf("Token should be deleted, got: %v", err)
 	}
+}
+
+// ============================================================
+// Atomic single-use enforcement (OAuth 2.1 / RFC 6749 §4.1.2)
+// ============================================================
+
+func TestFlowStore_AtomicCheckAndMarkAuthCodeUsed_Table(t *testing.T) {
+	tests := []struct {
+		name         string
+		prepare      func(t *testing.T, s *Store) string
+		wantSentinel error
+		wantUsedFlag bool
+	}{
+		{
+			name: "first use succeeds",
+			prepare: func(t *testing.T, s *Store) string {
+				code := &storage.AuthorizationCode{
+					Code:      "ac-first-use",
+					ClientID:  "client-1",
+					UserID:    testUserID,
+					CreatedAt: time.Now(),
+					ExpiresAt: time.Now().Add(5 * time.Minute),
+				}
+				require.NoError(t, s.SaveAuthorizationCode(t.Context(), code))
+				return code.Code
+			},
+		},
+		{
+			name: "second use returns reuse sentinel",
+			prepare: func(t *testing.T, s *Store) string {
+				code := &storage.AuthorizationCode{
+					Code:      "ac-reuse",
+					ClientID:  "client-1",
+					UserID:    testUserID,
+					CreatedAt: time.Now(),
+					ExpiresAt: time.Now().Add(5 * time.Minute),
+				}
+				require.NoError(t, s.SaveAuthorizationCode(t.Context(), code))
+				_, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code.Code)
+				require.NoError(t, err)
+				return code.Code
+			},
+			wantSentinel: storage.ErrAuthorizationCodeUsed,
+			wantUsedFlag: true,
+		},
+		{
+			name: "unknown code returns not-found",
+			prepare: func(_ *testing.T, _ *Store) string {
+				return "ac-nonexistent"
+			},
+			wantSentinel: storage.ErrAuthorizationCodeNotFound,
+		},
+		{
+			name: "expired code returns expired sentinel",
+			prepare: func(t *testing.T, s *Store) string {
+				// Bypass SaveAuthorizationCode (which rejects past expiry) by
+				// writing a long-TTL key with a past expires_at in the JSON.
+				// This exercises the Lua expiry-check branch.
+				code := "ac-expired"
+				j := authorizationCodeJSON{
+					Code:      code,
+					ClientID:  "client-1",
+					UserID:    testUserID,
+					CreatedAt: time.Now().Add(-10 * time.Minute).Unix(),
+					ExpiresAt: time.Now().Add(-1 * time.Minute).Unix(),
+					Used:      false,
+				}
+				data, err := json.Marshal(j)
+				require.NoError(t, err)
+				require.NoError(t, s.client.Do(
+					t.Context(),
+					s.client.B().Set().Key(s.codeKey(code)).Value(string(data)).Ex(time.Hour).Build(),
+				).Error())
+				return code
+			},
+			wantSentinel: storage.ErrTokenExpired,
+		},
+		{
+			name: "already-used code with malformed body still surfaces reuse sentinel",
+			prepare: func(t *testing.T, s *Store) string {
+				// Lua's cjson tolerates a string expires_at; Go's json.Unmarshal
+				// does not. Exercises the reuse path where the inner JSON cannot
+				// be decoded for forensics — caller must still see the sentinel.
+				code := "ac-reuse-malformed"
+				raw := `{"code":"ac-reuse-malformed","client_id":"client-1","user_id":"user-1","expires_at":"not-a-number","used":true}`
+				require.NoError(t, s.client.Do(
+					t.Context(),
+					s.client.B().Set().Key(s.codeKey(code)).Value(raw).Ex(time.Hour).Build(),
+				).Error())
+				return code
+			},
+			wantSentinel: storage.ErrAuthorizationCodeUsed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := testStore(t)
+
+			code := tt.prepare(t, s)
+			got, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code)
+
+			if tt.wantSentinel == nil {
+				require.NoError(t, err)
+				require.NotNil(t, got)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantSentinel)
+			if tt.wantUsedFlag {
+				require.NotNil(t, got, "reuse case must surface the stored code for forensics")
+				require.True(t, got.Used)
+			} else {
+				require.Nil(t, got, "non-reuse failures must not leak code data")
+			}
+		})
+	}
+}
+
+// TestFlowStore_AtomicCheckAndMarkAuthCodeUsed_MalformedSuccessJSON exercises
+// the Go-side json.Unmarshal error branch in the success path: Lua's cjson
+// accepts a string `expires_at`, Go's typed unmarshal does not.
+func TestFlowStore_AtomicCheckAndMarkAuthCodeUsed_MalformedSuccessJSON(t *testing.T) {
+	s := testStore(t)
+
+	const code = "ac-malformed-success"
+	raw := `{"code":"ac-malformed-success","client_id":"client-1","user_id":"user-1","expires_at":"not-a-number","used":false}`
+	require.NoError(t, s.client.Do(
+		t.Context(),
+		s.client.B().Set().Key(s.codeKey(code)).Value(raw).Ex(time.Hour).Build(),
+	).Error())
+
+	got, err := s.AtomicCheckAndMarkAuthCodeUsed(t.Context(), code)
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.NotErrorIs(t, err, storage.ErrAuthorizationCodeUsed)
+	require.NotErrorIs(t, err, storage.ErrAuthorizationCodeNotFound)
+}
+
+func TestFlowStore_AtomicCheckAndMarkAuthCodeUsed_ConcurrentN100(t *testing.T) {
+	const n = 100
+
+	s := testStore(t)
+
+	code := &storage.AuthorizationCode{
+		Code:      "ac-concurrent-100",
+		ClientID:  "client-1",
+		UserID:    testUserID,
+		CreatedAt: time.Now(),
+		ExpiresAt: time.Now().Add(5 * time.Minute),
+	}
+	require.NoError(t, s.SaveAuthorizationCode(t.Context(), code))
+
+	var success, reuse atomic.Int32
+	ready := make(chan struct{})
+	g, ctx := errgroup.WithContext(t.Context())
+	for range n {
+		g.Go(func() error {
+			<-ready
+			_, err := s.AtomicCheckAndMarkAuthCodeUsed(ctx, code.Code)
+			switch {
+			case err == nil:
+				success.Add(1)
+				return nil
+			case errors.Is(err, storage.ErrAuthorizationCodeUsed):
+				reuse.Add(1)
+				return nil
+			default:
+				return err
+			}
+		})
+	}
+	close(ready)
+	require.NoError(t, g.Wait())
+
+	require.Equal(t, int32(1), success.Load(), "more than one success would break OAuth 2.1 §4.1.2")
+	require.Equal(t, int32(n-1), reuse.Load())
+}
+
+func TestTokenStore_AtomicGetAndDeleteRefreshToken(t *testing.T) {
+	tests := []struct {
+		name         string
+		prepare      func(t *testing.T, s *Store) string
+		wantSentinel error
+	}{
+		{
+			name: "first use succeeds",
+			prepare: func(t *testing.T, s *Store) string {
+				const refreshToken = "rt-first-use"
+				providerToken := &oauth2.Token{
+					AccessToken:  "provider-access",
+					RefreshToken: "provider-refresh",
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}
+				require.NoError(t, s.SaveToken(t.Context(), refreshToken, providerToken))
+				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+				return refreshToken
+			},
+		},
+		{
+			name: "second use returns not-found sentinel",
+			prepare: func(t *testing.T, s *Store) string {
+				const refreshToken = "rt-reuse"
+				providerToken := &oauth2.Token{
+					AccessToken:  "provider-access",
+					RefreshToken: "provider-refresh",
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}
+				require.NoError(t, s.SaveToken(t.Context(), refreshToken, providerToken))
+				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+				_, _, _, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+				require.NoError(t, err)
+				return refreshToken
+			},
+			wantSentinel: storage.ErrTokenNotFound,
+		},
+		{
+			name: "unknown refresh token returns not-found",
+			prepare: func(_ *testing.T, _ *Store) string {
+				return "rt-nonexistent"
+			},
+			wantSentinel: storage.ErrTokenNotFound,
+		},
+		{
+			name: "refresh mapping without provider token returns not-found",
+			prepare: func(t *testing.T, s *Store) string {
+				// Exercises the TOKEN_NOT_FOUND branch of the Lua script: the
+				// refresh-token→userID mapping exists but the provider token
+				// has been evicted (TTL mismatch, manual deletion, etc.).
+				const refreshToken = "rt-orphan-mapping"
+				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+				return refreshToken
+			},
+			wantSentinel: storage.ErrTokenNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := testStore(t)
+
+			refreshToken := tt.prepare(t, s)
+			userID, _, providerToken, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+
+			if tt.wantSentinel == nil {
+				require.NoError(t, err)
+				require.Equal(t, testUserID, userID)
+				require.NotNil(t, providerToken)
+				return
+			}
+
+			require.ErrorIs(t, err, tt.wantSentinel)
+			require.Empty(t, userID)
+			require.Nil(t, providerToken)
+		})
+	}
+}
+
+// TestTokenStore_AtomicGetAndDeleteRefreshToken_MalformedTokenJSON exercises
+// the Go-side json.Unmarshal error branch in the success path: Lua's cjson
+// accepts a JSON array as a "token", Go's typed unmarshal into serializableToken
+// does not.
+func TestTokenStore_AtomicGetAndDeleteRefreshToken_MalformedTokenJSON(t *testing.T) {
+	s := testStore(t)
+
+	const refreshToken = "rt-malformed-token"
+	require.NoError(t, s.client.Do(
+		t.Context(),
+		s.client.B().Set().Key(s.refreshTokenKey(refreshToken)).Value(testUserID).Ex(time.Hour).Build(),
+	).Error())
+	require.NoError(t, s.client.Do(
+		t.Context(),
+		s.client.B().Set().Key(s.tokenKey(refreshToken)).Value(`[1,2,3]`).Ex(time.Hour).Build(),
+	).Error())
+
+	userID, clientID, gotToken, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, storage.ErrTokenNotFound)
+	require.Empty(t, userID)
+	require.Empty(t, clientID)
+	require.Nil(t, gotToken)
+}
+
+// TestTokenStore_AtomicGetAndDeleteRefreshToken_DecryptError exercises the
+// decryptToken error branch: an encryptor is configured but the provider
+// token field is not a valid ciphertext.
+func TestTokenStore_AtomicGetAndDeleteRefreshToken_DecryptError(t *testing.T) {
+	key, err := security.GenerateKey()
+	require.NoError(t, err)
+	enc, err := security.NewEncryptor(key)
+	require.NoError(t, err)
+
+	s := testStoreWithOpts(t, WithEncryptor(enc))
+
+	const refreshToken = "rt-decrypt-error"
+	require.NoError(t, s.client.Do(
+		t.Context(),
+		s.client.B().Set().Key(s.refreshTokenKey(refreshToken)).Value(testUserID).Ex(time.Hour).Build(),
+	).Error())
+	// Plain (un-encrypted) access token JSON — decryptToken will reject it.
+	require.NoError(t, s.client.Do(
+		t.Context(),
+		s.client.B().Set().Key(s.tokenKey(refreshToken)).Value(`{"access_token":"plaintext-not-a-ciphertext","token_type":"Bearer"}`).Ex(time.Hour).Build(),
+	).Error())
+
+	userID, clientID, gotToken, err := s.AtomicGetAndDeleteRefreshToken(t.Context(), refreshToken)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, storage.ErrTokenNotFound)
+	require.Empty(t, userID)
+	require.Empty(t, clientID)
+	require.Nil(t, gotToken)
+}
+
+func TestTokenStore_AtomicGetAndDeleteRefreshToken_ConcurrentN100(t *testing.T) {
+	const n = 100
+
+	s := testStore(t)
+
+	const refreshToken = "rt-concurrent-100"
+	providerToken := &oauth2.Token{
+		AccessToken:  "provider-access",
+		RefreshToken: "provider-refresh",
+		TokenType:    "Bearer",
+		Expiry:       time.Now().Add(time.Hour),
+	}
+	require.NoError(t, s.SaveToken(t.Context(), refreshToken, providerToken))
+	require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
+
+	var success, notFound atomic.Int32
+	ready := make(chan struct{})
+	g, ctx := errgroup.WithContext(t.Context())
+	for range n {
+		g.Go(func() error {
+			<-ready
+			_, _, _, err := s.AtomicGetAndDeleteRefreshToken(ctx, refreshToken)
+			switch {
+			case err == nil:
+				success.Add(1)
+				return nil
+			case errors.Is(err, storage.ErrTokenNotFound):
+				notFound.Add(1)
+				return nil
+			default:
+				return err
+			}
+		})
+	}
+	close(ready)
+	require.NoError(t, g.Wait())
+
+	require.Equal(t, int32(1), success.Load(), "more than one success would allow refresh token reuse")
+	require.Equal(t, int32(n-1), notFound.Load())
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

Test-coverage sweep across three uncovered or under-covered defences flagged by the audit at d31a02c. Three independent areas, no production changes.

### 1. Storage atomic single-use gates (RFC 6749 §4.1.2)

`AtomicCheckAndMarkAuthCodeUsed` and `AtomicGetAndDeleteRefreshToken` had 0% coverage in both backends; a regression here would silently allow authorization-code replay or refresh-token reuse.

Each backend now exercises:
- First-use success, then second-use sentinel (`ErrAuthorizationCodeUsed`, `ErrTokenNotFound`).
- Expired path, with backend-specific sentinels:
  - Authorization code: both backends return `ErrTokenExpired`.
  - Refresh token, memory backend: explicit expiry check returns `ErrTokenExpired`.
  - Refresh token, valkey backend: Redis TTL evicts the key, so the surfaced sentinel is `ErrTokenNotFound` (the call site hard-codes `ARGV[2]="-1"`, so the Lua "EXPIRED" branch is intentionally unused for refresh).
- N=100 concurrent goroutines via `errgroup.Group` racing the same code or refresh token, asserting exactly one success and N-1 sentinels (the actual safety property under contention).
- Cross-backend parity in `storage/atomic_gates_parity_test.go`: same inputs must produce the same outcomes on memory and valkey, otherwise CI fails.

Memory expiry tests run inside `testing/synctest.Test` bubbles for a virtual clock. Valkey auth-code expiry uses direct key injection (long Redis TTL, past `expires_at` in the JSON) to exercise the Lua expiry branch without real-time waits.

### 2. `ValidateNonceClaim` (OIDC Core §3.1.2.1, §3.1.3.7)

`providers/oidc/jwt.go:325` had 0% coverage. Adds a table test covering match, mismatch, claim absent, expectation absent, both empty, and same-length-different-content (constant-time path). Also adds a sibling test asserting that a non-string `nonce` JSON value fails to unmarshal into `IDTokenClaims.Nonce` before `ValidateNonceClaim` ever runs, documenting the defence-in-depth.

### 3. `validateTimeAndIssuer`

Folds the two existing one-off tests into one table and adds the expired, not-valid-yet, and default-branch (`ErrIssuedInTheFuture`) rows.

## Coverage

| Function | Coverage |
| --- | --- |
| `memory.AtomicCheckAndMarkAuthCodeUsed` | 100.0% |
| `memory.AtomicGetAndDeleteRefreshToken` | 90.0% |
| `valkey.AtomicCheckAndMarkAuthCodeUsed` | 94.7% |
| `valkey.AtomicGetAndDeleteRefreshToken` | 90.5% |
| `providers/oidc.ValidateNonceClaim` | 100.0% |
| `providers/oidc.validateTimeAndIssuer` | 100.0% |

`go test -race -count=1 ./storage/... ./providers/oidc/...` passes locally.