### PR TITLE
fix(server/config): reject empty Issuer in Validate()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`security.SetEncryptionMetricRecorder`**: replaced unprotected package-level variable with `atomic.Pointer`, eliminating a data race when multiple goroutines register or clear the hook concurrently (e.g., parallel test suites).
+- **`Config.Validate`** now returns `ErrMissingIssuer` when `Issuer` is empty. RFC 8414 §2 lists `issuer` as REQUIRED, and an empty value silently miswires every URL the server builds by string-concatenating onto `Issuer`. `server.New(...)` called with a nil or empty-Issuer config now fails to start instead of returning a half-configured server. (M1)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`security.SetEncryptionMetricRecorder`**: replaced unprotected package-level variable with `atomic.Pointer`, eliminating a data race when multiple goroutines register or clear the hook concurrently (e.g., parallel test suites).
-- **`Config.Validate`** now returns `ErrMissingIssuer` when `Issuer` is empty. `server.New(...)` called with a nil or empty-`Issuer` config fails to start instead of returning a half-configured server. (M1)
+- **`Config.Validate`** now returns `ErrMissingIssuer` when `Issuer` is empty. `server.New(...)` called with a nil or empty-`Issuer` config fails to start instead of returning a half-configured server.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`security.SetEncryptionMetricRecorder`**: replaced unprotected package-level variable with `atomic.Pointer`, eliminating a data race when multiple goroutines register or clear the hook concurrently (e.g., parallel test suites).
-- **`Config.Validate`** now returns `ErrMissingIssuer` when `Issuer` is empty. RFC 8414 §2 lists `issuer` as REQUIRED, and an empty value silently miswires every URL the server builds by string-concatenating onto `Issuer`. `server.New(...)` called with a nil or empty-Issuer config now fails to start instead of returning a half-configured server. (M1)
+- **`Config.Validate`** now returns `ErrMissingIssuer` when `Issuer` is empty. `server.New(...)` called with a nil or empty-`Issuer` config fails to start instead of returning a half-configured server. (M1)
 
 ### Added
 

--- a/handler/multitenant_test.go
+++ b/handler/multitenant_test.go
@@ -263,11 +263,6 @@ func TestExtractIssuerPath(t *testing.T) {
 			issuer:   "https://auth.example.com/tenant1/",
 			wantPath: "/tenant1",
 		},
-		{
-			name:     "empty_issuer",
-			issuer:   "",
-			wantPath: "",
-		},
 		// SECURITY: Path traversal attack attempts - verify sanitization
 		{
 			name:     "path_with_dots_normalized",

--- a/handler/multitenant_test.go
+++ b/handler/multitenant_test.go
@@ -263,6 +263,8 @@ func TestExtractIssuerPath(t *testing.T) {
 			issuer:   "https://auth.example.com/tenant1/",
 			wantPath: "/tenant1",
 		},
+		// empty_issuer case omitted: Config.Validate now rejects empty Issuer
+		// (ErrMissingIssuer), so server.New never produces a server with Issuer="".
 		// SECURITY: Path traversal attack attempts - verify sanitization
 		{
 			name:     "path_with_dots_normalized",

--- a/server/config.go
+++ b/server/config.go
@@ -13,10 +13,7 @@ import (
 	"time"
 )
 
-// ErrMissingIssuer is returned by Config.Validate when Config.Issuer is
-// empty. RFC 8414 §2 requires the issuer field; an empty value would
-// miswire every endpoint URL the server builds via Issuer concatenation
-// (authorize, token, jwks, register).
+// ErrMissingIssuer is returned by Config.Validate when Config.Issuer is empty (RFC 8414 §2).
 var ErrMissingIssuer = errors.New("issuer is required")
 
 // AccessTokenFormat selects how the server encodes access tokens.

--- a/server/config.go
+++ b/server/config.go
@@ -13,12 +13,11 @@ import (
 	"time"
 )
 
-// ErrMissingIssuer is returned by Config.Validate when the Issuer field is
-// empty. RFC 8414 §2 lists `issuer` as REQUIRED in the authorization server
-// metadata, and an empty value silently miswires every downstream URL
-// (authorize, token, jwks, ...) since those are built by string-concatenating
-// onto Issuer.
-var ErrMissingIssuer = errors.New("Issuer is required")
+// ErrMissingIssuer is returned by Config.Validate when Config.Issuer is
+// empty. RFC 8414 §2 requires the issuer field; an empty value would
+// miswire every endpoint URL the server builds via Issuer concatenation
+// (authorize, token, jwks, register).
+var ErrMissingIssuer = errors.New("issuer is required")
 
 // AccessTokenFormat selects how the server encodes access tokens.
 //

--- a/server/config.go
+++ b/server/config.go
@@ -4,6 +4,7 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,6 +12,13 @@ import (
 	"strings"
 	"time"
 )
+
+// ErrMissingIssuer is returned by Config.Validate when the Issuer field is
+// empty. RFC 8414 §2 lists `issuer` as REQUIRED in the authorization server
+// metadata, and an empty value silently miswires every downstream URL
+// (authorize, token, jwks, ...) since those are built by string-concatenating
+// onto Issuer.
+var ErrMissingIssuer = errors.New("Issuer is required")
 
 // AccessTokenFormat selects how the server encodes access tokens.
 //
@@ -1080,6 +1088,10 @@ func (c *Config) IsJWTAccessTokenFormat() bool {
 // are validated at construction time via applySecureDefaults / the
 // dedicated validate* helpers.
 func (c *Config) Validate() error {
+	if c.Issuer == "" {
+		return ErrMissingIssuer
+	}
+
 	if err := c.validateIntrospectionResourceServers(); err != nil {
 		return err
 	}

--- a/server/config_validate_test.go
+++ b/server/config_validate_test.go
@@ -226,6 +226,6 @@ func TestConfigIsJWTAccessTokenFormat(t *testing.T) {
 }
 
 func TestConfigJWKSEndpoint(t *testing.T) {
-	cfg := &Config{Issuer: "https://auth.example.com"}
+	cfg := &Config{Issuer: testAuthIssuer}
 	require.Equal(t, "https://auth.example.com/.well-known/jwks.json", cfg.JWKSEndpoint())
 }

--- a/server/config_validate_test.go
+++ b/server/config_validate_test.go
@@ -28,23 +28,29 @@ func generateECKey(t *testing.T, curve elliptic.Curve) *ecdsa.PrivateKey {
 	return k
 }
 
+func TestConfigValidate_MissingIssuer(t *testing.T) {
+	err := (&Config{}).Validate()
+	require.ErrorIs(t, err, ErrMissingIssuer)
+}
+
 func TestConfigValidate_OpaqueMode(t *testing.T) {
 	t.Run("empty AccessTokenFormat is opaque and accepted", func(t *testing.T) {
-		require.NoError(t, (&Config{}).Validate())
+		require.NoError(t, (&Config{Issuer: testIssuer}).Validate())
 	})
 
 	t.Run("explicit opaque is accepted", func(t *testing.T) {
-		require.NoError(t, (&Config{AccessTokenFormat: AccessTokenFormatOpaque}).Validate())
+		require.NoError(t, (&Config{Issuer: testIssuer, AccessTokenFormat: AccessTokenFormatOpaque}).Validate())
 	})
 
 	t.Run("unknown AccessTokenFormat is rejected", func(t *testing.T) {
-		err := (&Config{AccessTokenFormat: "JWT"}).Validate() // wrong case
+		err := (&Config{Issuer: testIssuer, AccessTokenFormat: "JWT"}).Validate() // wrong case
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not recognized")
 	})
 
 	t.Run("opaque mode ignores signing key fields", func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatOpaque,
 			AccessTokenSigningKey:       generateRSAKey(t),
 			AccessTokenSigningKeyID:     "k1",
@@ -63,6 +69,7 @@ func TestConfigValidate_JWTMode_RequiredFields(t *testing.T) {
 		{
 			name: "missing key",
 			cfg: &Config{
+				Issuer:                      testIssuer,
 				AccessTokenFormat:           AccessTokenFormatJWT,
 				AccessTokenSigningKeyID:     "k1",
 				AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
@@ -72,6 +79,7 @@ func TestConfigValidate_JWTMode_RequiredFields(t *testing.T) {
 		{
 			name: "missing kid",
 			cfg: &Config{
+				Issuer:                      testIssuer,
 				AccessTokenFormat:           AccessTokenFormatJWT,
 				AccessTokenSigningKey:       generateRSAKey(t),
 				AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
@@ -81,6 +89,7 @@ func TestConfigValidate_JWTMode_RequiredFields(t *testing.T) {
 		{
 			name: "missing alg",
 			cfg: &Config{
+				Issuer:                  testIssuer,
 				AccessTokenFormat:       AccessTokenFormatJWT,
 				AccessTokenSigningKey:   generateRSAKey(t),
 				AccessTokenSigningKeyID: "k1",
@@ -104,6 +113,7 @@ func TestConfigValidate_JWTMode_AlgorithmAccepted(t *testing.T) {
 	} {
 		t.Run(alg, func(t *testing.T) {
 			cfg := &Config{
+				Issuer:                      testIssuer,
 				AccessTokenFormat:           AccessTokenFormatJWT,
 				AccessTokenSigningKey:       generateRSAKey(t),
 				AccessTokenSigningKeyID:     "rsa-1",
@@ -114,6 +124,7 @@ func TestConfigValidate_JWTMode_AlgorithmAccepted(t *testing.T) {
 	}
 	t.Run(SigningAlgorithmES256, func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatJWT,
 			AccessTokenSigningKey:       generateECKey(t, elliptic.P256()),
 			AccessTokenSigningKeyID:     "ec-1",
@@ -123,6 +134,7 @@ func TestConfigValidate_JWTMode_AlgorithmAccepted(t *testing.T) {
 	})
 	t.Run(SigningAlgorithmES384, func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatJWT,
 			AccessTokenSigningKey:       generateECKey(t, elliptic.P384()),
 			AccessTokenSigningKeyID:     "ec-2",
@@ -136,6 +148,7 @@ func TestConfigValidate_JWTMode_AlgorithmRejected(t *testing.T) {
 	for _, alg := range []string{"none", "HS256", "HS384", "HS512", "RS128", ""} {
 		t.Run(alg, func(t *testing.T) {
 			cfg := &Config{
+				Issuer:                      testIssuer,
 				AccessTokenFormat:           AccessTokenFormatJWT,
 				AccessTokenSigningKey:       generateRSAKey(t),
 				AccessTokenSigningKeyID:     "k1",
@@ -155,6 +168,7 @@ func TestConfigValidate_JWTMode_AlgorithmRejected(t *testing.T) {
 func TestConfigValidate_JWTMode_KeyAlgMismatch(t *testing.T) {
 	t.Run("RSA key with ES256 alg rejected", func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatJWT,
 			AccessTokenSigningKey:       generateRSAKey(t),
 			AccessTokenSigningKeyID:     "k1",
@@ -167,6 +181,7 @@ func TestConfigValidate_JWTMode_KeyAlgMismatch(t *testing.T) {
 
 	t.Run("ECDSA key with RS256 alg rejected", func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatJWT,
 			AccessTokenSigningKey:       generateECKey(t, elliptic.P256()),
 			AccessTokenSigningKeyID:     "k1",
@@ -179,6 +194,7 @@ func TestConfigValidate_JWTMode_KeyAlgMismatch(t *testing.T) {
 
 	t.Run("ECDSA P-384 key with ES256 alg rejected", func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatJWT,
 			AccessTokenSigningKey:       generateECKey(t, elliptic.P384()),
 			AccessTokenSigningKeyID:     "k1",
@@ -191,6 +207,7 @@ func TestConfigValidate_JWTMode_KeyAlgMismatch(t *testing.T) {
 
 	t.Run("ECDSA P-256 key with ES384 alg rejected", func(t *testing.T) {
 		cfg := &Config{
+			Issuer:                      testIssuer,
 			AccessTokenFormat:           AccessTokenFormatJWT,
 			AccessTokenSigningKey:       generateECKey(t, elliptic.P256()),
 			AccessTokenSigningKeyID:     "k1",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 	provider := mock.NewProvider()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -34,8 +34,8 @@ func TestNew(t *testing.T) {
 		t.Fatal("New() returned nil")
 	}
 
-	if srv.Config.Issuer != "https://auth.example.com" {
-		t.Errorf("Issuer = %q, want %q", srv.Config.Issuer, "https://auth.example.com")
+	if srv.Config.Issuer != testAuthIssuer {
+		t.Errorf("Issuer = %q, want %q", srv.Config.Issuer, testAuthIssuer)
 	}
 
 	if srv.Logger == nil {
@@ -51,7 +51,7 @@ func TestNew_WithLogger(t *testing.T) {
 	logger := slog.Default()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, logger)
@@ -64,7 +64,7 @@ func TestNew_WithLogger(t *testing.T) {
 	}
 }
 
-func TestNew_NilConfig(t *testing.T) {
+func TestNew_NilConfig_Rejected(t *testing.T) {
 	store := memory.New()
 	defer store.Stop()
 
@@ -171,7 +171,7 @@ func TestServer_ProviderRevocationConfigDefaults(t *testing.T) {
 
 	// Create server with empty config (should apply defaults)
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 		// Don't set provider revocation fields - should use defaults
 	}
 
@@ -204,7 +204,7 @@ func TestServer_ProviderRevocationConfigCustomValues(t *testing.T) {
 
 	// Create server with custom config values
 	config := &Config{
-		Issuer:                             "https://auth.example.com",
+		Issuer:                             testAuthIssuer,
 		ProviderRevocationTimeout:          30,
 		ProviderRevocationMaxRetries:       5,
 		ProviderRevocationFailureThreshold: 0.3,
@@ -416,7 +416,7 @@ func TestServer_Shutdown(t *testing.T) {
 	provider := mock.NewProvider()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -458,7 +458,7 @@ func TestServer_Shutdown_WithoutRateLimiters(t *testing.T) {
 	provider := mock.NewProvider()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -482,7 +482,7 @@ func TestServer_Shutdown_ContextCancellation(t *testing.T) {
 	provider := mock.NewProvider()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -509,7 +509,7 @@ func TestServer_ShutdownWithTimeout(t *testing.T) {
 	provider := mock.NewProvider()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -540,7 +540,7 @@ func TestServer_ShutdownWithTimeout_ShortTimeout(t *testing.T) {
 	provider := mock.NewProvider()
 
 	config := &Config{
-		Issuer: "https://auth.example.com",
+		Issuer: testAuthIssuer,
 	}
 
 	srv, err := New(provider, store, store, store, config, nil)
@@ -650,7 +650,7 @@ func TestLogMandatoryAudienceScopes(t *testing.T) {
 
 		// Create server - it will log during initialization
 		config := &Config{
-			Issuer: "https://auth.example.com",
+			Issuer: testAuthIssuer,
 		}
 
 		srv, err := New(provider, store, store, store, config, slog.Default())
@@ -675,7 +675,7 @@ func TestLogMandatoryAudienceScopes(t *testing.T) {
 		}
 
 		config := &Config{
-			Issuer: "https://auth.example.com",
+			Issuer: testAuthIssuer,
 		}
 
 		srv, err := New(provider, store, store, store, config, slog.Default())
@@ -698,7 +698,7 @@ func TestLogMandatoryAudienceScopes(t *testing.T) {
 		}
 
 		config := &Config{
-			Issuer: "https://auth.example.com",
+			Issuer: testAuthIssuer,
 		}
 
 		srv, err := New(provider, store, store, store, config, slog.Default())

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
@@ -69,14 +70,8 @@ func TestNew_NilConfig(t *testing.T) {
 
 	provider := mock.NewProvider()
 
-	srv, err := New(provider, store, store, store, nil, nil)
-	if err != nil {
-		t.Fatalf("New() error = %v", err)
-	}
-
-	if srv.Config == nil {
-		t.Error("Config should not be nil when nil is passed")
-	}
+	_, err := New(provider, store, store, store, nil, nil)
+	require.ErrorIs(t, err, ErrMissingIssuer)
 }
 
 func TestNew_MissingProvider(t *testing.T) {

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -11,6 +11,9 @@ import (
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
 
+// testAuthIssuer is the issuer URL used in server construction tests.
+const testAuthIssuer = "https://auth.example.com"
+
 // testServerSetup holds common test dependencies
 type testServerSetup struct {
 	provider *mock.Provider
@@ -469,7 +472,7 @@ func TestHTTPSEnforcement_WithPort(t *testing.T) {
 func TestValidateClientStateParameter(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
-		Issuer:         "https://auth.example.com",
+		Issuer:         testAuthIssuer,
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -570,7 +573,7 @@ func TestValidateClientStateParameter(t *testing.T) {
 func TestValidateClientStateParameter_TimingAttackResistance(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
-		Issuer:         "https://auth.example.com",
+		Issuer:         testAuthIssuer,
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -614,7 +617,7 @@ func TestValidateClientStateParameter_TimingAttackResistance(t *testing.T) {
 func TestValidateClientScopes(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
-		Issuer:         "https://auth.example.com",
+		Issuer:         testAuthIssuer,
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -782,7 +785,7 @@ func TestValidateClientScopes(t *testing.T) {
 func TestValidateClientScopes_SecurityScenarios(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
-		Issuer:         "https://auth.example.com",
+		Issuer:         testAuthIssuer,
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -863,7 +866,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("empty state rejected when AllowNoStateParameter=false (default)", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})
@@ -880,7 +883,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("empty state allowed when AllowNoStateParameter=true", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -899,7 +902,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 
 		setup1 := newTestServerSetup(false)
 		srv1, err := setup1.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})
@@ -912,7 +915,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 
 		setup2 := newTestServerSetup(false)
 		srv2, err := setup2.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -927,7 +930,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("short non-empty state accepted when AllowNoStateParameter=true", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -944,7 +947,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("short non-empty state rejected when AllowNoStateParameter=false", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})
@@ -1157,7 +1160,7 @@ func TestValidateProviderStateParameter(t *testing.T) {
 	t.Run("empty provider state always rejected", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -1174,7 +1177,7 @@ func TestValidateProviderStateParameter(t *testing.T) {
 	t.Run("short provider state rejected even with AllowNoStateParameter=true", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -1191,7 +1194,7 @@ func TestValidateProviderStateParameter(t *testing.T) {
 	t.Run("valid-length provider state accepted", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
-			Issuer:                "https://auth.example.com",
+			Issuer:                testAuthIssuer,
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})

--- a/server/validation_test.go
+++ b/server/validation_test.go
@@ -469,6 +469,7 @@ func TestHTTPSEnforcement_WithPort(t *testing.T) {
 func TestValidateClientStateParameter(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
+		Issuer:         "https://auth.example.com",
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -569,6 +570,7 @@ func TestValidateClientStateParameter(t *testing.T) {
 func TestValidateClientStateParameter_TimingAttackResistance(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
+		Issuer:         "https://auth.example.com",
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -612,6 +614,7 @@ func TestValidateClientStateParameter_TimingAttackResistance(t *testing.T) {
 func TestValidateClientScopes(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
+		Issuer:         "https://auth.example.com",
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -779,6 +782,7 @@ func TestValidateClientScopes(t *testing.T) {
 func TestValidateClientScopes_SecurityScenarios(t *testing.T) {
 	setup := newTestServerSetup(false)
 	srv, err := setup.createServer(&Config{
+		Issuer:         "https://auth.example.com",
 		RequirePKCE:    true,
 		AllowPKCEPlain: false,
 	})
@@ -859,6 +863,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("empty state rejected when AllowNoStateParameter=false (default)", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})
@@ -875,6 +880,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("empty state allowed when AllowNoStateParameter=true", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -893,6 +899,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 
 		setup1 := newTestServerSetup(false)
 		srv1, err := setup1.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})
@@ -905,6 +912,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 
 		setup2 := newTestServerSetup(false)
 		srv2, err := setup2.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -919,6 +927,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("short non-empty state accepted when AllowNoStateParameter=true", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -935,6 +944,7 @@ func TestValidateClientStateParameter_AllowNoState(t *testing.T) {
 	t.Run("short non-empty state rejected when AllowNoStateParameter=false", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})
@@ -1147,6 +1157,7 @@ func TestValidateProviderStateParameter(t *testing.T) {
 	t.Run("empty provider state always rejected", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -1163,6 +1174,7 @@ func TestValidateProviderStateParameter(t *testing.T) {
 	t.Run("short provider state rejected even with AllowNoStateParameter=true", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: true,
 		})
@@ -1179,6 +1191,7 @@ func TestValidateProviderStateParameter(t *testing.T) {
 	t.Run("valid-length provider state accepted", func(t *testing.T) {
 		setup := newTestServerSetup(false)
 		srv, err := setup.createServer(&Config{
+			Issuer:                "https://auth.example.com",
 			RequirePKCE:           true,
 			AllowNoStateParameter: false,
 		})


### PR DESCRIPTION
## Summary

`Config.Validate()` now rejects an empty `Issuer` with a new `ErrMissingIssuer` sentinel. Previously, a server built with `Config{Issuer: ""}` (or with `config = nil`, which `applyDefaults` collapses to `&Config{}`) would start without complaint and then serve a discovery document that violates RFC 8414 §2 ("issuer REQUIRED") and silently miswire every URL the server builds by string-concatenating onto `Issuer` (authorize, token, jwks, register, ...).

Addresses **M1** in `mcp-oauth-audit-2026-05-28.md`.

## Behavioural impact

- `server.New(...)` called with `config = nil` or `Config{Issuer: ""}` now returns `ErrMissingIssuer` (wrapped as `invalid server config: ...`) instead of constructing a half-configured server. This is the intended fix; the nil/empty path was never safe.
- Existing tests that relied on the empty-Issuer escape hatch are updated to set `Issuer` (or, for `TestNew_NilConfig`, to assert the new error).
- The audit-flagged URL format check (separate item) is **not** in scope here; this PR only rejects the empty value.

## Scope

- `server/config.go` — `ErrMissingIssuer` sentinel + check at the top of `Validate()`.
- Tests updated to set `Issuer` where previously omitted (`server/config_validate_test.go`, `server/server_test.go`, `server/validation_test.go`, `handler/multitenant_test.go`).
- `CHANGELOG.md` — `### Fixed` entry.