### PR TITLE
fix(server): default JWT access token audience to the resource identifier

### DIFF
--- a/server/access_token_audience_test.go
+++ b/server/access_token_audience_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// newJWTModeServer builds a server in JWT access token mode with the given
+// resource identifier (empty string leaves it unset so GetResourceIdentifier
+// falls back to the issuer).
+func newJWTModeServer(t *testing.T, resourceIdentifier string) *Server {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	cfg := &Config{
+		Issuer:                      "https://auth.example.com",
+		ResourceIdentifier:          resourceIdentifier,
+		SupportedScopes:             []string{"openid"},
+		AccessTokenTTL:              600,
+		AccessTokenFormat:           AccessTokenFormatJWT,
+		AccessTokenSigningKey:       generateRSAKey(t),
+		AccessTokenSigningKeyID:     "test-kid-1",
+		AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
+		DisableNonceEchoRequirement: true,
+	}
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, nil)
+	require.NoError(t, err)
+	return srv
+}
+
+func parseAudience(t *testing.T, srv *Server, tokenString string) josejwt.Audience {
+	t.Helper()
+
+	parsed, err := josejwt.ParseSigned(tokenString, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var claims josejwt.Claims
+	require.NoError(t, parsed.Claims(srv.Config.AccessTokenSigningKey.Public(), &claims))
+	return claims.Audience
+}
+
+// TestIssueAccessToken_DefaultsAudienceToResourceIdentifier verifies that
+// access tokens issued for grants without an RFC 8707 resource parameter
+// still carry an aud claim (required by RFC 9068 §2.2), defaulting to the
+// server's own resource identifier. Clients using generic OAuth libraries
+// that never send a resource parameter would otherwise receive tokens that
+// downstream JWT validators (e.g. gateways fronting the resource server)
+// reject with an audience mismatch.
+func TestIssueAccessToken_DefaultsAudienceToResourceIdentifier(t *testing.T) {
+	now := time.Now().UTC()
+
+	t.Run("empty audience defaults to ResourceIdentifier", func(t *testing.T) {
+		srv := newJWTModeServer(t, "https://api.example.com/mcp")
+
+		tokenString, err := srv.issueAccessToken(t.Context(), accessTokenIssueParams{
+			UserID:    "user-42",
+			ClientID:  "client-abc",
+			Audience:  "",
+			ExpiresAt: now.Add(10 * time.Minute),
+		})
+		require.NoError(t, err)
+		require.Equal(t, josejwt.Audience{"https://api.example.com/mcp"}, parseAudience(t, srv, tokenString))
+	})
+
+	t.Run("empty audience falls back to issuer without ResourceIdentifier", func(t *testing.T) {
+		srv := newJWTModeServer(t, "")
+
+		tokenString, err := srv.issueAccessToken(t.Context(), accessTokenIssueParams{
+			UserID:    "user-42",
+			ClientID:  "client-abc",
+			Audience:  "",
+			ExpiresAt: now.Add(10 * time.Minute),
+		})
+		require.NoError(t, err)
+		require.Equal(t, josejwt.Audience{"https://auth.example.com"}, parseAudience(t, srv, tokenString))
+	})
+
+	t.Run("explicit audience is preserved", func(t *testing.T) {
+		srv := newJWTModeServer(t, "https://api.example.com/mcp")
+
+		tokenString, err := srv.issueAccessToken(t.Context(), accessTokenIssueParams{
+			UserID:    "user-42",
+			ClientID:  "client-abc",
+			Audience:  "https://other.example.com",
+			ExpiresAt: now.Add(10 * time.Minute),
+		})
+		require.NoError(t, err)
+		require.Equal(t, josejwt.Audience{"https://other.example.com"}, parseAudience(t, srv, tokenString))
+	})
+}

--- a/server/authcode.go
+++ b/server/authcode.go
@@ -964,10 +964,22 @@ type accessTokenIssueParams struct {
 // from the TokenStore in JWT mode only — opaque issuance ignores them so
 // the lookup is skipped to avoid an unnecessary storage round-trip.
 func (s *Server) issueAccessToken(ctx context.Context, p accessTokenIssueParams) (string, error) {
+	// RFC 9068 §2.2 requires the aud claim in JWT access tokens. Clients
+	// that omit the RFC 8707 resource parameter (e.g. generic OAuth
+	// libraries that predate resource indicators) would otherwise receive
+	// a token without audience binding, which downstream JWT validators
+	// (such as gateways in front of the resource server) rightly reject.
+	// Default to this server's own resource identifier — the only audience
+	// such a token could legitimately be used for. This also applies on
+	// refresh grants, so grants created before this default self-heal.
+	audience := p.Audience
+	if audience == "" {
+		audience = s.Config.GetResourceIdentifier()
+	}
 	claims := AccessTokenClaims{
 		Subject:   p.UserID,
 		ClientID:  p.ClientID,
-		Audience:  p.Audience,
+		Audience:  audience,
 		Scopes:    p.Scopes,
 		IssuedAt:  time.Now().UTC(),
 		ExpiresAt: p.ExpiresAt,


### PR DESCRIPTION
## What

When a grant has no RFC 8707 `resource` parameter, JWT-mode access tokens were issued with an empty `aud` claim. This change defaults the audience to the server's own resource identifier (`Config.GetResourceIdentifier()`) at issuance time in `issueAccessToken`, covering both authorization-code and refresh grants.

## Why

RFC 9068 §2.2 requires the `aud` claim in JWT access tokens. Clients using generic OAuth libraries that predate resource indicators (e.g. Backstage auth providers) never send `resource`, so they received tokens without audience binding. Downstream JWT validators reject those tokens — concretely, the agentgateway now fronting muster's `/mcp` endpoint enforces `aud == <resource identifier>` in Strict mode and returns `401 Error(InvalidAudience)`, which broke the AI chat on the Giant Swarm dev portal.

Defaulting to the server's own resource identifier is safe: it is the only audience such a token could legitimately be used for, and explicitly provided resource values are preserved unchanged.

Because the default is applied at issuance (not at grant creation), refresh grants created before this fix also pick up the correct audience on their next refresh — existing sessions self-heal without re-login.

Token exchange (RFC 8693) is unaffected: its handler already rejects requests without `resource`.

## Testing

- New `TestIssueAccessToken_DefaultsAudienceToResourceIdentifier` covers: defaulting to `ResourceIdentifier`, fallback to `Issuer` when `ResourceIdentifier` is unset, and preservation of explicit audiences.
- Full test suite passes.

A complementary client-side fix (sending the RFC 8707 `resource` parameter, as required by the MCP authorization spec) is in giantswarm/backstage#1727.

Made with [Cursor](https://cursor.com)