### PR TITLE
feat(server): audit token-exchange grant emissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`Server.ExchangeSubjectToken` now emits audit events on every branch.** Successful exchanges fire `EventTokenIssued` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, the audience, granted scope, and the upstream actor issuer. JWT-mode misconfiguration, unsupported `subject_token_type`, subject-token validator rejection, and access-token issuance failure each fire `EventAuthFailure` with a distinct reason so dashboards can split them. Prior to this change RFC 8693 was the only token-issuing path that bypassed the audit log.
+
 - **Startup `WARN` for development-only overrides.** `AllowInsecureHTTP`, `AllowPrivateIPClientMetadata`, and `AllowPrivateIPJWKS` now emit a `slog.LevelWarn` entry at server initialisation when set, making it harder to accidentally leave these flags enabled in production. `AllowPrivateIPClientMetadata` and `AllowPrivateIPJWKS` previously logged from `server.New` only; the warnings are now unified under `logCoreSecurityWarnings` alongside all other security-posture checks. All three flags are documented in `docs/security.md` under a new "Development-only overrides" subsection. Closes #342.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **`Server.ExchangeSubjectToken` now emits audit events on every branch.** Successful exchanges fire `EventTokenIssued` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, the audience, granted scope, and the upstream actor issuer. JWT-mode misconfiguration, unsupported `subject_token_type`, subject-token validator rejection, and access-token issuance failure each fire `EventAuthFailure` with a distinct reason so dashboards can split them. Prior to this change RFC 8693 was the only token-issuing path that bypassed the audit log.
+- **`Server.ExchangeSubjectToken` now emits audit events on every branch.** Successful exchanges fire `EventTokenIssued` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, the audience, granted scope, and the upstream actor issuer. JWT-mode misconfiguration, unsupported `subject_token_type`, subject-token validator rejection, and access-token issuance failure each fire `EventAuthFailure` with a distinct `reason`.
 
 - **Startup `WARN` for development-only overrides.** `AllowInsecureHTTP`, `AllowPrivateIPClientMetadata`, and `AllowPrivateIPJWKS` now emit a `slog.LevelWarn` entry at server initialisation when set, making it harder to accidentally leave these flags enabled in production. `AllowPrivateIPClientMetadata` and `AllowPrivateIPJWKS` previously logged from `server.New` only; the warnings are now unified under `logCoreSecurityWarnings` alongside all other security-posture checks. All three flags are documented in `docs/security.md` under a new "Development-only overrides" subsection. Closes #342.
 

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/giantswarm/mcp-oauth/security"
 )
 
 // GrantTypeTokenExchange is the grant_type value for RFC 8693 token exchange.
@@ -29,11 +31,13 @@ func (s *Server) ExchangeSubjectToken(
 	subjectToken, subjectTokenType, resource, scope, dpopJKT string,
 ) (*TokenExchangeResult, error) {
 	if !s.Config.IsJWTAccessTokenFormat() {
+		s.logAuthFailure(ctx, "", "", "token_exchange_jwt_mode_required")
 		return nil, fmt.Errorf("token exchange requires JWT access token mode (set AccessTokenFormat=jwt)")
 	}
 
 	v := s.SubjectValidatorFor(subjectTokenType)
 	if v == nil {
+		s.logAuthFailure(ctx, "", "", fmt.Sprintf("unsupported_subject_token_type: %s", subjectTokenType))
 		return nil, &TokenExchangeUnsupportedTypeError{tokenType: subjectTokenType}
 	}
 
@@ -41,6 +45,7 @@ func (s *Server) ExchangeSubjectToken(
 	if err != nil {
 		s.Logger.Debug("token exchange: subject token validation failed",
 			"subject_token_type", subjectTokenType, "error", err)
+		s.logAuthFailure(ctx, "", "", fmt.Sprintf("subject_token_validation_failed: %v", err))
 		return nil, fmt.Errorf("subject token validation: %w", err)
 	}
 
@@ -64,12 +69,25 @@ func (s *Server) ExchangeSubjectToken(
 		JKT:       dpopJKT,
 	})
 	if err != nil {
+		s.logAuthFailure(ctx, identity.Subject, "", fmt.Sprintf("access_token_issue_failed: %v", err))
 		return nil, fmt.Errorf("failed to issue exchange token: %w", err)
 	}
 
 	s.Logger.Debug("token exchange: issued token",
 		"sub", identity.Subject, "iss_act", identity.Issuer,
 		"aud", resource, "scope", grantedScope, "exp", expiresAt)
+
+	s.Auditor.LogEvent(ctx, security.Event{
+		Type:   security.EventTokenIssued,
+		UserID: identity.Subject,
+		Details: map[string]any{
+			"grant_type":         GrantTypeTokenExchange,
+			"subject_token_type": subjectTokenType,
+			"audience":           resource,
+			"scope":              grantedScope,
+			"act_iss":            identity.Issuer,
+		},
+	})
 
 	return &TokenExchangeResult{
 		AccessToken:     tokenStr,

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -31,13 +31,26 @@ func (s *Server) ExchangeSubjectToken(
 	subjectToken, subjectTokenType, resource, scope, dpopJKT string,
 ) (*TokenExchangeResult, error) {
 	if !s.Config.IsJWTAccessTokenFormat() {
-		s.logAuthFailure(ctx, "", "", "token_exchange_jwt_mode_required")
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type: security.EventAuthFailure,
+			Details: map[string]any{
+				"reason":     "token_exchange_jwt_mode_required",
+				"grant_type": GrantTypeTokenExchange,
+			},
+		})
 		return nil, fmt.Errorf("token exchange requires JWT access token mode (set AccessTokenFormat=jwt)")
 	}
 
 	v := s.SubjectValidatorFor(subjectTokenType)
 	if v == nil {
-		s.logAuthFailure(ctx, "", "", fmt.Sprintf("unsupported_subject_token_type: %s", subjectTokenType))
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type: security.EventAuthFailure,
+			Details: map[string]any{
+				"reason":             "unsupported_subject_token_type",
+				"grant_type":         GrantTypeTokenExchange,
+				"subject_token_type": subjectTokenType,
+			},
+		})
 		return nil, &TokenExchangeUnsupportedTypeError{tokenType: subjectTokenType}
 	}
 
@@ -45,7 +58,15 @@ func (s *Server) ExchangeSubjectToken(
 	if err != nil {
 		s.Logger.Debug("token exchange: subject token validation failed",
 			"subject_token_type", subjectTokenType, "error", err)
-		s.logAuthFailure(ctx, "", "", fmt.Sprintf("subject_token_validation_failed: %v", err))
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type: security.EventAuthFailure,
+			Details: map[string]any{
+				"reason":             "subject_token_validation_failed",
+				"grant_type":         GrantTypeTokenExchange,
+				"subject_token_type": subjectTokenType,
+				"error":              err.Error(),
+			},
+		})
 		return nil, fmt.Errorf("subject token validation: %w", err)
 	}
 
@@ -69,7 +90,18 @@ func (s *Server) ExchangeSubjectToken(
 		JKT:       dpopJKT,
 	})
 	if err != nil {
-		s.logAuthFailure(ctx, identity.Subject, "", fmt.Sprintf("access_token_issue_failed: %v", err))
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type:   security.EventAuthFailure,
+			UserID: identity.Subject,
+			Details: map[string]any{
+				"reason":             "access_token_issue_failed",
+				"grant_type":         GrantTypeTokenExchange,
+				"subject_token_type": subjectTokenType,
+				"audience":           resource,
+				"act_iss":            identity.Issuer,
+				"error":              err.Error(),
+			},
+		})
 		return nil, fmt.Errorf("failed to issue exchange token: %w", err)
 	}
 

--- a/server/token_exchange_test.go
+++ b/server/token_exchange_test.go
@@ -347,8 +347,11 @@ func TestExchangeSubjectToken_Audit_JWTModeRequired(t *testing.T) {
 		"https://api.example.com", "", "")
 	require.Error(t, err)
 
-	require.True(t, containsAuthFailure(buf.String(), "token_exchange_jwt_mode_required"),
-		"missing jwt-mode-required audit failure in: %s", buf.String())
+	out := buf.String()
+	require.True(t, containsAuthFailure(out, "token_exchange_jwt_mode_required"),
+		"missing jwt-mode-required audit failure in: %s", out)
+	require.Contains(t, out, GrantTypeTokenExchange,
+		"audit event must carry grant_type for dashboarding")
 }
 
 func TestExchangeSubjectToken_Audit_UnsupportedSubjectTokenType(t *testing.T) {
@@ -370,17 +373,21 @@ func TestExchangeSubjectToken_Audit_UnsupportedSubjectTokenType(t *testing.T) {
 	srv, err := New(mock.NewProvider(), store, store, store, cfg, logger)
 	require.NoError(t, err)
 	srv.Auditor = security.NewAuditor(logger, true)
-	// No validators registered → unsupported_subject_token_type path.
 
-	_, err = srv.ExchangeSubjectToken(t.Context(), "tok",
-		"urn:ietf:params:oauth:token-type:saml2",
+	const badType = "urn:ietf:params:oauth:token-type:saml2"
+	_, err = srv.ExchangeSubjectToken(t.Context(), "tok", badType,
 		"https://api.example.com", "", "")
 	require.Error(t, err)
 	var unsupported *TokenExchangeUnsupportedTypeError
 	require.ErrorAs(t, err, &unsupported)
 
-	require.True(t, containsAuthFailure(buf.String(), "unsupported_subject_token_type"),
-		"missing unsupported_subject_token_type audit failure in: %s", buf.String())
+	out := buf.String()
+	require.True(t, containsAuthFailure(out, "unsupported_subject_token_type"),
+		"missing unsupported_subject_token_type audit failure in: %s", out)
+	require.Contains(t, out, badType,
+		"audit event must carry the rejected subject_token_type for dashboarding")
+	require.Contains(t, out, GrantTypeTokenExchange,
+		"audit event must carry grant_type for dashboarding")
 }
 
 func TestExchangeSubjectToken_Audit_SubjectTokenValidationFailure(t *testing.T) {
@@ -390,8 +397,11 @@ func TestExchangeSubjectToken_Audit_SubjectTokenValidationFailure(t *testing.T) 
 		SubjectTokenTypeIDToken, "https://api.example.com", "", "")
 	require.Error(t, err)
 
-	require.True(t, containsAuthFailure(buf.String(), "subject_token_validation_failed"),
-		"missing subject_token_validation_failed audit failure in: %s", buf.String())
+	out := buf.String()
+	require.True(t, containsAuthFailure(out, "subject_token_validation_failed"),
+		"missing subject_token_validation_failed audit failure in: %s", out)
+	require.Contains(t, out, SubjectTokenTypeIDToken,
+		"audit event must carry the subject_token_type for dashboarding")
 }
 
 func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure(t *testing.T) {
@@ -403,8 +413,13 @@ func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure(t *testing.T) {
 		SubjectTokenTypeIDToken, "https://api.example.com", "read", "")
 	require.Error(t, err)
 
-	require.True(t, containsAuthFailure(buf.String(), "access_token_issue_failed"),
-		"missing access_token_issue_failed audit failure in: %s", buf.String())
+	out := buf.String()
+	require.True(t, containsAuthFailure(out, "access_token_issue_failed"),
+		"missing access_token_issue_failed audit failure in: %s", out)
+	require.Contains(t, out, "https://api.example.com",
+		"audit event must record the audience on issuance failure")
+	require.Contains(t, out, "act_iss",
+		"audit event must record the upstream actor issuer on issuance failure")
 }
 
 func TestExchangeSubjectToken_DPoP(t *testing.T) {

--- a/server/token_exchange_test.go
+++ b/server/token_exchange_test.go
@@ -1,6 +1,10 @@
 package server
 
 import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
 
@@ -233,6 +238,173 @@ func TestExchangeSubjectToken_RequiresJWTMode(t *testing.T) {
 	_, err := srv.ExchangeSubjectToken(t.Context(), "tok", SubjectTokenTypeIDToken, "https://api.example.com", "", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "JWT access token mode")
+}
+
+// failingAccessTokenIssuer always returns an error from Issue. Used to drive
+// the post-validation issuance branch of ExchangeSubjectToken in tests.
+type failingAccessTokenIssuer struct{ err error }
+
+func (f failingAccessTokenIssuer) Issue(context.Context, AccessTokenClaims) (string, error) {
+	return "", f.err
+}
+
+const auditExchangeKID = "audit-exchange-key"
+
+// newAuditExchangeTestServer builds an exchange-ready Server wired to a
+// buffer-backed slog logger so audit emissions can be asserted from log
+// output. The returned EC key matches the registered SubjectTokenValidator
+// so callers can mint subject tokens that pass validation.
+func newAuditExchangeTestServer(t *testing.T) (*Server, *bytes.Buffer, *ecdsa.PrivateKey) {
+	t.Helper()
+
+	ecKey := newTestECKey(t)
+	jwksURL, jwksClient := serveStaticJWKS(t, ecKey, auditExchangeKID)
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	logger, buf := captureLogger()
+
+	cfg := &Config{
+		Issuer:                      "https://auth.example.com",
+		ResourceIdentifier:          "https://api.example.com",
+		SupportedScopes:             []string{"read", "write"},
+		AccessTokenTTL:              600,
+		AccessTokenFormat:           AccessTokenFormatJWT,
+		AccessTokenSigningKey:       generateRSAKey(t),
+		AccessTokenSigningKeyID:     "audit-kid",
+		AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
+		DisableNonceEchoRequirement: true,
+	}
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, logger)
+	require.NoError(t, err)
+	srv.Auditor = security.NewAuditor(logger, true)
+
+	v, err := newOIDCValidatorWithClient(
+		[]TrustedIssuer{{Issuer: testIssuer, JwksURL: jwksURL}},
+		jwksClient,
+	)
+	require.NoError(t, err)
+	srv.subjectValidators = map[string]SubjectTokenValidator{
+		SubjectTokenTypeIDToken: v,
+	}
+
+	return srv, buf, ecKey
+}
+
+func makeAuditSubjectToken(t *testing.T, key *ecdsa.PrivateKey) string {
+	t.Helper()
+	return signSubjectToken(t, key, auditExchangeKID, josejwt.Claims{
+		Issuer:   testIssuer,
+		Subject:  testSubject,
+		Audience: josejwt.Audience{testAudience},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt: josejwt.NewNumericDate(time.Now()),
+	})
+}
+
+func TestExchangeSubjectToken_Audit_Success(t *testing.T) {
+	srv, buf, key := newAuditExchangeTestServer(t)
+
+	result, err := srv.ExchangeSubjectToken(
+		t.Context(),
+		makeAuditSubjectToken(t, key),
+		SubjectTokenTypeIDToken,
+		"https://api.example.com",
+		"read",
+		"",
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, result.AccessToken)
+
+	out := buf.String()
+	require.True(t, containsAuditEvent(out, security.EventTokenIssued),
+		"expected token_issued audit event, got: %s", out)
+	require.Contains(t, out, GrantTypeTokenExchange,
+		"audit event must carry grant_type so dashboards can split exchange issuances")
+	require.Contains(t, out, "https://api.example.com",
+		"audit event must record the audience")
+	require.Contains(t, out, "act_iss")
+}
+
+func TestExchangeSubjectToken_Audit_JWTModeRequired(t *testing.T) {
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	logger, buf := captureLogger()
+
+	cfg := &Config{
+		Issuer:                      "https://auth.example.com",
+		DisableNonceEchoRequirement: true,
+	}
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, logger)
+	require.NoError(t, err)
+	srv.Auditor = security.NewAuditor(logger, true)
+
+	_, err = srv.ExchangeSubjectToken(t.Context(), "tok", SubjectTokenTypeIDToken,
+		"https://api.example.com", "", "")
+	require.Error(t, err)
+
+	require.True(t, containsAuthFailure(buf.String(), "token_exchange_jwt_mode_required"),
+		"missing jwt-mode-required audit failure in: %s", buf.String())
+}
+
+func TestExchangeSubjectToken_Audit_UnsupportedSubjectTokenType(t *testing.T) {
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	logger, buf := captureLogger()
+
+	cfg := &Config{
+		Issuer:                      "https://auth.example.com",
+		AccessTokenTTL:              600,
+		AccessTokenFormat:           AccessTokenFormatJWT,
+		AccessTokenSigningKey:       generateRSAKey(t),
+		AccessTokenSigningKeyID:     "audit-unsupported-kid",
+		AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
+		DisableNonceEchoRequirement: true,
+	}
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, logger)
+	require.NoError(t, err)
+	srv.Auditor = security.NewAuditor(logger, true)
+	// No validators registered → unsupported_subject_token_type path.
+
+	_, err = srv.ExchangeSubjectToken(t.Context(), "tok",
+		"urn:ietf:params:oauth:token-type:saml2",
+		"https://api.example.com", "", "")
+	require.Error(t, err)
+	var unsupported *TokenExchangeUnsupportedTypeError
+	require.ErrorAs(t, err, &unsupported)
+
+	require.True(t, containsAuthFailure(buf.String(), "unsupported_subject_token_type"),
+		"missing unsupported_subject_token_type audit failure in: %s", buf.String())
+}
+
+func TestExchangeSubjectToken_Audit_SubjectTokenValidationFailure(t *testing.T) {
+	srv, buf, _ := newAuditExchangeTestServer(t)
+
+	_, err := srv.ExchangeSubjectToken(t.Context(), "not-a-real-token",
+		SubjectTokenTypeIDToken, "https://api.example.com", "", "")
+	require.Error(t, err)
+
+	require.True(t, containsAuthFailure(buf.String(), "subject_token_validation_failed"),
+		"missing subject_token_validation_failed audit failure in: %s", buf.String())
+}
+
+func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure(t *testing.T) {
+	srv, buf, key := newAuditExchangeTestServer(t)
+
+	srv.accessTokenIssuer = failingAccessTokenIssuer{err: fmt.Errorf("signer down")}
+
+	_, err := srv.ExchangeSubjectToken(t.Context(), makeAuditSubjectToken(t, key),
+		SubjectTokenTypeIDToken, "https://api.example.com", "read", "")
+	require.Error(t, err)
+
+	require.True(t, containsAuthFailure(buf.String(), "access_token_issue_failed"),
+		"missing access_token_issue_failed audit failure in: %s", buf.String())
 }
 
 func TestExchangeSubjectToken_DPoP(t *testing.T) {

--- a/server/token_exchange_test.go
+++ b/server/token_exchange_test.go
@@ -240,8 +240,7 @@ func TestExchangeSubjectToken_RequiresJWTMode(t *testing.T) {
 	require.Contains(t, err.Error(), "JWT access token mode")
 }
 
-// failingAccessTokenIssuer always returns an error from Issue. Used to drive
-// the post-validation issuance branch of ExchangeSubjectToken in tests.
+// failingAccessTokenIssuer always returns an error from Issue.
 type failingAccessTokenIssuer struct{ err error }
 
 func (f failingAccessTokenIssuer) Issue(context.Context, AccessTokenClaims) (string, error) {
@@ -251,9 +250,9 @@ func (f failingAccessTokenIssuer) Issue(context.Context, AccessTokenClaims) (str
 const auditExchangeKID = "audit-exchange-key"
 
 // newAuditExchangeTestServer builds an exchange-ready Server wired to a
-// buffer-backed slog logger so audit emissions can be asserted from log
-// output. The returned EC key matches the registered SubjectTokenValidator
-// so callers can mint subject tokens that pass validation.
+// buffer-backed slog logger. The returned EC key matches the registered
+// SubjectTokenValidator so callers can mint subject tokens that pass
+// validation.
 func newAuditExchangeTestServer(t *testing.T) (*Server, *bytes.Buffer, *ecdsa.PrivateKey) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

`Server.ExchangeSubjectToken` (RFC 8693) was the only token-issuing path that bypassed the audit log. An attacker exploiting a weak `SubjectTokenValidator` left no trail.

This wires `s.Auditor` into every return branch:

- **Success** → `security.EventTokenIssued` with `grant_type=urn:ietf:params:oauth:grant-type:token-exchange`, `audience`, `scope`, `subject_token_type`, and `act_iss` (upstream actor issuer).
- **JWT mode disabled** → `EventAuthFailure` reason `token_exchange_jwt_mode_required`.
- **Unsupported `subject_token_type`** → `EventAuthFailure` reason `unsupported_subject_token_type`, with the rejected type in `Details.subject_token_type`.
- **Subject-token validator rejection** → `EventAuthFailure` reason `subject_token_validation_failed`, with `Details.subject_token_type` and the underlying error in `Details.error`.
- **Access-token issuance failure** → `EventAuthFailure` reason `access_token_issue_failed`, with `audience`, `act_iss`, `subject_token_type`, and `Details.error`.

Reasons are stable strings; variable data lives in structured `Details` fields so dashboards can filter without regex.

## Notes

- Reuses existing `security.Event` shapes and the existing `EventTokenIssued` / `EventAuthFailure` constants. No new exported types in `security/`.
- Audit emission uses the canonical no-nil-guard pattern (`s.Auditor` is guaranteed non-nil after `Server.New`); matches `refresh.go` / `revoke.go`.
- HTTP-level checks in `handler/token_exchange.go` (missing `subject_token`, missing `resource`, DPoP failure) are intentionally not audited here; the handler-side coverage lands in #407.

## Tests

New tests in `server/token_exchange_test.go` assert the audit emission on each branch by capturing slog output through a buffer-backed `security.NewAuditor`:

- `TestExchangeSubjectToken_Audit_Success`
- `TestExchangeSubjectToken_Audit_JWTModeRequired`
- `TestExchangeSubjectToken_Audit_UnsupportedSubjectTokenType`
- `TestExchangeSubjectToken_Audit_SubjectTokenValidationFailure`
- `TestExchangeSubjectToken_Audit_AccessTokenIssueFailure` (drives the post-validation branch via a `failingAccessTokenIssuer` injected into `srv.accessTokenIssuer`).

\`\`\`
go test -race -count=1 -run TestExchangeSubjectToken ./server/
ok      github.com/giantswarm/mcp-oauth/server
\`\`\`