### PR TITLE
feat(server,handler): brokered RFC 8693 token exchange via pluggable Exchanger

### DIFF
--- a/docs/token-exchange.md
+++ b/docs/token-exchange.md
@@ -160,6 +160,64 @@ The resulting JWT carries `email`, `email_verified: true`, `groups: ["klaus-sre"
 
 This is library API only: the HTTP `/oauth/token` endpoint does not extract these from the request form. Use it from in-process wrappers that have already resolved the identity out-of-band.
 
+## Brokered exchange (audience parameter)
+
+When the client sends an RFC 8693 `audience` parameter, the server acts as a **token broker** instead of issuing a local JWT: it validates the subject token, enforces policy, and delegates the downstream exchange to a host-provided `Exchanger`. The returned token comes from the downstream issuer verbatim — useful when the target (e.g. a Kubernetes API server behind its own Dex) will not accept tokens minted by this server.
+
+### Host setup
+
+```go
+type myExchanger struct{ /* audience -> downstream Dex issuer + credentials */ }
+
+func (e *myExchanger) Exchange(ctx context.Context, req *server.ExchangerRequest) (*server.ExchangerResult, error) {
+    // req.Subject is the validated identity; req.SubjectToken is the raw token,
+    // typically forwarded as the subject_token of the downstream RFC 8693 request.
+    token, expiry, err := e.exchangeAtRemoteDex(ctx, req.Audience, req.SubjectToken, req.Scope)
+    if err != nil {
+        return nil, err // reported to the client as a generic invalid_grant
+    }
+    return &server.ExchangerResult{AccessToken: token, ExpiresAt: expiry}, nil
+}
+
+srv, _ := server.New(provider, store, store, store,
+    &server.Config{
+        Issuer: "https://broker.example.com",
+        // Per-client audience allowlist: which audiences each broker client
+        // may request. A miss returns invalid_target (RFC 8693 §2.2.2).
+        TokenExchangeClientAudiences: map[string][]string{
+            "backstage-backend-client-id": {"gaggle", "gauss"},
+        },
+    },
+    logger,
+    server.WithTrustedIssuers([]server.TrustedIssuer{ /* subject-token issuers */ }),
+    server.WithExchanger(&myExchanger{}),
+)
+```
+
+Return an error wrapping `server.ErrInvalidTarget` from `Exchange` to signal an audience the host cannot map; the client receives `invalid_target`.
+
+### Policy enforced by the broker path
+
+- **Client authentication is mandatory** and only confidential clients are accepted — the allowlist is keyed by client ID, which is spoofable for public clients (`unauthorized_client` otherwise).
+- **Per-client audience allowlist**: `Config.TokenExchangeClientAudiences`; a client requesting an audience outside its list gets `invalid_target`. Without `WithExchanger`, every audience request gets `invalid_target`.
+- **No refresh tokens** are issued; `expires_in` is bounded by the downstream token's expiry and clients are expected to re-exchange.
+- **DPoP is rejected** on this path (`invalid_request`) — the downstream issuer never saw the proof, so the binding would be a lie.
+- **Audit**: success and failure events carry the client ID, subject, requested audience, granted scope, and the deterministic cross-hop session ID (`ext-<hex>`, same derivation as forwarded-token acceptance, keyed by `Config.SessionIDHMACKey`) so broker audit lines correlate with downstream MCP server audit lines for the same token.
+
+### Client request
+
+```
+POST /oauth/token
+Authorization: Basic <client_id:client_secret>
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=urn:ietf:params:oauth:grant-type:token-exchange
+&subject_token=<id-token>
+&subject_token_type=urn:ietf:params:oauth:token-type:id_token
+&audience=gaggle
+&scope=openid groups
+```
+
 ## Route registration
 
-Token exchange is handled by `ServeToken` — no separate route is required. It activates automatically when the `grant_type` is `urn:ietf:params:oauth:grant-type:token-exchange` and at least one `SubjectTokenValidator` is registered. No `SubjectTokenValidator` = token exchange returns `unsupported_grant_type`.
+Token exchange is handled by `ServeToken` — no separate route is required. It activates automatically when the `grant_type` is `urn:ietf:params:oauth:grant-type:token-exchange` and at least one `SubjectTokenValidator` is registered. No `SubjectTokenValidator` = token exchange returns `unsupported_grant_type`. The brokered flow additionally requires `server.WithExchanger`.

--- a/handler/token_exchange.go
+++ b/handler/token_exchange.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	oauth "github.com/giantswarm/mcp-oauth"
 	"github.com/giantswarm/mcp-oauth/instrumentation"
 	"github.com/giantswarm/mcp-oauth/internal/constants"
 	"github.com/giantswarm/mcp-oauth/security"
@@ -21,6 +23,7 @@ func (h *Handler) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 	subjectToken := r.Form.Get("subject_token")
 	subjectTokenType := r.Form.Get("subject_token_type")
 	resource := r.Form.Get("resource")
+	audience := r.Form.Get("audience")
 	scope := r.Form.Get("scope")
 
 	if subjectToken == "" {
@@ -39,6 +42,14 @@ func (h *Handler) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 		h.writeError(w, constants.ErrorCodeInvalidRequest, "subject_token_type is required", http.StatusBadRequest)
 		return
 	}
+	// An audience parameter selects the brokered flow (RFC 8693 audience →
+	// downstream token via the host Exchanger). Without it, the local flow
+	// issues a JWT bound to the mandatory RFC 8707 resource.
+	if audience != "" {
+		h.handleBrokeredTokenExchange(w, r, clientIP, subjectToken, subjectTokenType, audience, resource, scope, startTime, span)
+		return
+	}
+
 	if resource == "" {
 		h.logAuthFailure(r.Context(), "", clientIP, "token_exchange_resource_missing",
 			"token exchange: resource missing")
@@ -77,6 +88,110 @@ func (h *Handler) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 	h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusOK, startTime)
 	instrumentation.SetSpanSuccess(span)
 	h.writeTokenExchangeResponse(w, result)
+}
+
+// handleBrokeredTokenExchange serves RFC 8693 requests that carry an
+// audience parameter: the authenticated client asks the broker for a
+// downstream token. Client authentication is mandatory (the per-client
+// audience allowlist is meaningless for a spoofable client_id, so public
+// clients are rejected). DPoP binding is not supported on this path — the
+// issued token is minted by a downstream issuer that never saw the proof.
+func (h *Handler) handleBrokeredTokenExchange(
+	w http.ResponseWriter, r *http.Request,
+	clientIP, subjectToken, subjectTokenType, audience, resource, scope string,
+	startTime time.Time, span trace.Span,
+) {
+	client, err := h.authenticateClient(r, r.Form.Get("client_id"), clientIP)
+	if err != nil {
+		instrumentation.RecordError(span, err)
+		instrumentation.SetSpanError(span, "client authentication failed")
+		var oauthErr *oauth.Error
+		if errors.As(err, &oauthErr) {
+			h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, oauthErr.Code)
+			h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, oauthErr.Status, startTime)
+			h.writeError(w, oauthErr.Code, oauthErr.Description, oauthErr.Status)
+		} else {
+			h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeInvalidClient)
+			h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusUnauthorized, startTime)
+			h.writeError(w, constants.ErrorCodeInvalidClient, "Client authentication failed", http.StatusUnauthorized)
+		}
+		return
+	}
+
+	instrumentation.SetSpanAttributes(span,
+		attribute.String(instrumentation.AttrClientID, client.ClientID),
+		attribute.String(instrumentation.AttrGrantType, server.GrantTypeTokenExchange),
+		attribute.String("oauth.token_exchange.audience", audience),
+	)
+
+	if !client.IsConfidential() {
+		h.logAuthFailure(r.Context(), client.ClientID, clientIP, "token_exchange_public_client_audience",
+			"brokered token exchange rejected: public client requested audience")
+		h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeUnauthorizedClient)
+		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "public client not allowed")
+		h.writeError(w, constants.ErrorCodeUnauthorizedClient,
+			"brokered token exchange requires a confidential client", http.StatusBadRequest)
+		return
+	}
+
+	if r.Header.Get("DPoP") != "" {
+		h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeInvalidRequest)
+		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "dpop not supported for brokered exchange")
+		h.writeError(w, constants.ErrorCodeInvalidRequest,
+			"DPoP binding is not supported for brokered token exchange", http.StatusBadRequest)
+		return
+	}
+
+	result, err := h.server.BrokerExchangeSubjectToken(r.Context(),
+		client.ClientID, subjectToken, subjectTokenType, audience, resource, scope)
+	if err != nil {
+		h.handleBrokeredTokenExchangeError(w, r, err, client.ClientID, clientIP, audience, startTime, span)
+		return
+	}
+
+	h.logger.Debug("brokered token exchange successful",
+		"client_id", client.ClientID, "audience", audience, "ip", clientIP, "scope", result.Scope)
+	h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusOK, startTime)
+	instrumentation.SetSpanSuccess(span)
+	h.writeTokenExchangeResponse(w, result)
+}
+
+func (h *Handler) handleBrokeredTokenExchangeError(
+	w http.ResponseWriter, r *http.Request, err error,
+	clientID, clientIP, audience string,
+	startTime time.Time, span trace.Span,
+) {
+	instrumentation.RecordError(span, err)
+
+	var unsupported *server.TokenExchangeUnsupportedTypeError
+	switch {
+	case errors.Is(err, server.ErrInvalidTarget):
+		h.logger.Debug("brokered token exchange: invalid target",
+			"client_id", clientID, "audience", audience, "ip", clientIP)
+		h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeInvalidTarget)
+		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "invalid target")
+		h.writeError(w, constants.ErrorCodeInvalidTarget,
+			"the requested audience cannot be served", http.StatusBadRequest)
+	case errors.As(err, &unsupported):
+		h.logger.Debug("brokered token exchange: unsupported subject_token_type",
+			"type", unsupported.TokenType(), "client_id", clientID, "ip", clientIP)
+		h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeUnsupportedGrantType)
+		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "unsupported subject_token_type")
+		h.writeError(w, constants.ErrorCodeUnsupportedGrantType,
+			"no validator registered for subject_token_type "+unsupported.TokenType(), http.StatusBadRequest)
+	default:
+		h.logger.Debug("brokered token exchange failed",
+			"client_id", clientID, "audience", audience, "ip", clientIP, "error", err)
+		h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeInvalidGrant)
+		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
+		instrumentation.SetSpanError(span, "brokered exchange failed")
+		// SECURITY: don't leak downstream-exchange detail to the client.
+		h.writeError(w, constants.ErrorCodeInvalidGrant, "subject token invalid or rejected", http.StatusBadRequest)
+	}
 }
 
 func (h *Handler) handleTokenExchangeError(

--- a/handler/token_exchange_broker_test.go
+++ b/handler/token_exchange_broker_test.go
@@ -1,0 +1,283 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/internal/constants"
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/server"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+type stubExchanger struct {
+	gotReq *server.ExchangerRequest
+	result *server.ExchangerResult
+	err    error
+}
+
+func (f *stubExchanger) Exchange(_ context.Context, req *server.ExchangerRequest) (*server.ExchangerResult, error) {
+	f.gotReq = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+type brokeredExchangeHarness struct {
+	handler      *Handler
+	srv          *server.Server
+	logs         *bytes.Buffer
+	clientID     string
+	clientSecret string
+}
+
+// setupBrokeredExchangeHandler builds a handler with a registered confidential
+// client, a happy-path subject validator, and (unless exchanger is nil) the
+// given Exchanger. allowedAudiences populates the registered client's
+// audience allowlist.
+func setupBrokeredExchangeHandler(t *testing.T, exchanger server.Exchanger, allowedAudiences []string, clientType string) *brokeredExchangeHarness {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	serverCfg := &server.Config{
+		Issuer:                      "https://broker.example.com",
+		DisableNonceEchoRequirement: true,
+		DisableDNSValidation:        true,
+	}
+
+	validator := &fakeSubjectValidator{identity: server.SubjectIdentity{
+		Subject: "user@example.com",
+		Issuer:  "https://dex.example.com",
+	}}
+
+	srvOpts := []server.Option{
+		server.WithAuditor(security.NewAuditor(logger, true)),
+		server.WithSubjectTokenValidator(server.SubjectTokenTypeIDToken, validator),
+	}
+	if exchanger != nil {
+		srvOpts = append(srvOpts, server.WithExchanger(exchanger))
+	}
+
+	srv, err := server.New(mock.NewProvider(), store, store, store, serverCfg, logger, srvOpts...)
+	require.NoError(t, err)
+
+	client, clientSecret, err := srv.RegisterClient(t.Context(), "broker-client", clientType, "",
+		[]string{"https://broker-client.example.com/callback"}, nil, "127.0.0.1", 10)
+	require.NoError(t, err)
+
+	if len(allowedAudiences) > 0 {
+		srv.Config.TokenExchangeClientAudiences = map[string][]string{
+			client.ClientID: allowedAudiences,
+		}
+	}
+
+	return &brokeredExchangeHarness{
+		handler:      New(srv, logger),
+		srv:          srv,
+		logs:         &buf,
+		clientID:     client.ClientID,
+		clientSecret: clientSecret,
+	}
+}
+
+func brokeredExchangeForm() url.Values {
+	return url.Values{
+		"grant_type":         {server.GrantTypeTokenExchange},
+		"subject_token":      {"subject-id-token"},
+		"subject_token_type": {server.SubjectTokenTypeIDToken},
+		"audience":           {"gaggle"},
+		"scope":              {"openid groups"},
+	}
+}
+
+func happyDownstreamResult() *server.ExchangerResult {
+	return &server.ExchangerResult{
+		AccessToken: "downstream-mc-token",
+		ExpiresAt:   time.Now().Add(15 * time.Minute),
+		Scope:       "openid groups",
+	}
+}
+
+func TestHandleBrokeredTokenExchange_HappyPath(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	req := newTokenExchangeRequest(brokeredExchangeForm())
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, "downstream-mc-token", body["access_token"])
+	require.Equal(t, server.SubjectTokenTypeAccessToken, body["issued_token_type"])
+	require.Equal(t, "Bearer", body["token_type"])
+	require.Equal(t, "openid groups", body["scope"])
+	require.NotContains(t, body, "refresh_token", "brokered exchange must never issue a refresh token")
+
+	expiresIn, ok := body["expires_in"].(float64)
+	require.True(t, ok)
+	require.Positive(t, expiresIn)
+	require.LessOrEqual(t, expiresIn, float64(15*60), "expires_in must be bounded by the downstream token expiry")
+
+	require.NotNil(t, ex.gotReq)
+	require.Equal(t, h.clientID, ex.gotReq.ClientID)
+	require.Equal(t, "gaggle", ex.gotReq.Audience)
+	require.Equal(t, "subject-id-token", ex.gotReq.SubjectToken)
+	require.Equal(t, "user@example.com", ex.gotReq.Subject.Subject)
+
+	require.True(t, auditEventLogged(t, h.logs, security.EventTokenIssued),
+		"missing token_issued audit in: %s", h.logs.String())
+}
+
+func TestHandleBrokeredTokenExchange_FormClientAuth(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	form := brokeredExchangeForm()
+	form.Set("client_id", h.clientID)
+	req := newTokenExchangeRequest(form)
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+}
+
+func requireOAuthError(t *testing.T, w *httptest.ResponseRecorder, wantStatus int, wantCode string) {
+	t.Helper()
+	require.Equal(t, wantStatus, w.Code, "body: %s", w.Body.String())
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	require.Equal(t, wantCode, body["error"])
+}
+
+func TestHandleBrokeredTokenExchange_AudienceNotAllowed(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	form := brokeredExchangeForm()
+	form.Set("audience", "not-allowed")
+	req := newTokenExchangeRequest(form)
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeInvalidTarget)
+	require.Nil(t, ex.gotReq, "exchanger must not run for a disallowed audience")
+	require.True(t, auditAuthFailureWithReason(t, h.logs, "token_exchange_audience_not_allowed"),
+		"missing audit in: %s", h.logs.String())
+}
+
+func TestHandleBrokeredTokenExchange_NoExchangerConfigured(t *testing.T) {
+	h := setupBrokeredExchangeHandler(t, nil, []string{"gaggle"}, "confidential")
+
+	req := newTokenExchangeRequest(brokeredExchangeForm())
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeInvalidTarget)
+}
+
+func TestHandleBrokeredTokenExchange_MissingClientAuth(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	req := newTokenExchangeRequest(brokeredExchangeForm())
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeInvalidRequest)
+	require.Nil(t, ex.gotReq)
+}
+
+func TestHandleBrokeredTokenExchange_WrongClientSecret(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	req := newTokenExchangeRequest(brokeredExchangeForm())
+	req.SetBasicAuth(h.clientID, "wrong-secret")
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusUnauthorized, constants.ErrorCodeInvalidClient)
+	require.Nil(t, ex.gotReq)
+}
+
+func TestHandleBrokeredTokenExchange_PublicClientRejected(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "public")
+
+	form := brokeredExchangeForm()
+	form.Set("client_id", h.clientID)
+	req := newTokenExchangeRequest(form)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeUnauthorizedClient)
+	require.Nil(t, ex.gotReq)
+}
+
+func TestHandleBrokeredTokenExchange_DPoPRejected(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	req := newTokenExchangeRequest(brokeredExchangeForm())
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	req.Header.Set("DPoP", "some-proof")
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeInvalidRequest)
+	require.Nil(t, ex.gotReq)
+}
+
+func TestHandleBrokeredTokenExchange_DownstreamFailure(t *testing.T) {
+	ex := &stubExchanger{err: context.DeadlineExceeded}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	req := newTokenExchangeRequest(brokeredExchangeForm())
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeInvalidGrant)
+}
+
+// The local-issuance path (no audience parameter) must be unaffected by the
+// presence of an Exchanger: resource stays mandatory and the local JWT flow
+// handles the request.
+func TestHandleBrokeredTokenExchange_NoAudienceFallsBackToLocalPath(t *testing.T) {
+	ex := &stubExchanger{result: happyDownstreamResult()}
+	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
+
+	form := brokeredExchangeForm()
+	form.Del("audience")
+	req := newTokenExchangeRequest(form)
+	req.SetBasicAuth(h.clientID, h.clientSecret)
+	w := httptest.NewRecorder()
+	h.handler.ServeToken(w, req)
+
+	// Local path requires resource; this proves the broker path was not taken.
+	requireOAuthError(t, w, http.StatusBadRequest, constants.ErrorCodeInvalidRequest)
+	require.Nil(t, ex.gotReq)
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -21,6 +21,11 @@ const (
 	OAuthSpecVersion                 = "OAuth 2.1"
 )
 
+// Token-exchange error codes (RFC 8693 §2.2.2).
+const (
+	ErrorCodeInvalidTarget = "invalid_target"
+)
+
 // DPoP error codes (RFC 9449).
 const (
 	ErrorCodeInvalidDPoPProof = "invalid_dpop_proof"

--- a/server/config.go
+++ b/server/config.go
@@ -733,6 +733,20 @@ type Config struct {
 	// Default: nil (only tokens for this server's ResourceIdentifier are accepted)
 	TrustedAudiences []string
 
+	// TokenExchangeClientAudiences is the per-client allowlist for the
+	// brokered RFC 8693 token-exchange flow. Keys are client IDs; values are
+	// the audiences each client may request via the `audience` parameter.
+	// A client requesting an audience not in its list receives invalid_target
+	// (RFC 8693 §2.2.2).
+	//
+	// Only consulted when an Exchanger is configured (server.WithExchanger).
+	// Entries should reference confidential clients only — the broker path
+	// rejects public clients because an unauthenticated client_id would make
+	// the allowlist spoofable.
+	//
+	// Default: nil (no client may request any audience).
+	TokenExchangeClientAudiences map[string][]string
+
 	// SessionIDHMACKey optionally replaces the default SHA-256 session-ID derivation
 	// in Server.AcceptForwardedIDToken with HMAC-SHA-256 keyed by this value.
 	//

--- a/server/options.go
+++ b/server/options.go
@@ -126,6 +126,19 @@ func WithTrustedIssuers(issuers []TrustedIssuer) Option {
 	}
 }
 
+// WithExchanger enables the brokered RFC 8693 token-exchange flow. When a
+// client sends an `audience` parameter with the token-exchange grant, the
+// server validates the subject token, enforces the per-client audience
+// allowlist (Config.TokenExchangeClientAudiences), and delegates the
+// downstream exchange to e. The host owns the audience→downstream-issuer
+// mapping; mcp-oauth owns validation, policy, and audit.
+//
+// Without this option, requests carrying an audience parameter are rejected
+// with invalid_target.
+func WithExchanger(e Exchanger) Option {
+	return func(s *Server) { s.exchanger = e }
+}
+
 // WithSubjectTokenValidator registers a custom SubjectTokenValidator for the
 // given subject_token_type URN. Use this to register a custom validator
 // alongside or instead of OIDCValidator.

--- a/server/server.go
+++ b/server/server.go
@@ -98,6 +98,10 @@ type Server struct {
 	// subjectValidators is the registry for RFC 8693 token-exchange validators,
 	// keyed by subject_token_type URN.
 	subjectValidators map[string]SubjectTokenValidator
+	// exchanger maps requested audiences to downstream tokens for the
+	// brokered RFC 8693 flow. Nil disables brokered exchange (audience
+	// requests are rejected with invalid_target).
+	exchanger Exchanger
 	// trustedIssuerValidator is the OIDCValidator built from WithTrustedIssuers.
 	// Non-nil enables the trusted-issuer Bearer branch in ValidateToken;
 	// token-exchange uses the same instance via subjectValidators.

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -68,47 +68,9 @@ func (s *Server) ExchangeSubjectToken(
 		return nil, fmt.Errorf("token exchange requires JWT access token mode (set AccessTokenFormat=jwt)")
 	}
 
-	switch subjectTokenType {
-	case SubjectTokenTypeIDToken, SubjectTokenTypeAccessToken, SubjectTokenTypeJWT:
-	default:
-		s.Auditor.LogEvent(ctx, security.Event{
-			Type: security.EventAuthFailure,
-			Details: map[string]any{
-				"reason":             "unsupported_subject_token_type",
-				"grant_type":         GrantTypeTokenExchange,
-				"subject_token_type": subjectTokenType,
-			},
-		})
-		return nil, &TokenExchangeUnsupportedTypeError{tokenType: subjectTokenType}
-	}
-
-	v := s.SubjectValidatorFor(subjectTokenType)
-	if v == nil {
-		s.Auditor.LogEvent(ctx, security.Event{
-			Type: security.EventAuthFailure,
-			Details: map[string]any{
-				"reason":             "unsupported_subject_token_type",
-				"grant_type":         GrantTypeTokenExchange,
-				"subject_token_type": subjectTokenType,
-			},
-		})
-		return nil, &TokenExchangeUnsupportedTypeError{tokenType: subjectTokenType}
-	}
-
-	identity, err := v.Validate(ctx, subjectToken, nil)
+	identity, err := s.validateExchangeSubjectToken(ctx, subjectToken, subjectTokenType)
 	if err != nil {
-		s.Logger.Debug("token exchange: subject token validation failed",
-			"subject_token_type", subjectTokenType, "error", err)
-		s.Auditor.LogEvent(ctx, security.Event{
-			Type: security.EventAuthFailure,
-			Details: map[string]any{
-				"reason":             "subject_token_validation_failed",
-				"grant_type":         GrantTypeTokenExchange,
-				"subject_token_type": subjectTokenType,
-				"error":              err.Error(),
-			},
-		})
-		return nil, fmt.Errorf("subject token validation: %w", err)
+		return nil, err
 	}
 
 	grantedScope := grantedExchangeScope(scope, identity.AllowedScopes)
@@ -178,6 +140,58 @@ func (s *Server) ExchangeSubjectToken(
 		Scope:           grantedScope,
 		IssuedTokenType: SubjectTokenTypeAccessToken,
 	}, nil
+}
+
+// validateExchangeSubjectToken routes subjectToken to the SubjectTokenValidator
+// registered for subjectTokenType and returns the verified identity. Audit
+// events for the failure paths are emitted here so the local-issuance flow
+// (ExchangeSubjectToken) and the brokered flow (BrokerExchangeSubjectToken)
+// share identical validation semantics.
+func (s *Server) validateExchangeSubjectToken(ctx context.Context, subjectToken, subjectTokenType string) (*SubjectIdentity, error) {
+	switch subjectTokenType {
+	case SubjectTokenTypeIDToken, SubjectTokenTypeAccessToken, SubjectTokenTypeJWT:
+	default:
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type: security.EventAuthFailure,
+			Details: map[string]any{
+				"reason":             "unsupported_subject_token_type",
+				"grant_type":         GrantTypeTokenExchange,
+				"subject_token_type": subjectTokenType,
+			},
+		})
+		return nil, &TokenExchangeUnsupportedTypeError{tokenType: subjectTokenType}
+	}
+
+	v := s.SubjectValidatorFor(subjectTokenType)
+	if v == nil {
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type: security.EventAuthFailure,
+			Details: map[string]any{
+				"reason":             "unsupported_subject_token_type",
+				"grant_type":         GrantTypeTokenExchange,
+				"subject_token_type": subjectTokenType,
+			},
+		})
+		return nil, &TokenExchangeUnsupportedTypeError{tokenType: subjectTokenType}
+	}
+
+	identity, err := v.Validate(ctx, subjectToken, nil)
+	if err != nil {
+		s.Logger.Debug("token exchange: subject token validation failed",
+			"subject_token_type", subjectTokenType, "error", err)
+		s.Auditor.LogEvent(ctx, security.Event{
+			Type: security.EventAuthFailure,
+			Details: map[string]any{
+				"reason":             "subject_token_validation_failed",
+				"grant_type":         GrantTypeTokenExchange,
+				"subject_token_type": subjectTokenType,
+				"error":              err.Error(),
+			},
+		})
+		return nil, fmt.Errorf("subject token validation: %w", err)
+	}
+
+	return identity, nil
 }
 
 // TokenExchangeUnsupportedTypeError is returned when no validator is registered

--- a/server/token_exchange_broker.go
+++ b/server/token_exchange_broker.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"github.com/giantswarm/mcp-oauth/security"
+)
+
+// ErrInvalidTarget is returned by BrokerExchangeSubjectToken when the
+// requested audience cannot be served: no Exchanger is configured, the
+// client's allowlist does not contain the audience, or the Exchanger
+// itself reports the audience as unknown. Handlers map it to the RFC 8693
+// §2.2.2 invalid_target error response.
+var ErrInvalidTarget = errors.New("requested audience is not allowed for this client")
+
+// ExchangerRequest carries the validated inputs of a brokered RFC 8693
+// token exchange to the host's Exchanger implementation. The subject token
+// has already been validated (signature, issuer, audience, expiry) and the
+// requesting client has been authenticated and allowlist-checked before the
+// Exchanger is invoked.
+type ExchangerRequest struct {
+	// Audience is the RFC 8693 audience parameter: the logical name of the
+	// downstream target the client wants a token for. The host maps it to a
+	// downstream issuer and credentials.
+	Audience string
+	// Resource is the RFC 8707 resource parameter, when the client supplied
+	// one alongside audience. May be empty.
+	Resource string
+	// Scope is the raw requested scope string. May be empty.
+	Scope string
+	// ClientID is the authenticated broker client that issued the request.
+	ClientID string
+	// Subject is the verified identity extracted from the subject token.
+	Subject *SubjectIdentity
+	// SubjectToken is the raw subject token. Hosts typically forward it
+	// verbatim as the subject_token of their own downstream exchange.
+	SubjectToken string
+	// SubjectTokenType is the RFC 8693 token-type URN of SubjectToken.
+	SubjectTokenType string
+}
+
+// ExchangerResult is the downstream token returned by an Exchanger.
+type ExchangerResult struct {
+	// AccessToken is the downstream token returned to the client verbatim.
+	AccessToken string
+	// IssuedTokenType is the RFC 8693 issued_token_type URN. Empty defaults
+	// to urn:ietf:params:oauth:token-type:access_token.
+	IssuedTokenType string
+	// ExpiresAt is the downstream token's expiry. It bounds the expires_in
+	// reported to the client — brokered tokens never outlive the downstream
+	// token, and no refresh token is issued; clients re-exchange instead.
+	ExpiresAt time.Time
+	// Scope is the scope granted by the downstream issuer. May be empty.
+	Scope string
+}
+
+// Exchanger maps a requested audience to a downstream token. Hosts (e.g. an
+// MCP aggregator acting as a token broker) implement it to perform the
+// downstream exchange — typically an RFC 8693 request against a remote
+// issuer using host-held credentials. mcp-oauth stays generic: it owns
+// subject-token validation, client authentication, allowlist policy, and
+// audit; the host owns the audience→issuer mapping.
+//
+// Returning an error wrapping ErrInvalidTarget signals that the audience is
+// unknown to the host; any other error is reported to the client as a
+// generic invalid_grant without leaking detail.
+type Exchanger interface {
+	Exchange(ctx context.Context, req *ExchangerRequest) (*ExchangerResult, error)
+}
+
+// Exchanger returns the configured Exchanger, or nil when brokered token
+// exchange is disabled.
+func (s *Server) Exchanger() Exchanger {
+	return s.exchanger
+}
+
+// BrokerExchangeSubjectToken implements the brokered RFC 8693 flow: a
+// confidential client presents a subject token and an audience, and receives
+// a downstream token minted by the configured Exchanger.
+//
+// Policy enforced here:
+//   - an Exchanger must be configured and the audience must be in the
+//     client's Config.TokenExchangeClientAudiences allowlist, otherwise
+//     ErrInvalidTarget is returned
+//   - the subject token is validated like any other token-exchange subject
+//     token (registered SubjectTokenValidator: signature, issuer, audience,
+//     expiry)
+//   - no refresh token is ever issued; the result's expiry is the downstream
+//     token's expiry and clients are expected to re-exchange
+//
+// Every outcome is audited. Success events carry the client ID, subject,
+// requested audience, granted scope, and the deterministic cross-hop session
+// ID derived from the subject token (same derivation as forwarded-token
+// acceptance, so broker audit lines correlate with downstream MCP audit
+// lines for the same token).
+func (s *Server) BrokerExchangeSubjectToken(
+	ctx context.Context,
+	clientID, subjectToken, subjectTokenType, audience, resource, scope string,
+) (*TokenExchangeResult, error) {
+	sessionID := s.deriveForwardedSessionID(subjectToken)
+
+	if s.exchanger == nil {
+		s.auditBrokerExchangeFailure(ctx, clientID, audience, sessionID, "token_exchange_no_exchanger", nil)
+		return nil, fmt.Errorf("%w: no exchanger configured", ErrInvalidTarget)
+	}
+
+	if !slices.Contains(s.Config.TokenExchangeClientAudiences[clientID], audience) {
+		s.auditBrokerExchangeFailure(ctx, clientID, audience, sessionID, "token_exchange_audience_not_allowed", nil)
+		return nil, fmt.Errorf("%w: audience %q", ErrInvalidTarget, audience)
+	}
+
+	identity, err := s.validateExchangeSubjectToken(ctx, subjectToken, subjectTokenType)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := s.exchanger.Exchange(ctx, &ExchangerRequest{
+		Audience:         audience,
+		Resource:         resource,
+		Scope:            scope,
+		ClientID:         clientID,
+		Subject:          identity,
+		SubjectToken:     subjectToken,
+		SubjectTokenType: subjectTokenType,
+	})
+	if err != nil {
+		s.Logger.Debug("brokered token exchange: downstream exchange failed",
+			"client_id", clientID, "audience", audience, "error", err)
+		s.auditBrokerExchangeFailure(ctx, clientID, audience, sessionID, "token_exchange_downstream_failed", map[string]any{
+			"sub":   identity.Subject,
+			"error": err.Error(),
+		})
+		if errors.Is(err, ErrInvalidTarget) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("downstream exchange: %w", err)
+	}
+	if result == nil || result.AccessToken == "" {
+		s.auditBrokerExchangeFailure(ctx, clientID, audience, sessionID, "token_exchange_downstream_empty_token", map[string]any{
+			"sub": identity.Subject,
+		})
+		return nil, fmt.Errorf("downstream exchange returned no token")
+	}
+
+	issuedTokenType := result.IssuedTokenType
+	if issuedTokenType == "" {
+		issuedTokenType = SubjectTokenTypeAccessToken
+	}
+
+	s.Logger.Debug("brokered token exchange: issued downstream token",
+		"client_id", clientID, "sub", identity.Subject, "iss_act", identity.Issuer,
+		"audience", audience, "scope", result.Scope, "exp", result.ExpiresAt,
+		"session_id", sessionID)
+
+	s.Auditor.LogEvent(ctx, security.Event{
+		Type:     security.EventTokenIssued,
+		UserID:   identity.Subject,
+		ClientID: clientID,
+		Details: map[string]any{
+			"grant_type":         GrantTypeTokenExchange,
+			"exchange":           "brokered",
+			"subject_token_type": subjectTokenType,
+			"audience":           audience,
+			"scope":              result.Scope,
+			"act_iss":            identity.Issuer,
+			"session_id":         sessionID,
+		},
+	})
+
+	return &TokenExchangeResult{
+		AccessToken:     result.AccessToken,
+		ExpiresAt:       result.ExpiresAt,
+		Scope:           result.Scope,
+		IssuedTokenType: issuedTokenType,
+	}, nil
+}
+
+// auditBrokerExchangeFailure emits the auth-failure audit event shared by all
+// brokered-exchange rejection paths. extra is merged over the base details.
+func (s *Server) auditBrokerExchangeFailure(ctx context.Context, clientID, audience, sessionID, reason string, extra map[string]any) {
+	details := map[string]any{
+		"reason":     reason,
+		"grant_type": GrantTypeTokenExchange,
+		"exchange":   "brokered",
+		"audience":   audience,
+		"session_id": sessionID,
+	}
+	for k, v := range extra {
+		details[k] = v
+	}
+	s.Auditor.LogEvent(ctx, security.Event{
+		Type:     security.EventAuthFailure,
+		ClientID: clientID,
+		Details:  details,
+	})
+}

--- a/server/token_exchange_broker_test.go
+++ b/server/token_exchange_broker_test.go
@@ -1,0 +1,257 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/security"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+type stubSubjectValidator struct {
+	identity SubjectIdentity
+	err      error
+}
+
+func (f *stubSubjectValidator) Validate(_ context.Context, _ string, _ []string) (*SubjectIdentity, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &f.identity, nil
+}
+
+type stubExchanger struct {
+	gotReq *ExchangerRequest
+	result *ExchangerResult
+	err    error
+}
+
+func (f *stubExchanger) Exchange(_ context.Context, req *ExchangerRequest) (*ExchangerResult, error) {
+	f.gotReq = req
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.result, nil
+}
+
+func newBrokerTestServer(t *testing.T, exchanger Exchanger, allowlist map[string][]string, validator SubjectTokenValidator) (*Server, *bytes.Buffer) {
+	t.Helper()
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	cfg := &Config{
+		Issuer:                       "https://broker.example.com",
+		DisableNonceEchoRequirement:  true,
+		TokenExchangeClientAudiences: allowlist,
+	}
+
+	opts := []Option{WithAuditor(security.NewAuditor(logger, true))}
+	if exchanger != nil {
+		opts = append(opts, WithExchanger(exchanger))
+	}
+	if validator != nil {
+		opts = append(opts, WithSubjectTokenValidator(SubjectTokenTypeIDToken, validator))
+	}
+
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, logger, opts...)
+	require.NoError(t, err)
+	return srv, &buf
+}
+
+func happyBrokerValidator() SubjectTokenValidator {
+	return &stubSubjectValidator{identity: SubjectIdentity{
+		Subject: "user@example.com",
+		Issuer:  "https://dex.example.com",
+	}}
+}
+
+func auditDetails(t *testing.T, buf *bytes.Buffer, eventType string) map[string]any {
+	t.Helper()
+	for _, line := range bytes.Split(buf.Bytes(), []byte("\n")) {
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Audit struct {
+				EventType string         `json:"event_type"`
+				ClientID  string         `json:"client_id"`
+				Details   map[string]any `json:"details"`
+			} `json:"audit"`
+		}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry.Audit.EventType == eventType {
+			entry.Audit.Details["__client_id"] = entry.Audit.ClientID
+			return entry.Audit.Details
+		}
+	}
+	t.Fatalf("no audit event of type %q in: %s", eventType, buf.String())
+	return nil
+}
+
+func TestBrokerExchangeSubjectToken_HappyPath(t *testing.T) {
+	expiry := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
+	ex := &stubExchanger{result: &ExchangerResult{
+		AccessToken: "downstream-token",
+		ExpiresAt:   expiry,
+		Scope:       "openid groups",
+	}}
+	srv, buf := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle", "gauss"}}, happyBrokerValidator())
+
+	result, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "openid groups")
+	require.NoError(t, err)
+
+	// Pass-through of the downstream token, expiry bounded by it, no refresh token by construction.
+	require.Equal(t, "downstream-token", result.AccessToken)
+	require.Equal(t, expiry, result.ExpiresAt)
+	require.Equal(t, "openid groups", result.Scope)
+	require.Equal(t, SubjectTokenTypeAccessToken, result.IssuedTokenType)
+
+	// Exchanger received the validated identity and raw subject token.
+	require.NotNil(t, ex.gotReq)
+	require.Equal(t, "gaggle", ex.gotReq.Audience)
+	require.Equal(t, "backstage", ex.gotReq.ClientID)
+	require.Equal(t, "subject-jwt", ex.gotReq.SubjectToken)
+	require.Equal(t, SubjectTokenTypeIDToken, ex.gotReq.SubjectTokenType)
+	require.Equal(t, "user@example.com", ex.gotReq.Subject.Subject)
+	require.Equal(t, "https://dex.example.com", ex.gotReq.Subject.Issuer)
+
+	// Audit carries client ID, audience, scope, and the deterministic session ID.
+	details := auditDetails(t, buf, security.EventTokenIssued)
+	require.Equal(t, "backstage", details["__client_id"])
+	require.Equal(t, "brokered", details["exchange"])
+	require.Equal(t, "gaggle", details["audience"])
+	require.Equal(t, "openid groups", details["scope"])
+	require.Equal(t, srv.deriveForwardedSessionID("subject-jwt"), details["session_id"])
+}
+
+func TestBrokerExchangeSubjectToken_DefaultIssuedTokenType(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{
+		AccessToken:     "downstream-token",
+		IssuedTokenType: SubjectTokenTypeIDToken,
+		ExpiresAt:       time.Now().Add(time.Minute),
+	}}
+	srv, _ := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	result, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.NoError(t, err)
+	require.Equal(t, SubjectTokenTypeIDToken, result.IssuedTokenType)
+}
+
+func TestBrokerExchangeSubjectToken_AudienceNotAllowed(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{AccessToken: "x"}}
+	srv, buf := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "other-mc", "", "")
+	require.ErrorIs(t, err, ErrInvalidTarget)
+	require.Nil(t, ex.gotReq, "exchanger must not be invoked on allowlist miss")
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "token_exchange_audience_not_allowed", details["reason"])
+	require.Equal(t, "other-mc", details["audience"])
+}
+
+func TestBrokerExchangeSubjectToken_UnknownClient(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{AccessToken: "x"}}
+	srv, _ := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"unknown-client", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.ErrorIs(t, err, ErrInvalidTarget)
+}
+
+func TestBrokerExchangeSubjectToken_NoExchanger(t *testing.T) {
+	srv, buf := newBrokerTestServer(t, nil,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.ErrorIs(t, err, ErrInvalidTarget)
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "token_exchange_no_exchanger", details["reason"])
+}
+
+func TestBrokerExchangeSubjectToken_SubjectValidationFailure(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{AccessToken: "x"}}
+	srv, buf := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}},
+		&stubSubjectValidator{err: fmt.Errorf("token expired")})
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "bad-token", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInvalidTarget)
+	require.Nil(t, ex.gotReq, "exchanger must not be invoked on subject validation failure")
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "subject_token_validation_failed", details["reason"])
+}
+
+func TestBrokerExchangeSubjectToken_UnsupportedSubjectTokenType(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{AccessToken: "x"}}
+	srv, _ := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject", "urn:ietf:params:oauth:token-type:saml2", "gaggle", "", "")
+	var unsupported *TokenExchangeUnsupportedTypeError
+	require.ErrorAs(t, err, &unsupported)
+}
+
+func TestBrokerExchangeSubjectToken_DownstreamFailure(t *testing.T) {
+	ex := &stubExchanger{err: fmt.Errorf("dex unreachable")}
+	srv, buf := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrInvalidTarget)
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "token_exchange_downstream_failed", details["reason"])
+}
+
+func TestBrokerExchangeSubjectToken_DownstreamInvalidTarget(t *testing.T) {
+	ex := &stubExchanger{err: fmt.Errorf("%w: unmapped audience", ErrInvalidTarget)}
+	srv, _ := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.ErrorIs(t, err, ErrInvalidTarget)
+}
+
+func TestBrokerExchangeSubjectToken_DownstreamEmptyToken(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{}}
+	srv, buf := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, happyBrokerValidator())
+
+	_, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.Error(t, err)
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "token_exchange_downstream_empty_token", details["reason"])
+}


### PR DESCRIPTION
## Summary

Closes #446.

The base RFC 8693 token-exchange grant (subject-token validation via `TrustedIssuer`/JWKS, local JWT issuance, audit, metadata advertising) already shipped in #349 and follow-ups. This PR adds the remaining broker path so a host (e.g. muster, giantswarm/muster#831) can act as an RFC 8693 token broker for external clients such as a Backstage backend (giantswarm/backstage#1737, epic giantswarm/giantswarm#36840):

- **`Exchanger` interface + `server.WithExchanger(...)`** — when a request carries the RFC 8693 `audience` parameter, the server validates the subject token and delegates the downstream exchange to the host, which owns the audience → downstream issuer/credentials mapping. mcp-oauth stays generic.
- **Per-client audience allowlist** — `Config.TokenExchangeClientAudiences` maps client IDs to requestable audiences; a miss returns `invalid_target` (RFC 8693 §2.2.2). Without an `Exchanger`, every audience request is `invalid_target`.
- **Client authentication on the broker path** — mandatory, confidential clients only (`unauthorized_client` otherwise); the allowlist would be spoofable for public clients.
- **No refresh tokens** for brokered tokens; `expires_in` is bounded by the downstream token expiry — clients re-exchange.
- **DPoP rejected on the broker path** — the downstream issuer never saw the proof, so the binding would be a lie.
- **Audit** — success/failure events carry client ID, subject, requested audience, granted scope, and the deterministic cross-hop SSO session ID (`deriveForwardedSessionID`, same derivation as forwarded-token acceptance).

The local-issuance flow (no `audience` parameter) is unchanged; its subject-token validation is factored into a shared helper.

## Test plan

- [x] `go test ./...` green
- [x] New unit tests: allowlist enforcement (`invalid_target`), unknown client, no exchanger, downstream failure/empty-token/`ErrInvalidTarget` passthrough, audit content incl. session ID, expiry bounding, no `refresh_token` in response, client-auth failure modes, public-client rejection, DPoP rejection, audience-less fallback to the local path
- [x] golangci-lint (CI-pinned v2.9.0) clean

Made with [Cursor](https://cursor.com)