### PR TITLE
refactor(security): unexport test discovery client, drop memory.Store type assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+<<<<<<< HEAD
 - Client IP tracking now uses the `storage.ClientIPTracker` optional interface instead of a concrete `*memory.Store` type assertion.
+=======
+- Client IP tracking now uses the `storage.ClientIPTracker` optional interface instead of a concrete `*memory.Store` type assertion (H4).
+>>>>>>> 88a17c0 (chore: consolidate CHANGELOG entries, trim comment)
 - **BREAKING — `SubjectTokenValidator.Validate` signature** is now `Validate(ctx, tokenString string, defaultAudiences []string) (*SubjectIdentity, error)` (was `Validate(ctx, subjectToken, subjectTokenType string) (SubjectIdentity, error)`). The `subject_token_type` URN gate moved into `ExchangeSubjectToken`; the return is a pointer; `defaultAudiences` applies when the matched issuer's `AllowedAudiences` is empty (`nil` accepts any audience).
 - `WithTrustedIssuers` now also registers its `OIDCValidator` for `ValidateToken`; token-exchange behavior is unchanged.
 - **BREAKING — `memory.New` now accepts `...Option`** (was `func New() *Store`). Pass `memory.WithEncryptor(enc)`, `memory.WithInstrumentation(inst)`, etc. at construction instead of calling `SetX` after the fact.
@@ -46,7 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+<<<<<<< HEAD
 - `oidc.NewTestDiscoveryClient` is no longer exported. Test helpers live in `internal/testutil`. The `dex.Config.skipValidation` field has been removed.
+=======
+- **Breaking:** `oidc.NewTestDiscoveryClient` is no longer exported. Test helpers live in `internal/testutil`. The `dex.Config.skipValidation` field has been removed. (H8)
+>>>>>>> 88a17c0 (chore: consolidate CHANGELOG entries, trim comment)
 - `memory.SetEncryptor`, `memory.SetInstrumentation`, `memory.SetLogger`, `memory.SetRevokedFamilyRetentionDays` — replaced by construction-time options.
 - **`dpop/valkey` package removed.** The Valkey-backed DPoP replay cache is now at `storage/valkey.NewDPoPReplayCache`. Update imports from `github.com/giantswarm/mcp-oauth/dpop/valkey` to `github.com/giantswarm/mcp-oauth/storage/valkey` and replace `valkey.New(client, prefix)` with `valkey.NewDPoPReplayCache(client, prefix)`.
 - **`server.Clock` interface and `server.DNSResolver` interface removed.** `clientMetadataCache` now calls `time.Now()` directly; use `testing/synctest` for TTL-sensitive tests. `Config.DNSResolver` is now `*net.Resolver`; pass a `*net.Resolver` with a custom `Dial` function to intercept DNS in tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-<<<<<<< HEAD
 - Client IP tracking now uses the `storage.ClientIPTracker` optional interface instead of a concrete `*memory.Store` type assertion.
-=======
-- Client IP tracking now uses the `storage.ClientIPTracker` optional interface instead of a concrete `*memory.Store` type assertion (H4).
->>>>>>> 88a17c0 (chore: consolidate CHANGELOG entries, trim comment)
 - **BREAKING — `SubjectTokenValidator.Validate` signature** is now `Validate(ctx, tokenString string, defaultAudiences []string) (*SubjectIdentity, error)` (was `Validate(ctx, subjectToken, subjectTokenType string) (SubjectIdentity, error)`). The `subject_token_type` URN gate moved into `ExchangeSubjectToken`; the return is a pointer; `defaultAudiences` applies when the matched issuer's `AllowedAudiences` is empty (`nil` accepts any audience).
 - `WithTrustedIssuers` now also registers its `OIDCValidator` for `ValidateToken`; token-exchange behavior is unchanged.
 - **BREAKING — `memory.New` now accepts `...Option`** (was `func New() *Store`). Pass `memory.WithEncryptor(enc)`, `memory.WithInstrumentation(inst)`, etc. at construction instead of calling `SetX` after the fact.
@@ -50,11 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-<<<<<<< HEAD
 - `oidc.NewTestDiscoveryClient` is no longer exported. Test helpers live in `internal/testutil`. The `dex.Config.skipValidation` field has been removed.
-=======
-- **Breaking:** `oidc.NewTestDiscoveryClient` is no longer exported. Test helpers live in `internal/testutil`. The `dex.Config.skipValidation` field has been removed. (H8)
->>>>>>> 88a17c0 (chore: consolidate CHANGELOG entries, trim comment)
 - `memory.SetEncryptor`, `memory.SetInstrumentation`, `memory.SetLogger`, `memory.SetRevokedFamilyRetentionDays` — replaced by construction-time options.
 - **`dpop/valkey` package removed.** The Valkey-backed DPoP replay cache is now at `storage/valkey.NewDPoPReplayCache`. Update imports from `github.com/giantswarm/mcp-oauth/dpop/valkey` to `github.com/giantswarm/mcp-oauth/storage/valkey` and replace `valkey.New(client, prefix)` with `valkey.NewDPoPReplayCache(client, prefix)`.
 - **`server.Clock` interface and `server.DNSResolver` interface removed.** `clientMetadataCache` now calls `time.Now()` directly; use `testing/synctest` for TTL-sensitive tests. `Config.DNSResolver` is now `*net.Resolver`; pass a `*net.Resolver` with a custom `Dial` function to intercept DNS in tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Client IP tracking now uses the `storage.ClientIPTracker` optional interface instead of a concrete `*memory.Store` type assertion.
 - **BREAKING — `SubjectTokenValidator.Validate` signature** is now `Validate(ctx, tokenString string, defaultAudiences []string) (*SubjectIdentity, error)` (was `Validate(ctx, subjectToken, subjectTokenType string) (SubjectIdentity, error)`). The `subject_token_type` URN gate moved into `ExchangeSubjectToken`; the return is a pointer; `defaultAudiences` applies when the matched issuer's `AllowedAudiences` is empty (`nil` accepts any audience).
 - `WithTrustedIssuers` now also registers its `OIDCValidator` for `ValidateToken`; token-exchange behavior is unchanged.
 - **BREAKING — `memory.New` now accepts `...Option`** (was `func New() *Store`). Pass `memory.WithEncryptor(enc)`, `memory.WithInstrumentation(inst)`, etc. at construction instead of calling `SetX` after the fact.
@@ -45,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- `oidc.NewTestDiscoveryClient` is no longer exported. Test helpers live in `internal/testutil`. The `dex.Config.skipValidation` field has been removed.
 - `memory.SetEncryptor`, `memory.SetInstrumentation`, `memory.SetLogger`, `memory.SetRevokedFamilyRetentionDays` — replaced by construction-time options.
 - **`dpop/valkey` package removed.** The Valkey-backed DPoP replay cache is now at `storage/valkey.NewDPoPReplayCache`. Update imports from `github.com/giantswarm/mcp-oauth/dpop/valkey` to `github.com/giantswarm/mcp-oauth/storage/valkey` and replace `valkey.New(client, prefix)` with `valkey.NewDPoPReplayCache(client, prefix)`.
 - **`server.Clock` interface and `server.DNSResolver` interface removed.** `clientMetadataCache` now calls `time.Now()` directly; use `testing/synctest` for TTL-sensitive tests. `Config.DNSResolver` is now `*net.Resolver`; pass a `*net.Resolver` with a custom `Dial` function to intercept DNS in tests.

--- a/SECURITY_CHECKLIST.md
+++ b/SECURITY_CHECKLIST.md
@@ -19,7 +19,7 @@ This checklist should be completed for all pull requests that modify security-se
 - [ ] Link-local addresses blocked (169.254.169.254 - metadata services)
 - [ ] HTTPS enforced for all external communications
 - [ ] HTTP redirects validated to prevent SSRF via redirects
-- [ ] `skipValidation` flag ONLY used in test files with `NewTestDiscoveryClient`
+- [ ] `oidc.WithSkipValidation()` only used via `internal/testutil.NewDiscoveryClient` in test files
 
 ### 3. Input Validation ✓
 
@@ -140,8 +140,7 @@ This checklist should be completed for all pull requests that modify security-se
 ## Test Security
 
 - [ ] Test-only security bypasses have build tags or clear documentation
-- [ ] `NewTestDiscoveryClient` only used in `*_test.go` files
-- [ ] `skipValidation` only set to `true` in test code
+- [ ] `oidc.WithSkipValidation()` only called via `internal/testutil.NewDiscoveryClient` in `*_test.go` files
 - [ ] Test servers use `httptest.Server` (not real external services)
 - [ ] No test credentials committed to repository
 

--- a/internal/testutil/oidc_discovery.go
+++ b/internal/testutil/oidc_discovery.go
@@ -1,0 +1,16 @@
+package testutil
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+)
+
+// NewDiscoveryClient returns an OIDC discovery client with SSRF validation
+// disabled. Use only in tests that spin up httptest servers on loopback
+// addresses.
+func NewDiscoveryClient(httpClient *http.Client, cacheTTL time.Duration, logger *slog.Logger) *oidc.DiscoveryClient {
+	return oidc.NewDiscoveryClientWithOptions(httpClient, cacheTTL, logger, oidc.WithSkipValidation())
+}

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -116,7 +116,7 @@ func NewProvider(cfg *Config) (*Provider, error) {
 			"cwe", "CWE-918",
 		)
 	}
-	discoveryClient := resolveDiscoveryClient(cfg.discoveryClient, httpClient)
+	discoveryClient := resolveDiscoveryClient(cfg.discoveryClient, httpClient, logger)
 
 	doc, err := performOIDCDiscovery(discoveryClient, cfg.IssuerURL, requestTimeout)
 	if err != nil {
@@ -241,11 +241,11 @@ func resolveHTTPClient(client *http.Client, allowPrivateIP bool, timeout time.Du
 
 // resolveDiscoveryClient returns override when non-nil, otherwise constructs a
 // production discovery client from httpClient.
-func resolveDiscoveryClient(override *oidc.DiscoveryClient, httpClient *http.Client) *oidc.DiscoveryClient {
+func resolveDiscoveryClient(override *oidc.DiscoveryClient, httpClient *http.Client, logger *slog.Logger) *oidc.DiscoveryClient {
 	if override != nil {
 		return override
 	}
-	return oidc.NewDiscoveryClient(httpClient, 1*time.Hour, nil)
+	return oidc.NewDiscoveryClient(httpClient, 1*time.Hour, logger)
 }
 
 // performOIDCDiscovery performs OIDC discovery to fetch endpoints.

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -84,9 +84,10 @@ type Config struct {
 	// WARNING: Reduces SSRF protection. Only enable for private IdP deployments.
 	AllowPrivateIP bool
 
-	// skipValidation is for tests only — bypasses SSRF issuer-URL validation so
-	// test servers on localhost are reachable. Must never be set in production code.
-	skipValidation bool
+	// discoveryClient overrides the OIDC discovery client. Nil means
+	// NewProvider constructs one from the other config fields. Same-package
+	// tests use this to inject a client pointed at a loopback httptest server.
+	discoveryClient *oidc.DiscoveryClient
 }
 
 // NewProvider creates a new Dex OAuth provider.
@@ -115,7 +116,7 @@ func NewProvider(cfg *Config) (*Provider, error) {
 			"cwe", "CWE-918",
 		)
 	}
-	discoveryClient := createDiscoveryClient(cfg.skipValidation, httpClient)
+	discoveryClient := resolveDiscoveryClient(cfg.discoveryClient, httpClient)
 
 	doc, err := performOIDCDiscovery(discoveryClient, cfg.IssuerURL, requestTimeout)
 	if err != nil {
@@ -160,8 +161,10 @@ func validateRequiredConfig(cfg *Config) error {
 		return fmt.Errorf("issuer URL is required")
 	}
 
-	// SECURITY: Validate issuer URL with SSRF protection (skip for tests)
-	if !cfg.skipValidation {
+	// SECURITY: Validate issuer URL with SSRF protection.
+	// When a discovery client is injected (tests only), skip URL validation:
+	// the injected client is already bound to a trusted server.
+	if cfg.discoveryClient == nil {
 		if err := oidc.ValidateIssuerURL(cfg.IssuerURL); err != nil {
 			return fmt.Errorf("invalid issuer URL: %w", err)
 		}
@@ -236,10 +239,11 @@ func resolveHTTPClient(client *http.Client, allowPrivateIP bool, timeout time.Du
 	return &http.Client{Timeout: timeout}
 }
 
-// createDiscoveryClient creates an OIDC discovery client.
-func createDiscoveryClient(skipValidation bool, httpClient *http.Client) *oidc.DiscoveryClient {
-	if skipValidation {
-		return oidc.NewTestDiscoveryClient(httpClient, 1*time.Hour, nil)
+// resolveDiscoveryClient returns override when non-nil, otherwise constructs a
+// production discovery client from httpClient.
+func resolveDiscoveryClient(override *oidc.DiscoveryClient, httpClient *http.Client) *oidc.DiscoveryClient {
+	if override != nil {
+		return override
 	}
 	return oidc.NewDiscoveryClient(httpClient, 1*time.Hour, nil)
 }

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/giantswarm/mcp-oauth/internal/testutil"
 	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
 
@@ -19,15 +20,17 @@ import (
 // from issue #218 where users had 303 groups and were blocked by the previous limit of 100.
 const enterpriseGroupCount = 303
 
-// Helper function to create test config for a given server
+// testConfig builds a Config pointing at a loopback httptest server.
+// An injected discovery client bypasses SSRF URL validation so that
+// tests can use httptest.NewTLSServer on loopback addresses.
 func testConfig(server *httptest.Server, options ...func(*Config)) *Config {
 	cfg := &Config{
-		IssuerURL:      server.URL,
-		ClientID:       "test-client",
-		ClientSecret:   "test-secret",
-		RedirectURL:    "http://localhost:8080/callback",
-		HTTPClient:     server.Client(), // Use test server's HTTP client (trusts test TLS cert)
-		skipValidation: true,            // Skip SSRF validation for test servers on localhost
+		IssuerURL:       server.URL,
+		ClientID:        "test-client",
+		ClientSecret:    "test-secret",
+		RedirectURL:     "http://localhost:8080/callback",
+		HTTPClient:      server.Client(),
+		discoveryClient: testutil.NewDiscoveryClient(server.Client(), 1*time.Hour, nil),
 	}
 
 	for _, opt := range options {

--- a/providers/oidc/discovery.go
+++ b/providers/oidc/discovery.go
@@ -106,37 +106,24 @@ func NewDiscoveryClient(httpClient *http.Client, cacheTTL time.Duration, logger 
 	}
 }
 
-// NewTestDiscoveryClient creates a discovery client that skips SSRF validation.
-//
-// ⚠️  CRITICAL SECURITY WARNING ⚠️
-//
-// This function bypasses ALL security protections including:
-//   - Private IP blocking (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-//   - Loopback blocking (127.0.0.1, ::1)
-//   - Link-local blocking (169.254.169.254 - AWS metadata service)
-//   - HTTPS enforcement
-//
-// NEVER USE THIS IN PRODUCTION CODE!
-//
-// This function exists ONLY for unit tests with httptest.Server on localhost.
-// The forbidigo linter is configured to detect and prevent misuse.
-//
-// Intended Use (test files only):
-//
-//	func TestOIDCProvider(t *testing.T) {
-//	    testServer := httptest.NewTLSServer(mockOIDCHandler)
-//	    defer testServer.Close()
-//	    client := oidc.NewTestDiscoveryClient(testServer.Client(), 1*time.Hour, nil)
-//	    // ... test code ...
-//	}
-//
-// Security Enforcement:
-//   - Linter rules prevent usage outside *_test.go files
-//   - Code review must verify all usages are in test code
-//   - CI/CD should fail if this appears in production code paths
-func NewTestDiscoveryClient(httpClient *http.Client, cacheTTL time.Duration, logger *slog.Logger) *DiscoveryClient {
+// WithSkipValidation returns a [DiscoveryOption] that disables SSRF and HTTPS
+// validation on the discovery client. Intended exclusively for unit tests that
+// spin up httptest servers on loopback addresses. Production callers must not
+// use this option — it bypasses all URL security checks.
+func WithSkipValidation() DiscoveryOption {
+	return func(c *DiscoveryClient) { c.skipValidation = true }
+}
+
+// DiscoveryOption is a functional option for [NewDiscoveryClientWithOptions].
+type DiscoveryOption func(*DiscoveryClient)
+
+// NewDiscoveryClientWithOptions creates a discovery client applying the given
+// options after default initialization. Use [WithSkipValidation] only in tests.
+func NewDiscoveryClientWithOptions(httpClient *http.Client, cacheTTL time.Duration, logger *slog.Logger, opts ...DiscoveryOption) *DiscoveryClient {
 	client := NewDiscoveryClient(httpClient, cacheTTL, logger)
-	client.skipValidation = true
+	for _, opt := range opts {
+		opt(client)
+	}
 	return client
 }
 

--- a/providers/oidc/discovery_test.go
+++ b/providers/oidc/discovery_test.go
@@ -27,9 +27,7 @@ func (m *mockTime) Since(t time.Time) time.Duration { return m.now.Sub(t) }
 // This allows tests to use httptest servers (which use loopback addresses)
 // without triggering SSRF protection.
 func newTestClient(httpClient *http.Client, ttl time.Duration) *DiscoveryClient {
-	client := NewDiscoveryClient(httpClient, ttl, slog.Default())
-	client.skipValidation = true // Bypass SSRF validation for test servers
-	return client
+	return NewDiscoveryClientWithOptions(httpClient, ttl, slog.Default(), WithSkipValidation())
 }
 
 func TestNewDiscoveryClient(t *testing.T) {

--- a/server/client.go
+++ b/server/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage"
-	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
 
 // Client type constants (also defined in root package constants.go)
@@ -182,8 +181,8 @@ func GenerateRegistrationAccessToken() (plaintext, hash string, err error) {
 
 // trackClientIPAndLog tracks the IP for DoS protection and logs the registration.
 func (s *Server) trackClientIPAndLog(ctx context.Context, client *storage.Client, _ /* clientSecret - not logged for security */, clientIP string) {
-	if memStore, ok := s.clientStore.(*memory.Store); ok {
-		memStore.TrackClientIP(clientIP)
+	if tracker, ok := s.clientStore.(storage.ClientIPTracker); ok {
+		_ = tracker.TrackClientIP(ctx, client.ClientID, clientIP)
 	}
 
 	s.Auditor.LogClientRegistered(ctx, client.ClientID, client.ClientType, clientIP)

--- a/server/client.go
+++ b/server/client.go
@@ -182,7 +182,9 @@ func GenerateRegistrationAccessToken() (plaintext, hash string, err error) {
 // trackClientIPAndLog tracks the IP for DoS protection and logs the registration.
 func (s *Server) trackClientIPAndLog(ctx context.Context, client *storage.Client, _ /* clientSecret - not logged for security */, clientIP string) {
 	if tracker, ok := s.clientStore.(storage.ClientIPTracker); ok {
-		_ = tracker.TrackClientIP(ctx, client.ClientID, clientIP)
+		if err := tracker.TrackClientIP(context.WithoutCancel(ctx), client.ClientID, clientIP); err != nil {
+			s.Logger.Warn("failed to track client IP", "client_id", client.ClientID, "ip", clientIP, "error", err)
+		}
 	}
 
 	s.Auditor.LogClientRegistered(ctx, client.ClientID, client.ClientType, clientIP)

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -766,7 +766,6 @@ func TestServer_CanRegisterWithTrustedScheme(t *testing.T) {
 
 // TestServer_RegisterClient_NoIPTrackerNoPanic confirms that registering a client
 // against a ClientStore that does not implement ClientIPTracker does not panic.
-// This exercises the optional-interface branch in trackClientIPAndLog.
 func TestServer_RegisterClient_NoIPTrackerNoPanic(t *testing.T) {
 	ctx := t.Context()
 	combined := mockstorage.NewCombined()

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
+	mockstorage "github.com/giantswarm/mcp-oauth/storage/mock"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
 
@@ -760,5 +761,40 @@ func TestServer_CanRegisterWithTrustedScheme(t *testing.T) {
 				t.Errorf("scheme = %q, want %q", scheme, tt.wantScheme)
 			}
 		})
+	}
+}
+
+// TestServer_RegisterClient_NoIPTrackerNoPanic confirms that registering a client
+// against a ClientStore that does not implement ClientIPTracker does not panic.
+// This exercises the optional-interface branch in trackClientIPAndLog.
+func TestServer_RegisterClient_NoIPTrackerNoPanic(t *testing.T) {
+	ctx := t.Context()
+	combined := mockstorage.NewCombined()
+
+	provider := mock.NewProvider()
+	config := &Config{Issuer: "https://auth.example.com"}
+
+	srv, err := New(provider, combined, combined, combined, config, nil)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	// combined does not implement storage.ClientIPTracker; the server must
+	// skip IP tracking gracefully rather than panicking.
+	client, _, err := srv.RegisterClient(
+		ctx,
+		"stub client",
+		ClientTypeConfidential,
+		"",
+		[]string{"https://example.com/callback"},
+		[]string{"openid"},
+		"10.0.0.1",
+		100,
+	)
+	if err != nil {
+		t.Fatalf("RegisterClient() unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("RegisterClient() returned nil client")
 	}
 }

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -529,11 +529,14 @@ func (s *Store) CheckIPLimit(_ context.Context, ip string, maxClientsPerIP int) 
 	return nil
 }
 
-// TrackClientIP increments the client count for an IP address
-func (s *Store) TrackClientIP(ip string) {
+// TrackClientIP increments the registration count for the given IP address.
+// The clientID parameter is accepted for interface compatibility but is not
+// persisted by the in-memory store.
+func (s *Store) TrackClientIP(_ context.Context, _ /* clientID */ string, ip string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.clientsPerIP[ip]++
+	return nil
 }
 
 // ============================================================

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -117,6 +117,7 @@ var (
 	_ storage.RevokedTokenStore               = (*Store)(nil)
 	_ storage.RefreshTokenFamilyByIDStore     = (*Store)(nil)
 	_ storage.ActiveRefreshTokenByFamilyStore = (*Store)(nil)
+	_ storage.ClientIPTracker                 = (*Store)(nil)
 )
 
 // Option configures a Store at construction time.

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -766,7 +766,7 @@ func TestStore_CheckIPLimit(t *testing.T) {
 
 	// Register clients for this IP
 	for i := 0; i < maxClients; i++ {
-		store.TrackClientIP(ip)
+		_ = store.TrackClientIP(ctx, "", ip)
 	}
 
 	// Should fail after reaching limit

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -329,6 +329,12 @@ type ClientStore interface {
 	CheckIPLimit(ctx context.Context, ip string, maxClientsPerIP int) error
 }
 
+// ClientIPTracker is an optional capability implemented by ClientStore
+// implementations that can record the most recent client IP per client_id.
+type ClientIPTracker interface {
+	TrackClientIP(ctx context.Context, clientID, ip string) error
+}
+
 // FlowStore defines the interface for managing OAuth authorization flows.
 //
 // # Understanding StateID vs ProviderState

--- a/storage/valkey/client.go
+++ b/storage/valkey/client.go
@@ -254,8 +254,10 @@ func (s *Store) CheckIPLimit(ctx context.Context, ip string, maxClientsPerIP int
 	return nil
 }
 
-// TrackClientIP increments the client count for an IP address
-func (s *Store) TrackClientIP(ctx context.Context, ip string) (err error) {
+// TrackClientIP increments the client count for an IP address.
+// The clientID parameter is accepted for interface compatibility but is not
+// stored separately; only the IP address is tracked.
+func (s *Store) TrackClientIP(ctx context.Context, _ /* clientID */ string, ip string) (err error) {
 	op := s.startTracedOp(ctx, "track_client_ip")
 	defer op.end(&err)
 

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -164,6 +164,7 @@ var (
 	_ storage.TokenMetadataStore              = (*Store)(nil)
 	_ storage.RevokedTokenStore               = (*Store)(nil)
 	_ storage.ActiveRefreshTokenByFamilyStore = (*Store)(nil)
+	_ storage.ClientIPTracker                 = (*Store)(nil)
 )
 
 // New creates a new Valkey-backed storage instance. All dependencies

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -947,7 +947,7 @@ func TestClientStore_CheckIPLimit(t *testing.T) {
 
 	// Track some clients
 	for i := 0; i < 3; i++ {
-		_ = s.TrackClientIP(ctx, "192.168.1.2")
+		_ = s.TrackClientIP(ctx, "", "192.168.1.2")
 	}
 
 	// Check limit
@@ -958,7 +958,7 @@ func TestClientStore_CheckIPLimit(t *testing.T) {
 
 	// Track more to exceed limit
 	for i := 0; i < 3; i++ {
-		_ = s.TrackClientIP(ctx, "192.168.1.2")
+		_ = s.TrackClientIP(ctx, "", "192.168.1.2")
 	}
 
 	err = s.CheckIPLimit(ctx, "192.168.1.2", 5)
@@ -2080,7 +2080,7 @@ func TestValidation_GenericErrorMessages(t *testing.T) {
 	// Test that CheckIPLimit returns generic error when limit exceeded
 	// First, set up an IP that has exceeded the limit
 	for i := 0; i < 5; i++ {
-		_ = s.TrackClientIP(ctx, "192.168.99.99")
+		_ = s.TrackClientIP(ctx, "", "192.168.99.99")
 	}
 
 	err = s.CheckIPLimit(ctx, "192.168.99.99", 3)


### PR DESCRIPTION
## Wave 2.1 — unexport `NewTestDiscoveryClient` (H8)

`oidc.NewTestDiscoveryClient` bypassed SSRF and HTTPS validation entirely. Any code path that could influence whether `dex.Config.skipValidation` was set could coerce the server into fetching arbitrary internal URLs.

Changes:
- `oidc.NewTestDiscoveryClient` is removed. A new `oidc.WithSkipValidation()` functional option and `oidc.NewDiscoveryClientWithOptions` replace it, giving `internal/testutil` a safe construction path that cannot be imported by downstream consumers.
- `internal/testutil.NewDiscoveryClient` is the new canonical test helper. It calls `WithSkipValidation` internally; anything outside this module's `internal/` tree cannot import it.
- `dex.Config.skipValidation` is removed. Tests that need to point a Dex provider at a loopback httptest server now inject a pre-built `*oidc.DiscoveryClient` via the unexported `Config.discoveryClient` field. When that field is non-nil, `NewProvider` skips the issuer URL SSRF check (the injected client is already bound to a trusted server) and uses the client directly.

## Wave 2.2 — drop `*memory.Store` type assertion (H4)

`server/client.go` contained `s.clientStore.(*memory.Store)` to call `TrackClientIP`. Any operator wiring a custom or valkey `ClientStore` silently lost the client-IP registration tracking.

Changes:
- `storage.ClientIPTracker` optional interface added to `storage/storage.go`.
- `trackClientIPAndLog` uses `s.clientStore.(storage.ClientIPTracker)` — if the store implements it, IP tracking runs; otherwise it is skipped without panic.
- `memory.Store.TrackClientIP` and `valkey.Store.TrackClientIP` updated to the unified signature `TrackClientIP(ctx, clientID, ip string) error`.
- `TestServer_RegisterClient_NoIPTrackerNoPanic` confirms a mock `ClientStore` without `ClientIPTracker` does not panic on registration.