### PR TITLE
chore: bootstrap release-please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,14 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  release:
+    uses: giantswarm/github-workflows/.github/workflows/release.yaml@main
+    secrets:
+      TAYLORBOT_GITHUB_ACTION: ${{ secrets.TAYLORBOT_GITHUB_ACTION }}


### PR DESCRIPTION
Adopt release-please for automated releases (GS pattern).

## What's in this PR

- `release-please-config.json`, `.release-please-manifest.json`, and `.github/workflows/release.yaml` calling the reusable workflow at `giantswarm/github-workflows/.github/workflows/release.yaml@main`. Seeded at `0.2.0`.
- `changelog-sections` mapped to `### Added` / `### Changed` / `### Fixed` / `### Security` (legacy changelog style, matches the giantswarm/releases scraper).
- `CHANGELOG.md` normalized: existing Keep-a-Changelog reference-link entries (`## [x.y.z] - DATE` plus trailing `[x.y.z]: url` block) rewritten to release-please's inline-link H2 format. No bullet content changed.

## After merge

release-please uses the `v0.2.0` tag as its boundary and opens a release PR once a `feat:` or `fix:` Conventional Commit lands on `main`.

If `## [Unreleased]` in this file contains entries describing commits already merged to `main`, the first release-please PR may produce a section that overlaps with them. Review the first release PR and either remove the `## [Unreleased]` block in this PR or in that one before merging it.