### PR TITLE
feat(dex): AllowPrivateIP for OIDC discovery behind internal load balancers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dex.Config.AllowPrivateIP`: allows the Dex issuer URL to resolve to a private/loopback IP during OIDC discovery and token endpoint calls. Required for clusters where the public Dex hostname resolves to an internal load balancer (e.g. Azure internal LB). Emits a `CWE-918` startup warning. Consumers set `muster.muster.oauth.server.dex.allowPrivateIPOIDC: true`.
+
 ### Fixed
 
 - **JSON encode errors on response writes** are now logged instead of silently swallowed across all handler endpoints (discovery, token, token-exchange, introspection, registration, client management, userinfo, JWKS, and error responses). The HTTP status is unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dex.Config.AllowPrivateIP`: allows the Dex issuer URL to resolve to a private/loopback IP during OIDC discovery and token endpoint calls. Required for clusters where the public Dex hostname resolves to an internal load balancer (e.g. Azure internal LB). Emits a `CWE-918` startup warning. Consumers set `muster.muster.oauth.server.dex.allowPrivateIPOIDC: true`.
+- `dex.Config.AllowPrivateIP`: allows the Dex issuer URL to resolve to a private/loopback IP during OIDC discovery and token endpoint calls. Required for clusters where the public Dex hostname resolves to an internal load balancer (e.g. Azure internal LB). Emits a startup warning when enabled.
 
 ### Fixed
 

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -73,8 +73,14 @@ type Config struct {
 	// AllowPrivateIP allows the Dex issuer URL to resolve to a private or
 	// loopback IP address during OIDC discovery and token endpoint calls. Required
 	// when Dex is fronted by an internal-only load balancer (e.g. Azure internal LB,
-	// air-gapped clusters) where the public hostname resolves to an RFC 1918
-	// address. Emits a startup warning when set.
+	// air-gapped clusters) where the public hostname resolves to an RFC 1918 address.
+	// Emits a startup warning when set.
+	//
+	// Note: IP-literal private addresses in IssuerURL (e.g. https://10.0.0.1) are
+	// still rejected by URL validation regardless of this flag. This flag only lifts
+	// the transport-level SSRF check for hostnames that resolve to private IPs at
+	// connection time.
+	//
 	// WARNING: Reduces SSRF protection. Only enable for private IdP deployments.
 	AllowPrivateIP bool
 

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -70,6 +70,14 @@ type Config struct {
 	// Default: slog.Default()
 	Logger *slog.Logger
 
+	// AllowPrivateIP allows the Dex issuer URL to resolve to a private or
+	// loopback IP address during OIDC discovery. Required when Dex is
+	// fronted by an internal-only load balancer (e.g. Azure internal LB,
+	// air-gapped clusters) where the public hostname resolves to an RFC 1918
+	// address. Emits a startup warning when set.
+	// WARNING: Reduces SSRF protection. Only enable for private IdP deployments.
+	AllowPrivateIP bool
+
 	// skipValidation skips SSRF protection for issuer URLs
 	// INTERNAL USE ONLY: This is for testing with localhost test servers
 	// Production code must NEVER set this to true
@@ -89,7 +97,14 @@ func NewProvider(cfg *Config) (*Provider, error) {
 	}
 
 	requestTimeout := resolveTimeout(cfg.RequestTimeout)
-	httpClient := resolveHTTPClient(cfg.HTTPClient, requestTimeout)
+	httpClient := resolveHTTPClient(cfg.HTTPClient, cfg.AllowPrivateIP, requestTimeout)
+	if cfg.AllowPrivateIP && cfg.HTTPClient == nil {
+		slog.Warn("SECURITY WARNING: AllowPrivateIP is enabled for Dex OIDC discovery",
+			"risk", "OIDC discovery and token endpoints can resolve to private/internal IP addresses — SSRF possible",
+			"recommendation", "Unset for production deployments; use only for private IdP deployments (e.g., internal load balancer fronting Dex)",
+			"cwe", "CWE-918",
+		)
+	}
 	discoveryClient := createDiscoveryClient(cfg.skipValidation, httpClient)
 
 	doc, err := performOIDCDiscovery(discoveryClient, cfg.IssuerURL, requestTimeout)
@@ -202,10 +217,16 @@ func resolveTimeout(timeout time.Duration) time.Duration {
 	return timeout
 }
 
-// resolveHTTPClient returns the HTTP client, creating one if not provided.
-func resolveHTTPClient(client *http.Client, timeout time.Duration) *http.Client {
+// resolveHTTPClient returns the HTTP client to use for Dex API calls and OIDC
+// discovery. When allowPrivateIP is true and no explicit client is provided, a
+// client without SSRF protection is returned so that Dex issuer URLs resolving
+// to RFC 1918 addresses (e.g. internal load balancers) are reachable.
+func resolveHTTPClient(client *http.Client, allowPrivateIP bool, timeout time.Duration) *http.Client {
 	if client != nil {
 		return client
+	}
+	if allowPrivateIP {
+		return oidc.NewPrivateIPAllowedHTTPClient(timeout)
 	}
 	return &http.Client{Timeout: timeout}
 }

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -71,16 +71,15 @@ type Config struct {
 	Logger *slog.Logger
 
 	// AllowPrivateIP allows the Dex issuer URL to resolve to a private or
-	// loopback IP address during OIDC discovery. Required when Dex is
-	// fronted by an internal-only load balancer (e.g. Azure internal LB,
+	// loopback IP address during OIDC discovery and token endpoint calls. Required
+	// when Dex is fronted by an internal-only load balancer (e.g. Azure internal LB,
 	// air-gapped clusters) where the public hostname resolves to an RFC 1918
 	// address. Emits a startup warning when set.
 	// WARNING: Reduces SSRF protection. Only enable for private IdP deployments.
 	AllowPrivateIP bool
 
-	// skipValidation skips SSRF protection for issuer URLs
-	// INTERNAL USE ONLY: This is for testing with localhost test servers
-	// Production code must NEVER set this to true
+	// skipValidation is for tests only — bypasses SSRF issuer-URL validation so
+	// test servers on localhost are reachable. Must never be set in production code.
 	skipValidation bool
 }
 
@@ -96,12 +95,18 @@ func NewProvider(cfg *Config) (*Provider, error) {
 		return nil, err
 	}
 
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	requestTimeout := resolveTimeout(cfg.RequestTimeout)
+	// httpClient is used for both OIDC discovery and token endpoint calls.
 	httpClient := resolveHTTPClient(cfg.HTTPClient, cfg.AllowPrivateIP, requestTimeout)
 	if cfg.AllowPrivateIP && cfg.HTTPClient == nil {
-		slog.Warn("SECURITY WARNING: AllowPrivateIP is enabled for Dex OIDC discovery",
+		logger.Warn("SECURITY WARNING: AllowPrivateIP is enabled for Dex OIDC discovery and token endpoints",
 			"risk", "OIDC discovery and token endpoints can resolve to private/internal IP addresses — SSRF possible",
-			"recommendation", "Unset for production deployments; use only for private IdP deployments (e.g., internal load balancer fronting Dex)",
+			"recommendation", "Only enable when the IdP is behind an internal-only load balancer; ensure the issuer URL is not attacker-controlled",
 			"cwe", "CWE-918",
 		)
 	}
@@ -115,11 +120,6 @@ func NewProvider(cfg *Config) (*Provider, error) {
 	maxGroups := cfg.MaxGroups
 	if maxGroups <= 0 {
 		maxGroups = oidc.DefaultMaxGroups
-	}
-
-	logger := cfg.Logger
-	if logger == nil {
-		logger = slog.Default()
 	}
 
 	return &Provider{

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -107,9 +107,8 @@ func NewProvider(cfg *Config) (*Provider, error) {
 	}
 
 	requestTimeout := resolveTimeout(cfg.RequestTimeout)
-	// httpClient is used for both OIDC discovery and token endpoint calls.
 	httpClient := resolveHTTPClient(cfg.HTTPClient, cfg.AllowPrivateIP, requestTimeout)
-	if cfg.AllowPrivateIP && cfg.HTTPClient == nil {
+	if cfg.AllowPrivateIP {
 		logger.Warn("SECURITY WARNING: AllowPrivateIP is enabled for Dex OIDC discovery and token endpoints",
 			"risk", "OIDC discovery and token endpoints can resolve to private/internal IP addresses — SSRF possible",
 			"recommendation", "Only enable when the IdP is behind an internal-only load balancer; ensure the issuer URL is not attacker-controlled",

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -962,3 +962,114 @@ func TestTooManyScopes(t *testing.T) {
 		t.Errorf("NewProvider() error = %v, want error about scopes", err)
 	}
 }
+
+func TestResolveHTTPClient(t *testing.T) {
+	timeout := 5 * time.Second
+	custom := &http.Client{Timeout: 99 * time.Second}
+
+	tests := []struct {
+		name           string
+		client         *http.Client
+		allowPrivateIP bool
+		wantSame       *http.Client // non-nil: pointer equality check
+		wantTimeout    time.Duration
+	}{
+		{
+			name:           "explicit client returned unchanged",
+			client:         custom,
+			allowPrivateIP: false,
+			wantSame:       custom,
+		},
+		{
+			name:           "explicit client with allowPrivateIP returned unchanged",
+			client:         custom,
+			allowPrivateIP: true,
+			wantSame:       custom,
+		},
+		{
+			name:           "nil client without allowPrivateIP returns plain client",
+			client:         nil,
+			allowPrivateIP: false,
+			wantTimeout:    timeout,
+		},
+		{
+			name:           "nil client with allowPrivateIP returns private-IP-allowed client",
+			client:         nil,
+			allowPrivateIP: true,
+			wantTimeout:    timeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveHTTPClient(tt.client, tt.allowPrivateIP, timeout)
+			if got == nil {
+				t.Fatal("resolveHTTPClient() returned nil")
+			}
+			if tt.wantSame != nil && got != tt.wantSame {
+				t.Errorf("resolveHTTPClient() returned different client; want same pointer")
+			}
+		})
+	}
+}
+
+func TestAllowPrivateIP_WarningEmitted(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// HTTPClient = nil overrides testConfig's default (server.Client()), so the warning
+	// fires. Discovery then fails because NewPrivateIPAllowedHTTPClient does not trust
+	// the test server's self-signed cert — that's expected. We only care that the
+	// warning was emitted to the custom logger before the failure.
+	_, _ = NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.AllowPrivateIP = true
+		cfg.HTTPClient = nil
+		cfg.Logger = logger
+	}))
+
+	if !strings.Contains(buf.String(), "CWE-918") {
+		t.Errorf("expected CWE-918 warning in log output; got: %q", buf.String())
+	}
+}
+
+func TestAllowPrivateIP_NoWarningWithExplicitClient(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	_, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.AllowPrivateIP = true
+		// HTTPClient is already set by testConfig (server.Client()); keep it
+		cfg.Logger = logger
+	}))
+	if err != nil {
+		t.Fatalf("NewProvider() failed: %v", err)
+	}
+
+	if strings.Contains(buf.String(), "CWE-918") {
+		t.Errorf("unexpected CWE-918 warning when HTTPClient is explicitly set; got: %s", buf.String())
+	}
+}
+
+// TestAllowPrivateIP_IPLiteralStillRejected confirms that AllowPrivateIP does not
+// bypass static URL validation: an IP-literal private IssuerURL is rejected even
+// when the flag is set, because the flag only lifts the transport-level check.
+func TestAllowPrivateIP_IPLiteralStillRejected(t *testing.T) {
+	_, err := NewProvider(&Config{
+		IssuerURL:      "https://10.0.0.1",
+		ClientID:       "client",
+		ClientSecret:   "secret",
+		AllowPrivateIP: true,
+	})
+	if err == nil {
+		t.Fatal("NewProvider() succeeded, want error for private IP literal")
+	}
+	if !strings.Contains(err.Error(), "invalid issuer URL") {
+		t.Errorf("NewProvider() error = %v, want error containing 'invalid issuer URL'", err)
+	}
+}

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -1035,7 +1035,7 @@ func TestAllowPrivateIP_WarningEmitted(t *testing.T) {
 	}
 }
 
-func TestAllowPrivateIP_NoWarningWithExplicitClient(t *testing.T) {
+func TestAllowPrivateIP_WarningEmittedWithExplicitClient(t *testing.T) {
 	server := setupMockDexServer(t)
 	defer server.Close()
 
@@ -1051,8 +1051,8 @@ func TestAllowPrivateIP_NoWarningWithExplicitClient(t *testing.T) {
 		t.Fatalf("NewProvider() failed: %v", err)
 	}
 
-	if strings.Contains(buf.String(), "CWE-918") {
-		t.Errorf("unexpected CWE-918 warning when HTTPClient is explicitly set; got: %s", buf.String())
+	if !strings.Contains(buf.String(), "CWE-918") {
+		t.Errorf("expected CWE-918 warning even when HTTPClient is explicitly set; got: %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## What

Adds `AllowPrivateIP bool` to `dex.Config`. When set, OIDC discovery and token endpoint calls use `oidc.NewPrivateIPAllowedHTTPClient` instead of the default plain `http.Client`, allowing the Dex issuer URL to resolve to an RFC 1918 address.

## Why

Clusters where the public Dex hostname resolves to an internal-only load balancer (Azure internal LB, air-gapped environments) fail OIDC discovery silently: the SSRF-safe client's dial hook blocks private IPs, producing a `context deadline exceeded` timeout rather than an explicit rejection. Configuring `AllowPrivateIP: true` is the only fix short of running a public-IP load balancer.

This follows the exact pattern already established for JWKS validation (`AllowPrivateIPJWKS` in `JWKSClientOptions`) and token exchange (`AllowPrivateIP` in `TokenExchangerOptions`).

## Security

A `CWE-918` startup warning is emitted whenever `AllowPrivateIP` is set, regardless of whether the caller supplies an explicit `HTTPClient`. The flag is `false` by default; no existing behaviour changes.

## Consumer

`muster` exposes this as `muster.muster.oauth.server.dex.allowPrivateIPOIDC: true` in its Helm values (companion PR in giantswarm/muster).