### PR TITLE
fix(handler): log JSON encode errors on response writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **JSON encode errors on response writes** at the discovery, token, and registration endpoints are now logged instead of silently swallowed. The HTTP status was already committed by the time `json.NewEncoder(w).Encode(...)` runs, so the response stays the same; operators now have a signal when a broken pipe or slow-client write truncates the body.
+- **JSON encode errors on response writes** are now logged instead of silently swallowed across all handler endpoints (discovery, token, token-exchange, introspection, registration, client management, userinfo, JWKS, and error responses). The HTTP status is unchanged.
 
 - **`security.SetEncryptionMetricRecorder`**: replaced unprotected package-level variable with `atomic.Pointer`, eliminating a data race when multiple goroutines register or clear the hook concurrently (e.g., parallel test suites).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **JSON encode errors on response writes** at the discovery, token, and registration endpoints are now logged instead of silently swallowed. The HTTP status was already committed by the time `json.NewEncoder(w).Encode(...)` runs, so the response stays the same; operators now have a signal when a broken pipe or slow-client write truncates the body.
+
 - **`security.SetEncryptionMetricRecorder`**: replaced unprotected package-level variable with `atomic.Pointer`, eliminating a data race when multiple goroutines register or clear the hook concurrently (e.g., parallel test suites).
 
 ### Added

--- a/handler/discovery.go
+++ b/handler/discovery.go
@@ -58,7 +58,9 @@ func (h *Handler) ServeProtectedResourceMetadata(w http.ResponseWriter, r *http.
 
 	h.recordHTTPMetrics(r.Context(), endpointProtectedResource, http.MethodGet, http.StatusOK, startTime)
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(metadata)
+	if err := json.NewEncoder(w).Encode(metadata); err != nil {
+		h.logger.Warn("Failed to encode protected resource metadata response", "error", err)
+	}
 }
 
 // extractResourcePath extracts the resource path from a Protected Resource Metadata URL.
@@ -376,7 +378,9 @@ func (h *Handler) serveAuthServerMetadata(w http.ResponseWriter, r *http.Request
 
 	h.recordHTTPMetrics(r.Context(), endpointDiscovery, http.MethodGet, http.StatusOK, startTime)
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(metadata)
+	if err := json.NewEncoder(w).Encode(metadata); err != nil {
+		h.logger.Warn("Failed to encode authorization server metadata response", "error", err)
+	}
 }
 
 // buildAuthServerMetadata returns the metadata served at both

--- a/handler/discovery.go
+++ b/handler/discovery.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	_ "embed"
-	"encoding/json"
 	"net/http"
 	"net/url"
 	"path"
@@ -58,9 +57,7 @@ func (h *Handler) ServeProtectedResourceMetadata(w http.ResponseWriter, r *http.
 
 	h.recordHTTPMetrics(r.Context(), endpointProtectedResource, http.MethodGet, http.StatusOK, startTime)
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(metadata); err != nil {
-		h.logger.Warn("Failed to encode protected resource metadata response", "error", err)
-	}
+	h.writeJSON(w, metadata)
 }
 
 // extractResourcePath extracts the resource path from a Protected Resource Metadata URL.
@@ -378,9 +375,7 @@ func (h *Handler) serveAuthServerMetadata(w http.ResponseWriter, r *http.Request
 
 	h.recordHTTPMetrics(r.Context(), endpointDiscovery, http.MethodGet, http.StatusOK, startTime)
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(metadata); err != nil {
-		h.logger.Warn("Failed to encode authorization server metadata response", "error", err)
-	}
+	h.writeJSON(w, metadata)
 }
 
 // buildAuthServerMetadata returns the metadata served at both
@@ -534,7 +529,5 @@ func (h *Handler) ServeJWKS(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/jwk-set+json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 
-	if err := json.NewEncoder(w).Encode(jwks); err != nil {
-		h.logger.Warn("Failed to encode JWKS response", "error", err)
-	}
+	h.writeJSON(w, jwks)
 }

--- a/handler/dpop_middleware.go
+++ b/handler/dpop_middleware.go
@@ -155,9 +155,10 @@ func writeDPoPError(w http.ResponseWriter, wwwAuth, dpopNonce, code, description
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	//nolint:errcheck — encoding map[string]string never fails
-	_ = json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"error":             code,
 		"error_description": description,
-	})
+	}); err != nil {
+		slog.Warn("Failed to encode DPoP error response", "error", err, "code", code)
+	}
 }

--- a/handler/dpop_middleware.go
+++ b/handler/dpop_middleware.go
@@ -53,7 +53,7 @@ func DPoPMiddleware(replayCache server.DPoPReplayCache, nonceProvider server.DPo
 	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			serveDPoP(w, r, next, replayCache, nonceProvider, trustedProxies)
+			serveDPoP(w, r, next, replayCache, nonceProvider, trustedProxies, slog.Default())
 		})
 	}
 }
@@ -71,12 +71,13 @@ func (h *Handler) DPoPMiddleware() func(http.Handler) http.Handler {
 				h.server.DPoPReplayCache(),
 				h.server.DPoPNonceProvider(),
 				h.server.TrustedProxyCIDRs(),
+				h.logger,
 			)
 		})
 	}
 }
 
-func serveDPoP(w http.ResponseWriter, r *http.Request, next http.Handler, replayCache server.DPoPReplayCache, nonceProvider server.DPoPNonceProvider, trustedProxies []*net.IPNet) {
+func serveDPoP(w http.ResponseWriter, r *http.Request, next http.Handler, replayCache server.DPoPReplayCache, nonceProvider server.DPoPNonceProvider, trustedProxies []*net.IPNet, logger *slog.Logger) {
 	auth := r.Header.Get("Authorization")
 	if !strings.HasPrefix(strings.ToLower(auth), "dpop ") {
 		next.ServeHTTP(w, r)
@@ -86,7 +87,7 @@ func serveDPoP(w http.ResponseWriter, r *http.Request, next http.Handler, replay
 	proof := r.Header.Get("DPoP")
 	if proof == "" {
 		writeDPoPError(
-			w,
+			w, logger,
 			dpopWWWAuthenticate(constants.ErrorCodeInvalidRequest, "DPoP proof required"),
 			"",
 			constants.ErrorCodeInvalidRequest,
@@ -98,7 +99,7 @@ func serveDPoP(w http.ResponseWriter, r *http.Request, next http.Handler, replay
 	htu := dpopHTU(r, trustedProxies)
 	proofClaims, err := server.ValidateDPoPProof(r.Context(), proof, r.Method, htu, accessToken, replayCache, nonceProvider, time.Now())
 	if err != nil {
-		writeDPoPValidationError(w, r, err, nonceProvider)
+		writeDPoPValidationError(w, r, err, nonceProvider, logger)
 		return
 	}
 
@@ -109,14 +110,14 @@ func serveDPoP(w http.ResponseWriter, r *http.Request, next http.Handler, replay
 	next.ServeHTTP(w, r2)
 }
 
-func writeDPoPValidationError(w http.ResponseWriter, r *http.Request, err error, nonceProvider server.DPoPNonceProvider) {
+func writeDPoPValidationError(w http.ResponseWriter, r *http.Request, err error, nonceProvider server.DPoPNonceProvider, logger *slog.Logger) {
 	if errors.Is(err, server.ErrDPoPNonceInvalid) {
 		nonce := ""
 		if nonceProvider != nil {
 			nonce = nonceProvider.Nonce(r.Context())
 		}
 		writeDPoPError(
-			w,
+			w, logger,
 			dpopWWWAuthenticate(constants.ErrorCodeUseDPoPNonce, "Resource server requires nonce in DPoP proof"),
 			nonce,
 			constants.ErrorCodeUseDPoPNonce,
@@ -126,7 +127,7 @@ func writeDPoPValidationError(w http.ResponseWriter, r *http.Request, err error,
 		return
 	}
 	writeDPoPError(
-		w,
+		w, logger,
 		dpopWWWAuthenticate(constants.ErrorCodeInvalidDPoPProof, err.Error()),
 		"",
 		constants.ErrorCodeInvalidDPoPProof,
@@ -146,7 +147,7 @@ func dpopWWWAuthenticate(code, description string) string {
 // writeDPoPError writes a JSON DPoP error response.
 // wwwAuth is written as the WWW-Authenticate header when non-empty (RFC 9449 §7.1).
 // dpopNonce is written as the DPoP-Nonce header when non-empty (RFC 9449 §8).
-func writeDPoPError(w http.ResponseWriter, wwwAuth, dpopNonce, code, description string, status int) {
+func writeDPoPError(w http.ResponseWriter, logger *slog.Logger, wwwAuth, dpopNonce, code, description string, status int) {
 	if wwwAuth != "" {
 		w.Header().Set("WWW-Authenticate", wwwAuth)
 	}
@@ -159,6 +160,6 @@ func writeDPoPError(w http.ResponseWriter, wwwAuth, dpopNonce, code, description
 		"error":             code,
 		"error_description": description,
 	}); err != nil {
-		slog.Warn("Failed to encode DPoP error response", "error", err, "code", code)
+		logger.Warn("failed to write JSON response", "error", err, "code", code)
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -261,11 +261,15 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	if err := json.NewEncoder(w).Encode(map[string]string{
+	h.writeJSON(w, map[string]string{
 		"error":             code,
 		"error_description": description,
-	}); err != nil {
-		h.logger.Warn("Failed to encode error response", "error", err, "code", code)
+	})
+}
+
+func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		h.logger.Warn("failed to write JSON response", "error", err)
 	}
 }
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -261,10 +261,12 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"error":             code,
 		"error_description": description,
-	})
+	}); err != nil {
+		h.logger.Warn("Failed to encode error response", "error", err, "code", code)
+	}
 }
 
 // dropIfOversize returns the empty string when v exceeds maxLen — used for

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -201,12 +200,10 @@ func (h *Handler) writeUnauthorizedError(w http.ResponseWriter, r *http.Request,
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
-	if err := json.NewEncoder(w).Encode(map[string]string{
+	h.writeJSON(w, map[string]string{
 		"error":             code,
 		"error_description": description,
-	}); err != nil {
-		h.logger.Warn("Failed to encode unauthorized error response", "error", err)
-	}
+	})
 }
 
 // writeInsufficientScopeError writes a 403 Forbidden response with insufficient_scope error.
@@ -236,15 +233,12 @@ func (h *Handler) writeInsufficientScopeError(w http.ResponseWriter, requiredSco
 	// Use formatWWWAuthenticate to build the header with error details
 	w.Header().Set("WWW-Authenticate", h.formatWWWAuthenticate(scope, constants.ErrorCodeInsufficientScope, description))
 
-	// Write JSON error response body
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusForbidden)
-	if err := json.NewEncoder(w).Encode(map[string]string{
+	h.writeJSON(w, map[string]string{
 		"error":             constants.ErrorCodeInsufficientScope,
 		"error_description": description,
-	}); err != nil {
-		h.logger.Warn("Failed to encode insufficient scope error response", "error", err)
-	}
+	})
 }
 
 // formatWWWAuthenticate formats the WWW-Authenticate header value per RFC 6750 and RFC 9728

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -201,10 +201,12 @@ func (h *Handler) writeUnauthorizedError(w http.ResponseWriter, r *http.Request,
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
-	_ = json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"error":             code,
 		"error_description": description,
-	})
+	}); err != nil {
+		h.logger.Warn("Failed to encode unauthorized error response", "error", err)
+	}
 }
 
 // writeInsufficientScopeError writes a 403 Forbidden response with insufficient_scope error.
@@ -237,10 +239,12 @@ func (h *Handler) writeInsufficientScopeError(w http.ResponseWriter, requiredSco
 	// Write JSON error response body
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusForbidden)
-	_ = json.NewEncoder(w).Encode(map[string]string{
+	if err := json.NewEncoder(w).Encode(map[string]string{
 		"error":             constants.ErrorCodeInsufficientScope,
 		"error_description": description,
-	})
+	}); err != nil {
+		h.logger.Warn("Failed to encode insufficient scope error response", "error", err)
+	}
 }
 
 // formatWWWAuthenticate formats the WWW-Authenticate header value per RFC 6750 and RFC 9728

--- a/handler/register.go
+++ b/handler/register.go
@@ -394,9 +394,7 @@ func (h *Handler) writeRegistrationResponse(w http.ResponseWriter, client *stora
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		h.logger.Warn("Failed to encode registration response", "error", err)
-	}
+	h.writeJSON(w, response)
 }
 
 // Helper methods

--- a/handler/register.go
+++ b/handler/register.go
@@ -394,7 +394,9 @@ func (h *Handler) writeRegistrationResponse(w http.ResponseWriter, client *stora
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.logger.Warn("Failed to encode registration response", "error", err)
+	}
 }
 
 // Helper methods

--- a/handler/register_management.go
+++ b/handler/register_management.go
@@ -129,7 +129,9 @@ func (h *Handler) writeClientMetadata(w http.ResponseWriter, client *storage.Cli
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	body := h.buildClientResponseBody(client)
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(body)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		h.logger.Warn("Failed to encode client metadata response", "error", err)
+	}
 }
 
 // handleClientManagementPut handles PUT /oauth/register/{client_id}.
@@ -191,7 +193,9 @@ func (h *Handler) handleClientManagementPut(w http.ResponseWriter, r *http.Reque
 	body := h.buildClientResponseBody(&updated)
 	body["registration_access_token"] = newToken
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(body)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		h.logger.Warn("Failed to encode client management update response", "error", err)
+	}
 }
 
 // handleClientManagementDelete handles DELETE /oauth/register/{client_id}.

--- a/handler/register_management.go
+++ b/handler/register_management.go
@@ -129,9 +129,7 @@ func (h *Handler) writeClientMetadata(w http.ResponseWriter, client *storage.Cli
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	body := h.buildClientResponseBody(client)
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(body); err != nil {
-		h.logger.Warn("Failed to encode client metadata response", "error", err)
-	}
+	h.writeJSON(w, body)
 }
 
 // handleClientManagementPut handles PUT /oauth/register/{client_id}.
@@ -193,9 +191,7 @@ func (h *Handler) handleClientManagementPut(w http.ResponseWriter, r *http.Reque
 	body := h.buildClientResponseBody(&updated)
 	body["registration_access_token"] = newToken
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(body); err != nil {
-		h.logger.Warn("Failed to encode client management update response", "error", err)
-	}
+	h.writeJSON(w, body)
 }
 
 // handleClientManagementDelete handles DELETE /oauth/register/{client_id}.

--- a/handler/revoke.go
+++ b/handler/revoke.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -201,9 +200,7 @@ func (h *Handler) ServeTokenIntrospection(w http.ResponseWriter, r *http.Request
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		h.logger.Warn("Failed to encode introspection response", "error", err)
-	}
+	h.writeJSON(w, response)
 	h.recordHTTPMetrics(r.Context(), endpointIntrospect, http.MethodPost, http.StatusOK, startTime)
 	instrumentation.SetSpanSuccess(span)
 }

--- a/handler/revoke.go
+++ b/handler/revoke.go
@@ -201,7 +201,9 @@ func (h *Handler) ServeTokenIntrospection(w http.ResponseWriter, r *http.Request
 	security.SetSecurityHeaders(w, h.server.Config.Issuer)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_ = json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.logger.Warn("Failed to encode introspection response", "error", err)
+	}
 	h.recordHTTPMetrics(r.Context(), endpointIntrospect, http.MethodPost, http.StatusOK, startTime)
 	instrumentation.SetSpanSuccess(span)
 }

--- a/handler/token.go
+++ b/handler/token.go
@@ -473,7 +473,9 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token *oauth2.Token,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.logger.Warn("Failed to encode token response", "error", err)
+	}
 }
 
 // isValidAuthMethod checks if the given token endpoint auth method is supported

--- a/handler/token.go
+++ b/handler/token.go
@@ -3,7 +3,6 @@ package handler
 import (
 	"context"
 	_ "embed"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -473,9 +472,7 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token *oauth2.Token,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		h.logger.Warn("Failed to encode token response", "error", err)
-	}
+	h.writeJSON(w, response)
 }
 
 // isValidAuthMethod checks if the given token endpoint auth method is supported

--- a/handler/token_exchange.go
+++ b/handler/token_exchange.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -117,7 +116,5 @@ func (h *Handler) writeTokenExchangeResponse(w http.ResponseWriter, result *serv
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(response); err != nil {
-		h.logger.Warn("Failed to encode token exchange response", "error", err)
-	}
+	h.writeJSON(w, response)
 }

--- a/handler/token_exchange.go
+++ b/handler/token_exchange.go
@@ -117,5 +117,7 @@ func (h *Handler) writeTokenExchangeResponse(w http.ResponseWriter, result *serv
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		h.logger.Warn("Failed to encode token exchange response", "error", err)
+	}
 }

--- a/handler/userinfo.go
+++ b/handler/userinfo.go
@@ -116,7 +116,7 @@ func (h *Handler) ServeUserInfo(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(claims); err != nil {
-		h.logger.Warn("Failed to encode userinfo response", "error", err)
+		h.logger.Warn("failed to write JSON response", "error", err)
 		h.recordHTTPMetrics(r.Context(), endpointUserInfo, r.Method, http.StatusInternalServerError, startTime)
 		return
 	}


### PR DESCRIPTION
## Summary

All response-write paths in `handler/` previously did `_ = json.NewEncoder(w).Encode(...)`. After the HTTP status is committed, a broken pipe or slow-client write truncates the body, and the encoder error gives the only signal — silently dropping it left operators blind.

Now logged via `h.logger.Warn` (or `slog.Warn` for the package-level `writeDPoPError`), matching the existing JWKS handler pattern. Status codes are unchanged because there's nothing safe to send after the status line is on the wire.

Sites covered:

- Discovery (protected resource + AS metadata)
- Token + token exchange
- Introspection
- Client registration + client management (GET/PUT)
- Userinfo + JWKS (already in place; kept for reference)
- Generic `writeError`, `writeUnauthorizedError`, `writeInsufficientScopeError`, `writeDPoPError`

Also drops the stale `//nolint:errcheck — encoding map[string]string never fails` comment on `writeDPoPError`: the encoder also surfaces ResponseWriter errors, which is the failure mode we're now logging.

Closes audit finding M4.