### PR TITLE
fix: let trusted-issuer branch defer ID tokens to forwarded validation

### DIFF
--- a/server/validate.go
+++ b/server/validate.go
@@ -188,8 +188,10 @@ func (s *Server) attemptProactiveRefresh(ctx context.Context, accessToken string
 //     entry's JWKS; aud checked against the entry's AllowedAudiences
 //     (defaulting to Config.GetResourceIdentifier when empty); RFC 9068 §4
 //     typ=at+jwt enforced. A non-matching iss returns ErrIssuerNotTrusted
-//     and falls through to subsequent branches; any other validation
-//     failure is a hard rejection.
+//     and falls through to subsequent branches; a typ failure on a token
+//     whose aud is in Config.TrustedAudiences falls through to the
+//     forwarded-ID-token branch (it is an ID token, not an access token);
+//     any other validation failure is a hard rejection.
 //  3. Forwarded ID token (when the bearer is a JWT whose aud matches
 //     Config.TrustedAudiences). Verified via the upstream provider's JWKS
 //     for SSO token forwarding.
@@ -392,12 +394,32 @@ func (s *Server) isTrustedAudience(audience string) bool {
 	return helpers.MatchAudienceSecure(audience, s.Config.TrustedAudiences) != ""
 }
 
+// hasTrustedAudience reports whether any of the token's audiences is in the
+// TrustedAudiences list.
+func (s *Server) hasTrustedAudience(audiences []string) bool {
+	for _, aud := range audiences {
+		if s.isTrustedAudience(aud) {
+			return true
+		}
+	}
+	return false
+}
+
 // validateTrustedIssuerJWT runs the WithTrustedIssuers Bearer branch of
 // ValidateToken. Returns (nil, nil) when no validator is configured or the
 // token's iss is not a configured peer (caller falls through); (userInfo,
 // nil) on success; (nil, err) on any other validation failure (caller
 // returns the error). The RFC 9068 typ enforcement runs only after the
 // JWS signature has been verified by Validate.
+//
+// A token that fails only the typ check but carries an audience listed in
+// Config.TrustedAudiences is not an access token at all — it is an ID
+// token forwarded by a trusted upstream service (SSO token forwarding).
+// Hard-rejecting it here would shadow the forwarded-ID-token branch
+// whenever the upstream issuer is also configured as a trusted issuer
+// (e.g. for RFC 8693 subject-token validation). Such tokens fall through
+// instead; the forwarded-ID-token branch re-validates them independently
+// against the server's own provider JWKS.
 func (s *Server) validateTrustedIssuerJWT(ctx context.Context, accessToken string) (*providers.UserInfo, error) {
 	if s.trustedIssuerValidator == nil {
 		return nil, nil
@@ -411,6 +433,12 @@ func (s *Server) validateTrustedIssuerJWT(ctx context.Context, accessToken strin
 		return nil, fmt.Errorf("trusted issuer JWT validation failed: %w", err)
 	}
 	if err := checkRFC9068TypeHeader(accessToken); err != nil {
+		if identity.Claims != nil && s.hasTrustedAudience(identity.Claims.Audience) {
+			s.Logger.Debug("Trusted-issuer JWT without at+jwt typ carries a trusted audience, deferring to forwarded ID token validation",
+				"issuer", identity.Issuer,
+				"token_suffix", helpers.TokenSuffix(accessToken, 8))
+			return nil, nil
+		}
 		s.Auditor.LogAuthFailure(ctx, identity.Subject, "", "", "trusted_issuer_typ_invalid")
 		return nil, fmt.Errorf("trusted issuer JWT: %w", err)
 	}

--- a/server/validate_trusted_issuer_test.go
+++ b/server/validate_trusted_issuer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
 
 // signSubjectTokenWithType is signSubjectToken with a caller-controlled typ
@@ -150,6 +151,39 @@ func TestValidateToken_TrustedIssuer_RejectsWrongAudience(t *testing.T) {
 	_, err = srv.ValidateToken(context.Background(), token)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "trusted issuer JWT validation failed")
+}
+
+// TestValidateToken_TrustedIssuer_IDTokenFallsThroughToForwarded covers the
+// gazelle-style deployment where the server's main OIDC provider is ALSO
+// configured as a trusted issuer (for RFC 8693 subject-token validation).
+// A forwarded ID token (typ != at+jwt) from that issuer whose aud is in
+// TrustedAudiences must not be hard-rejected by the trusted-issuer branch;
+// it falls through to the forwarded-ID-token branch and is accepted there.
+func TestValidateToken_TrustedIssuer_IDTokenFallsThroughToForwarded(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+
+	tiJWKSClient := oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+		HTTPClient:     h.jwksServer.Client(),
+		AllowPrivateIP: true,
+	})
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:           h.issuer,
+		JwksURL:          h.jwksServer.URL,
+		AllowedAudiences: []string{h.audience},
+	}}, tiJWKSClient)
+	require.NoError(t, err)
+	h.srv.trustedIssuerValidator = v
+
+	// signToken signs with typ "JWT" — an ID token, not an RFC 9068 access
+	// token. aud is in TrustedAudiences, so the trusted-issuer branch must
+	// defer instead of hard-rejecting on the typ check.
+	tok := h.signToken(t, h.validClaims())
+
+	userInfo, err := h.srv.ValidateToken(context.Background(), tok)
+	require.NoError(t, err)
+	require.NotNil(t, userInfo)
+	require.Equal(t, "user-subject-123", userInfo.ID)
+	require.Equal(t, providers.TokenSourceSSO, userInfo.TokenSource)
 }
 
 func TestValidateToken_TrustedIssuer_UnknownIssFallsThroughToOpaque(t *testing.T) {


### PR DESCRIPTION
## Summary

Deployments that enable both `WithTrustedIssuers` (RFC 8693 subject-token validation) and `TrustedAudiences` (SSO token forwarding) for the *same* issuer were broken: a forwarded ID token's `iss` matched the trusted-issuer Bearer branch (priority 2), which hard-rejects any token without `typ: at+jwt` (RFC 9068 §4) — so the forwarded-ID-token branch (priority 3) that exists precisely for these ID tokens was unreachable. Observed in production on muster: Backstage AI-chat forwarding returned 401 `trusted issuer JWT: typ header is "", expected "at+jwt"` while the identical setup without `trustedIssuers` worked.

The fix: when the typ check fails AND the token carries an audience listed in `Config.TrustedAudiences`, the trusted-issuer branch defers (falls through) instead of hard-rejecting. The forwarded-ID-token branch then re-validates the token independently against the provider's JWKS. Tokens failing typ without a trusted audience are still hard-rejected, preserving RFC 9068 enforcement.

## Test plan

- [x] New test `TestValidateToken_TrustedIssuer_IDTokenFallsThroughToForwarded` (same issuer registered as trusted issuer + main provider; ID token accepted via forwarded branch)
- [x] Existing `TestValidateToken_TrustedIssuer_RejectsWrongTyp` unchanged (no trusted audience → hard reject)
- [x] Full `./server` suite green

Made with [Cursor](https://cursor.com)