### PR TITLE
ci: fix pre-commit gofmt & golangci-lint violations on main

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -26,17 +26,17 @@ const (
 // Endpoint labels for `oauth_http_requests_total{endpoint="..."}` etc.
 // Future renames are breaking changes for downstream dashboards.
 const (
-	endpointAuthorize        = "authorize"
-	endpointCallback         = "callback"
-	endpointToken            = "token"
-	endpointRevoke           = "revoke"
-	endpointIntrospect       = "introspect"
-	endpointRegister         = "register"
-	endpointValidateToken    = "validate_token"
-	endpointUserInfo         = "userinfo"
-	endpointDiscovery        = "discovery"
-	endpointJWKS             = "jwks"
-	endpointClientManagement = "client_management"
+	endpointAuthorize         = "authorize"
+	endpointCallback          = "callback"
+	endpointToken             = "token"
+	endpointRevoke            = "revoke"
+	endpointIntrospect        = "introspect"
+	endpointRegister          = "register"
+	endpointValidateToken     = "validate_token"
+	endpointUserInfo          = "userinfo"
+	endpointDiscovery         = "discovery"
+	endpointJWKS              = "jwks"
+	endpointClientManagement  = "client_management"
 	endpointProtectedResource = "protected_resource"
 )
 

--- a/handler/middleware_test.go
+++ b/handler/middleware_test.go
@@ -1638,7 +1638,7 @@ func setupDPoPTestHandler(t *testing.T, accessToken, jkt string) (*Handler, *mem
 // token presented as plain Bearer is rejected.
 func TestValidateToken_DPoPBoundToken_BearerBypass(t *testing.T) {
 	const (
-		accessToken = "dpop-bound-opaque-token"
+		accessToken = "dpop-bound-opaque-token" //nolint:gosec // G101 false positive — test fixture label, not a credential
 		boundJKT    = "some-jwk-thumbprint"
 	)
 
@@ -1667,7 +1667,7 @@ func TestValidateToken_DPoPBoundToken_BearerBypass(t *testing.T) {
 // key thumbprint does not match the token's cnf.jkt is rejected.
 func TestValidateToken_DPoPBoundToken_KeyMismatch(t *testing.T) {
 	const (
-		accessToken = "dpop-bound-opaque-token-2"
+		accessToken = "dpop-bound-opaque-token-2" //nolint:gosec // G101 false positive — test fixture label, not a credential
 		boundJKT    = "token-bound-jkt"
 		proofJKT    = "different-proof-jkt"
 	)
@@ -1697,7 +1697,7 @@ func TestValidateToken_DPoPBoundToken_KeyMismatch(t *testing.T) {
 // presented with a matching proof JKT in context is accepted.
 func TestValidateToken_DPoPBoundToken_ValidProof(t *testing.T) {
 	const (
-		accessToken = "dpop-bound-opaque-token-3"
+		accessToken = "dpop-bound-opaque-token-3" //nolint:gosec // G101 false positive — test fixture label, not a credential
 		boundJKT    = "matching-jkt-value"
 	)
 

--- a/handler/revoke.go
+++ b/handler/revoke.go
@@ -10,8 +10,8 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	"github.com/giantswarm/mcp-oauth/internal/constants"
 	"github.com/giantswarm/mcp-oauth/instrumentation"
+	"github.com/giantswarm/mcp-oauth/internal/constants"
 	"github.com/giantswarm/mcp-oauth/security"
 )
 

--- a/oauthconfig/env_internal_test.go
+++ b/oauthconfig/env_internal_test.go
@@ -31,7 +31,7 @@ func TestOptionalSecret_TightPermissionsNoWarn(t *testing.T) {
 func TestOptionalSecret_WorldReadableWarns(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secret")
-	require.NoError(t, os.WriteFile(path, []byte("leak-risk"), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte("leak-risk"), 0o644)) //nolint:gosec // G306 intentional: world-readable mode exercises the permission-warning path under test
 
 	var buf bytes.Buffer
 	prev := slog.Default()
@@ -50,7 +50,7 @@ func TestOptionalSecret_WorldReadableWarns(t *testing.T) {
 func TestOptionalSecret_HardFailWhenStrictModeOn(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "secret")
-	require.NoError(t, os.WriteFile(path, []byte("leak-risk"), 0o644))
+	require.NoError(t, os.WriteFile(path, []byte("leak-risk"), 0o644)) //nolint:gosec // G306 intentional: world-readable mode exercises the strict-mode hard-fail path under test
 
 	t.Setenv("OAUTH_REQUIRE_TIGHT_SECRET_PERMISSIONS", "true")
 	t.Setenv("OAUTH_TEST_SECRET_FILE", path)

--- a/server/access_token.go
+++ b/server/access_token.go
@@ -241,7 +241,7 @@ func (j *jwtIssuer) Issue(_ context.Context, c AccessTokenClaims) (string, error
 	if len(c.Extra) > 0 {
 		for k := range c.Extra {
 			if _, reserved := jwtReservedClaims[k]; reserved {
-				return "", fmt.Errorf("Extra map contains reserved JWT claim %q", k)
+				return "", fmt.Errorf("extra map contains reserved JWT claim %q", k)
 			}
 		}
 		builder = builder.Claims(c.Extra)

--- a/server/client_test.go
+++ b/server/client_test.go
@@ -8,8 +8,8 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
-	mockstorage "github.com/giantswarm/mcp-oauth/storage/mock"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
+	mockstorage "github.com/giantswarm/mcp-oauth/storage/mock"
 )
 
 func TestServer_RegisterClient(t *testing.T) {

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -210,7 +210,7 @@ func matchClaimPattern(pattern, value string) error {
 
 // Token-type URN constants shared between OIDCValidator and the token-exchange handler.
 const (
-	SubjectTokenTypeIDToken     = "urn:ietf:params:oauth:token-type:id_token"
-	SubjectTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token"
-	SubjectTokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"
+	SubjectTokenTypeIDToken     = "urn:ietf:params:oauth:token-type:id_token"     // #nosec G101 -- RFC 8693 token-type URN identifier, not a credential
+	SubjectTokenTypeAccessToken = "urn:ietf:params:oauth:token-type:access_token" // #nosec G101 -- RFC 8693 token-type URN identifier, not a credential
+	SubjectTokenTypeJWT         = "urn:ietf:params:oauth:token-type:jwt"          // #nosec G101 -- RFC 8693 token-type URN identifier, not a credential
 )

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GrantTypeTokenExchange is the grant_type value for RFC 8693 token exchange.
-const GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange"
+const GrantTypeTokenExchange = "urn:ietf:params:oauth:grant-type:token-exchange" // #nosec G101 -- RFC 8693 grant-type URN identifier, not a credential
 
 // TokenExchangeResult holds the output of a successful token exchange.
 type TokenExchangeResult struct {

--- a/server/validate_trusted_issuer_test.go
+++ b/server/validate_trusted_issuer_test.go
@@ -168,7 +168,7 @@ func TestValidateToken_TrustedIssuer_UnknownIssFallsThroughToOpaque(t *testing.T
 	srv.trustedIssuerValidator = v
 
 	provider.ValidateTokenFunc = func(_ context.Context, accessToken string) (*providers.UserInfo, error) {
-		if accessToken == "opaque-bearer" {
+		if accessToken == "opaque-bearer" { //nolint:gosec // G101 false positive — test fixture label, not a credential
 			return &providers.UserInfo{ID: "opaque-user", Email: "u@example.com"}, nil
 		}
 		return nil, errors.New("not configured")

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -690,7 +690,7 @@ func TestTokenStore_AtomicGetAndDeleteRefreshToken(t *testing.T) {
 				// Exercises the TOKEN_NOT_FOUND branch of the Lua script: the
 				// refresh-token→userID mapping exists but the provider token
 				// has been evicted (TTL mismatch, manual deletion, etc.).
-				const refreshToken = "rt-orphan-mapping"
+				const refreshToken = "rt-orphan-mapping" //nolint:gosec // G101 false positive — test fixture label, not a credential
 				require.NoError(t, s.SaveRefreshToken(t.Context(), refreshToken, testUserID, time.Now().Add(time.Hour)))
 				return refreshToken
 			},
@@ -726,7 +726,7 @@ func TestTokenStore_AtomicGetAndDeleteRefreshToken(t *testing.T) {
 func TestTokenStore_AtomicGetAndDeleteRefreshToken_MalformedTokenJSON(t *testing.T) {
 	s := testStore(t)
 
-	const refreshToken = "rt-malformed-token"
+	const refreshToken = "rt-malformed-token" //nolint:gosec // G101 false positive — test fixture label, not a credential
 	require.NoError(t, s.client.Do(
 		t.Context(),
 		s.client.B().Set().Key(s.refreshTokenKey(refreshToken)).Value(testUserID).Ex(time.Hour).Build(),
@@ -757,7 +757,7 @@ func TestTokenStore_AtomicGetAndDeleteRefreshToken_DecryptError(t *testing.T) {
 
 	s := testStoreWithOpts(t, WithEncryptor(enc))
 
-	const refreshToken = "rt-decrypt-error"
+	const refreshToken = "rt-decrypt-error" //nolint:gosec // G101 false positive — test fixture label, not a credential
 	require.NoError(t, s.client.Do(
 		t.Context(),
 		s.client.B().Set().Key(s.refreshTokenKey(refreshToken)).Value(testUserID).Ex(time.Hour).Build(),
@@ -781,7 +781,7 @@ func TestTokenStore_AtomicGetAndDeleteRefreshToken_ConcurrentN100(t *testing.T) 
 
 	s := testStore(t)
 
-	const refreshToken = "rt-concurrent-100"
+	const refreshToken = "rt-concurrent-100" //nolint:gosec // G101 false positive — test fixture label, not a credential
 	providerToken := &oauth2.Token{
 		AccessToken:  "provider-access",
 		RefreshToken: "provider-refresh",


### PR DESCRIPTION
## Why

The repo's pre-commit hook set (`.pre-commit-config.yaml`) fails against `main`. This debt is invisible today because **no CI workflow runs pre-commit yet** — the pending *Align files* PR (#421) introduces `.github/workflows/pre_commit_go.yaml` and is the first PR to surface it. #421's required `pre-commit` check is red purely because of pre-existing debt on `main`, not because of its own payload.

This PR cleans up that debt on `main` (off a fresh branch, **not** on architectbot's `teams-alignment-branch`) so the workflow passes once #421 regenerates onto a clean `main`.

## What fails on `main` and the fix

Verified locally with the exact hook tooling (golangci-lint **v2.9.0**, same args as CI):

| Hook | Failure | Fix |
|------|---------|-----|
| `go-fmt` | const-block alignment (`handler/handler.go`), import order (`handler/revoke.go`, `server/client_test.go`) | `gofmt -w` (mechanical) |
| `golangci-lint` (`-E=gosec -E=goconst -E=govet`) | 14 gosec (G101/G306) + 1 staticcheck (ST1005) | see below |

golangci-lint findings:
- **G101** on RFC 8693 token-type/grant-type **URN constants** (`server/subject_validator.go`, `server/token_exchange.go`) → `// #nosec G101 --` (URN identifiers, not credentials; matches existing `config.go` style).
- **G101** on **test fixture labels** (`handler/middleware_test.go`, `storage/valkey/store_test.go`, `server/validate_trusted_issuer_test.go`) → `//nolint:gosec // G101 ...` (matches existing test style).
- **G306** on two `oauthconfig` tests that **intentionally** write world-readable files to exercise the permission-warning path → `//nolint:gosec // G306 ...` (tightening to `0o600` would defeat the test).
- **ST1005** capitalized error string → lowercased `"extra map contains reserved JWT claim"` (`server/access_token.go`); no caller/test asserts the old text.

## go.mod / go.sum intentionally untouched

The `pre-commit` `go-mod-tidy` hook runs on GitHub runners honoring the `go 1.25` directive, under which `main` is **already tidy** (`go mod tidy -go=1.25` is a no-op). A direct-require promotion of `prometheus/client_golang` only appears under a 1.26 toolchain and would break the `Verify` `mod-tidy-check` (which also runs go1.26 but honors the directive). So no module changes are needed or wanted here.

## Scope / safety
- Only behavioral change is one error-string's first letter. Everything else is formatting and lint annotations.
- Touches **no** `zz_*` file and nothing in the align payload.
- Reviewed by an automated code-reviewer pass: no blockers; all suppressions confirmed as genuine false positives.

> Note: the `pre-commit` CI check cannot run on this PR because `pre_commit_go.yaml` doesn't exist on `main` yet (it arrives via #421). Verification of the pre-commit hooks is therefore local, with the exact hook versions/args. After this merges, #421 should be regenerated/rebased onto the now-clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)