### PR TITLE
chore(ci): SHA-pin internal security workflows

### DIFF
--- a/.github/workflows/zz_generated.fix_vulnerabilities.yaml
+++ b/.github/workflows/zz_generated.fix_vulnerabilities.yaml
@@ -26,7 +26,7 @@ permissions: {}
 
 jobs:
   fix:
-    uses: giantswarm/github-workflows/.github/workflows/fix-vulnerabilities.yaml@main
+    uses: giantswarm/github-workflows/.github/workflows/fix-vulnerabilities.yaml@7a3c79b112a67c1e5a0e90e8c64207bff580152e # main 2026-05-27
     permissions:
       contents: read
     with:

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -13,6 +13,6 @@ permissions: {}
 
 jobs:
   publish:
-    uses: giantswarm/github-workflows/.github/workflows/gitleaks.yaml@main
+    uses: giantswarm/github-workflows/.github/workflows/gitleaks.yaml@7a3c79b112a67c1e5a0e90e8c64207bff580152e # main 2026-05-27
     permissions:
       contents: read

--- a/.github/workflows/zz_generated.run_ossf_scorecard.yaml
+++ b/.github/workflows/zz_generated.run_ossf_scorecard.yaml
@@ -28,7 +28,7 @@ permissions: {}
 
 jobs:
   analysis:
-    uses: giantswarm/github-workflows/.github/workflows/ossf-scorecard.yaml@main
+    uses: giantswarm/github-workflows/.github/workflows/ossf-scorecard.yaml@7a3c79b112a67c1e5a0e90e8c64207bff580152e # main 2026-05-27
     permissions:
       contents: read
       actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING — `oauthconfig.StorageFromEnv` and `StorageFromEnvWithPrefix` signatures changed.** Both now accept `enc *security.Encryptor, inst *instrumentation.Instrumentation` before the `logger` argument, and wire them into the constructed store.
 - Encryption at rest is wired on the store (`memory.WithEncryptor` / `valkey.WithEncryptor`), not the server. Remove any `server.WithEncryptor` / `oauth.WithEncryptor` calls and pass the encryptor directly to the store constructor.
 - `server.Config.RevokedFamilyRetentionDays` removed; set the retention period on the memory store via `memory.WithRevokedFamilyRetentionDays` instead.
+- Internal security workflows (gitleaks, OSSF Scorecard, fix-vulnerabilities) SHA-pin the `giantswarm/github-workflows` reference instead of tracking `@main` (H7).
 
 ### Removed
 


### PR DESCRIPTION
## Summary

Pin `giantswarm/github-workflows` to a SHA in the three security workflows so an unreviewed push to that repo's `main` cannot land in CI here. Addresses **H7** in `mcp-oauth-audit-2026-05-28.md`.

Pinned to `7a3c79b112a67c1e5a0e90e8c64207bff580152e` (giantswarm/github-workflows `main` as of 2026-05-27):

- `.github/workflows/zz_generated.gitleaks.yaml`
- `.github/workflows/zz_generated.run_ossf_scorecard.yaml`
- `.github/workflows/zz_generated.fix_vulnerabilities.yaml`

## Scope

Non-security shared workflows (semantic-pr, validate-changelog, add-team-labels, create_release_pr, create_release) stay on `@main` on purpose. They are owned internally, do not touch secrets, and pinning them would generate constant churn without a security win.

## Known follow-up

These three files are devctl-generated and carry a `DO NOT EDIT` header. The next devctl regen will revert the SHA pins unless the corresponding templates in `giantswarm/devctl` are updated to emit a pinned reference (or are taught to preserve a SHA pin). I'll open a follow-up against devctl. Until then, anyone running `devctl gen workflows` against this repo needs to know not to commit the revert.