### PR TITLE
fix: drop ### prefix from changelog-sections

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,15 +1,15 @@
 {
   "release-type": "simple",
   "changelog-sections": [
-    {"type": "feat",     "section": "### Added"},
-    {"type": "fix",      "section": "### Fixed"},
-    {"type": "refactor", "section": "### Changed"},
-    {"type": "perf",     "section": "### Changed"},
-    {"type": "docs",     "section": "### Changed"},
-    {"type": "chore",    "section": "### Changed"},
-    {"type": "test",     "section": "### Changed"},
-    {"type": "build",    "section": "### Changed"},
-    {"type": "ci",       "section": "### Changed"},
-    {"type": "security", "section": "### Security"}
+    {"type": "feat",     "section": "Added"},
+    {"type": "fix",      "section": "Fixed"},
+    {"type": "refactor", "section": "Changed"},
+    {"type": "perf",     "section": "Changed"},
+    {"type": "docs",     "section": "Changed"},
+    {"type": "chore",    "section": "Changed"},
+    {"type": "test",     "section": "Changed"},
+    {"type": "build",    "section": "Changed"},
+    {"type": "ci",       "section": "Changed"},
+    {"type": "security", "section": "Security"}
   ]
 }


### PR DESCRIPTION
release-please renders section headings as `### <value>`, so the `### ` prefix in section strings produces `### ### Added` in the generated CHANGELOG.