### PR TITLE
docs: add Unreleased compare link required by devctl release flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1650,6 +1650,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rate limiting to prevent DoS and brute force attacks
 - Token expiration with automatic cleanup
 
+[Unreleased]: https://github.com/giantswarm/mcp-oauth/compare/v0.2.198...HEAD
+
 ## Release History
 
 ### Version Numbering


### PR DESCRIPTION
## What

Adds the keep-a-changelog link reference line for `[Unreleased]` to CHANGELOG.md.

## Why

#421 (align files) removed the per-merge `auto-release.yaml` workflow in favor of the platform-standard devctl release flow (`Create Release PR` on `main#release#*` branches). That flow's changelog tooling requires an `[Unreleased]: https://github.com/.../compare/vX.Y.Z...HEAD` link line and currently fails with `no match for pattern ... found in data`, so no release can be cut since the migration. This unblocks releasing v0.2.199 (which carries the JWT audience-default fix from #440 needed by muster).

Made with [Cursor](https://cursor.com)