### PR TITLE
feat(server): per-issuer AcceptedTypHeaders for trusted-issuer Bearer validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `server.TrustedIssuer.AcceptedTypHeaders`: per-issuer list of accepted JWT `typ` header values for Bearer validation. Empty keeps the RFC 9068 §4 default (`at+jwt`). Kubernetes ServiceAccount tokens carry no `typ` header, so the previously unconditional `at+jwt` requirement made the documented K8s SA trust use case impossible; configure `[""]` (optionally with `"JWT"`) on the cluster issuer entry to accept them. Signature, issuer, audience, and claim checks are unchanged.
+
 ## [0.2.199] - 2026-06-10
 
 ### Added

--- a/server/options.go
+++ b/server/options.go
@@ -102,7 +102,8 @@ func WithTokenRefreshHandler(handler TokenRefreshHandler) Option {
 //   - ValidateToken: a Bearer JWT at /mcp is accepted when its iss matches
 //     a configured entry. Signature is verified via the entry's JWKS; aud
 //     is checked against AllowedAudiences (defaulting to the server's
-//     ResourceIdentifier when empty); RFC 9068 typ=at+jwt is enforced.
+//     ResourceIdentifier when empty); the typ header is checked against
+//     AcceptedTypHeaders (default RFC 9068 typ=at+jwt).
 //
 // Use TrustedIssuer.AllowedClaims to constrain accepted subjects per issuer.
 // Empty list is a no-op.

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -66,6 +66,13 @@ type TrustedIssuer struct {
 	// WARNING: Disables SSRF protection for this issuer's JWKS fetch. Only set
 	// when JwksURL is a known, controlled in-cluster endpoint.
 	AllowPrivateIPJWKS bool
+	// AcceptedTypHeaders lists the JWT typ header values accepted when a
+	// Bearer token from this issuer is presented to the resource server.
+	// Empty defaults to ["at+jwt"] (RFC 9068 §4). Issuers that mint plain
+	// JWTs need an explicit list: Kubernetes ServiceAccount tokens carry no
+	// typ header at all, so use [""] to accept them. Signature, audience,
+	// and claim checks still apply unchanged.
+	AcceptedTypHeaders []string
 }
 
 // OIDCValidator validates JWTs from statically configured trusted issuers.
@@ -114,6 +121,16 @@ func newOIDCValidatorWithClients(issuers []TrustedIssuer, safeClient, permissive
 		m[ti.Issuer] = ti
 	}
 	return &OIDCValidator{issuers: m, safeClient: safeClient, permissiveClient: permissiveClient}, nil
+}
+
+// BearerTypHeaders returns the JWT typ header values accepted for Bearer
+// tokens from the given issuer, defaulting to ["at+jwt"] (RFC 9068 §4) when
+// the issuer is unknown or has no AcceptedTypHeaders configured.
+func (v *OIDCValidator) BearerTypHeaders(issuer string) []string {
+	if ti, ok := v.issuers[issuer]; ok && len(ti.AcceptedTypHeaders) > 0 {
+		return ti.AcceptedTypHeaders
+	}
+	return []string{rfc9068TokenType}
 }
 
 // Validate verifies a JWT against the configured trusted issuers. The

--- a/server/validate.go
+++ b/server/validate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -18,11 +19,12 @@ import (
 	"github.com/giantswarm/mcp-oauth/storage"
 )
 
-// checkRFC9068TypeHeader enforces RFC 9068 §4: a JWT access token presented
-// to a resource server MUST carry the typ header value "at+jwt". The check
-// runs on the verified token; reading the header from a re-parse is safe
-// because the JWS signature covers the header bytes.
-func checkRFC9068TypeHeader(tokenString string) error {
+// checkTypeHeader verifies the JWT typ header against an accepted set. An
+// empty string in accepted matches a token with no typ header (Kubernetes
+// ServiceAccount tokens omit it). The check runs on the verified token;
+// reading the header from a re-parse is safe because the JWS signature
+// covers the header bytes.
+func checkTypeHeader(tokenString string, accepted []string) error {
 	parsed, err := josejwt.ParseSigned(tokenString, supportedAccessTokenAlgs)
 	if err != nil {
 		return fmt.Errorf("parse JWT header: %w", err)
@@ -31,10 +33,10 @@ func checkRFC9068TypeHeader(tokenString string) error {
 		return errors.New("JWT has no header")
 	}
 	typ, _ := parsed.Headers[0].ExtraHeaders[jose.HeaderType].(string)
-	if typ != rfc9068TokenType {
-		return fmt.Errorf("typ header is %q, expected %q (RFC 9068 §4)", typ, rfc9068TokenType)
+	if slices.Contains(accepted, typ) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("typ header is %q, accepted %q (RFC 9068 §4 unless overridden per issuer)", typ, accepted)
 }
 
 // supportedAccessTokenAlgs lists the asymmetric signing algorithms accepted
@@ -186,8 +188,9 @@ func (s *Server) attemptProactiveRefresh(ctx context.Context, accessToken string
 //  2. Trusted-issuer JWT (when WithTrustedIssuers is configured AND the
 //     bearer's iss matches a configured entry). Signature verified via the
 //     entry's JWKS; aud checked against the entry's AllowedAudiences
-//     (defaulting to Config.GetResourceIdentifier when empty); RFC 9068 §4
-//     typ=at+jwt enforced. A non-matching iss returns ErrIssuerNotTrusted
+//     (defaulting to Config.GetResourceIdentifier when empty); typ header
+//     checked against the entry's AcceptedTypHeaders (default RFC 9068 §4
+//     at+jwt). A non-matching iss returns ErrIssuerNotTrusted
 //     and falls through to subsequent branches; a typ failure on a token
 //     whose aud is in Config.TrustedAudiences falls through to the
 //     forwarded-ID-token branch (it is an ID token, not an access token);
@@ -409,8 +412,9 @@ func (s *Server) hasTrustedAudience(audiences []string) bool {
 // ValidateToken. Returns (nil, nil) when no validator is configured or the
 // token's iss is not a configured peer (caller falls through); (userInfo,
 // nil) on success; (nil, err) on any other validation failure (caller
-// returns the error). The RFC 9068 typ enforcement runs only after the
-// JWS signature has been verified by Validate.
+// returns the error). The typ header enforcement (per-issuer
+// AcceptedTypHeaders, default RFC 9068 at+jwt) runs only after the JWS
+// signature has been verified by Validate.
 //
 // A token that fails only the typ check but carries an audience listed in
 // Config.TrustedAudiences is not an access token at all — it is an ID
@@ -432,9 +436,9 @@ func (s *Server) validateTrustedIssuerJWT(ctx context.Context, accessToken strin
 		s.Auditor.LogAuthFailure(ctx, "", "", "", "trusted_issuer_jwt_invalid")
 		return nil, fmt.Errorf("trusted issuer JWT validation failed: %w", err)
 	}
-	if err := checkRFC9068TypeHeader(accessToken); err != nil {
+	if err := checkTypeHeader(accessToken, s.trustedIssuerValidator.BearerTypHeaders(identity.Issuer)); err != nil {
 		if identity.Claims != nil && s.hasTrustedAudience(identity.Claims.Audience) {
-			s.Logger.Debug("Trusted-issuer JWT without at+jwt typ carries a trusted audience, deferring to forwarded ID token validation",
+			s.Logger.Debug("Trusted-issuer JWT failed typ check but carries a trusted audience, deferring to forwarded ID token validation",
 				"issuer", identity.Issuer,
 				"token_suffix", helpers.TokenSuffix(accessToken, 8))
 			return nil, nil

--- a/server/validate_trusted_issuer_test.go
+++ b/server/validate_trusted_issuer_test.go
@@ -229,3 +229,71 @@ func TestValidateToken_TrustedIssuer_UnknownIssFallsThroughToOpaque(t *testing.T
 	require.Error(t, err)
 	require.NotContains(t, err.Error(), "trusted issuer JWT")
 }
+
+func TestValidateToken_TrustedIssuer_AcceptedTypHeaders_K8sSAToken(t *testing.T) {
+	key := newTestECKey(t)
+	const kid = "ti-kid"
+	jwksURL, jwksClient := serveStaticJWKS(t, key, kid)
+
+	srv, _, _ := setupFlowTestServer(t)
+
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             testIssuer,
+		JwksURL:            jwksURL,
+		AllowedAudiences:   []string{srv.Config.GetResourceIdentifier()},
+		AcceptedTypHeaders: []string{"", "JWT"},
+	}}, jwksClient)
+	require.NoError(t, err)
+	srv.trustedIssuerValidator = v
+
+	claims := josejwt.Claims{
+		Issuer:   testIssuer,
+		Subject:  testSubject,
+		Audience: josejwt.Audience{srv.Config.GetResourceIdentifier()},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt: josejwt.NewNumericDate(time.Now()),
+	}
+
+	// Kubernetes SA tokens carry no typ header at all.
+	noTyp := signSubjectTokenWithType(t, key, kid, "", claims)
+	userInfo, err := srv.ValidateToken(context.Background(), noTyp)
+	require.NoError(t, err)
+	require.Equal(t, testSubject, userInfo.ID)
+
+	plainJWT := signSubjectTokenWithType(t, key, kid, "JWT", claims)
+	userInfo, err = srv.ValidateToken(context.Background(), plainJWT)
+	require.NoError(t, err)
+	require.Equal(t, testSubject, userInfo.ID)
+
+	// at+jwt is no longer in the accepted set once overridden.
+	atJWT := signSubjectTokenWithType(t, key, kid, rfc9068TokenType, claims)
+	_, err = srv.ValidateToken(context.Background(), atJWT)
+	require.Error(t, err)
+}
+
+func TestValidateToken_TrustedIssuer_DefaultTypStillRejectsMissingTyp(t *testing.T) {
+	key := newTestECKey(t)
+	const kid = "ti-kid"
+	jwksURL, jwksClient := serveStaticJWKS(t, key, kid)
+
+	srv, _, _ := setupFlowTestServer(t)
+
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:           testIssuer,
+		JwksURL:          jwksURL,
+		AllowedAudiences: []string{srv.Config.GetResourceIdentifier()},
+	}}, jwksClient)
+	require.NoError(t, err)
+	srv.trustedIssuerValidator = v
+
+	noTyp := signSubjectTokenWithType(t, key, kid, "", josejwt.Claims{
+		Issuer:   testIssuer,
+		Subject:  testSubject,
+		Audience: josejwt.Audience{srv.Config.GetResourceIdentifier()},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt: josejwt.NewNumericDate(time.Now()),
+	})
+	_, err = srv.ValidateToken(context.Background(), noTyp)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "RFC 9068")
+}


### PR DESCRIPTION
## What

Adds `TrustedIssuer.AcceptedTypHeaders`: a per-issuer list of accepted JWT `typ` header values for the trusted-issuer Bearer branch of `ValidateToken`. Empty keeps the RFC 9068 §4 default (`at+jwt`). An empty string in the list matches a token with no `typ` header.

## Why

The trusted-issuer path enforces `typ: at+jwt` unconditionally (`server/validate.go`), but Kubernetes ServiceAccount tokens carry no `typ` header at all. That makes the documented K8s SA trust use case (see the `AllowPrivateIPJWKS` doc, which explicitly cites the API server's `/openid/v1/jwks`) impossible: every SA token is hard-rejected after passing signature, issuer, audience, and claim checks, observed live on glean as `trusted_issuer_typ_invalid`.

RFC 9068 §4's typ rule prevents cross-JWT confusion for OAuth access tokens. SA tokens are not RFC 9068 access tokens; the security boundary for a workload-identity issuer entry is signature + exact `iss` routing + audience + `allowedClaims`, all of which remain enforced. The override is explicit, per issuer, and defaults stay strict.

## Usage

```go
server.TrustedIssuer{
    Issuer:             "https://oidcissuer....blob.core.windows.net/oidc-test/",
    JwksURL:            "https://oidcissuer..../openid/v1/jwks",
    AllowedClaims:      map[string]string{"sub": "system:serviceaccount:kagent:*"},
    AcceptedTypHeaders: []string{""},
}
```