### PR TITLE
feat(providers,server): external-issuer signal on UserInfo + WithTrustedAudiences option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `providers.TokenSourceTrustedIssuer` (`"trusted-issuer"`) constant and `UserInfo.IsExternalIssuer() bool` method. A Bearer validated against a `WithTrustedIssuers` entry is now tagged with this source instead of `TokenSourceSSO`, so downstream servers can distinguish an external-IdP token (requires impersonation or token-exchange) from a Dex-forwarded SSO token (can be passed through as a bearer).
+
+- `providers.UserInfo.Issuer string` field, populated on the `TokenSourceTrustedIssuer` path with the originating issuer URL (e.g. the cluster's SA OIDC issuer). Empty for `TokenSourceSSO` and `TokenSourceOAuth`.
+
+- `server.WithTrustedAudiences([]string) Option`: functional option equivalent to setting `Config.TrustedAudiences`, for symmetry with `WithTrustedIssuers`.
+
+### Changed
+
+- `server.validateTrustedIssuerJWT` now sets `UserInfo.TokenSource = TokenSourceTrustedIssuer` and `UserInfo.Issuer` instead of the previous `TokenSourceSSO`. Callers that relied on `userInfo.IsSSO()` being true for trusted-issuer tokens must switch to `userInfo.IsExternalIssuer()`.
+
 - `server.ExchangerRequest` now carries `ActorToken string`, `ActorTokenType string`, and `Actor *server.SubjectIdentity`. The brokered token-exchange endpoint accepts RFC 8693 `actor_token` and `actor_token_type` form parameters; when present the actor token is validated against the server's trusted issuers (same validator path as the subject token) and the verified actor identity is forwarded to the `Exchanger`. Absent actor params leave `Actor` nil and `BrokerExchangeSubjectToken` behaves identically to before.
 
 - `server.TokenExchangeUnsupportedTypeError` now exposes a `Role() string` method returning `"subject"` or `"actor"` to identify which token in the exchange request had an unsupported type. Handlers and callers that previously matched this error via `errors.As` now receive accurate role information for error messages and logs.

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -150,6 +150,18 @@ const (
 	// For those flows, fetch the upstream id_token by another path (e.g.
 	// the configured TokenRefreshHandler cache).
 	TokenSourceJWT TokenSource = "jwt"
+
+	// TokenSourceTrustedIssuer indicates the user was authenticated via a
+	// Bearer JWT validated against a WithTrustedIssuers entry. The token
+	// was issued by an external IdP (e.g. a Kubernetes cluster's SA issuer)
+	// whose JWKS is configured explicitly — it was not issued by this server
+	// and is not a Dex-forwarded ID token.
+	//
+	// Downstream servers should use this to select impersonation rather than
+	// bearer passthrough: the token's audience is the muster/broker STS, not
+	// the downstream resource server, so direct passthrough would be rejected.
+	// Use UserInfo.Issuer to identify the originating issuer.
+	TokenSourceTrustedIssuer TokenSource = "trusted-issuer"
 )
 
 // UserInfo represents user information from a provider
@@ -197,6 +209,16 @@ type UserInfo struct {
 	// UserInfo is deserialized from untrusted input). Always use the server's
 	// ValidateToken() method to obtain a trusted UserInfo with correct TokenSource.
 	TokenSource TokenSource
+
+	// Issuer is the token issuer URL, populated only when TokenSource is
+	// TokenSourceTrustedIssuer. It identifies the external IdP that signed
+	// the Bearer token (e.g. the cluster's SA OIDC issuer URL). Empty for
+	// Dex-forwarded (TokenSourceSSO) and OAuth-issued (TokenSourceOAuth)
+	// tokens; those are issued by this server's own IdP.
+	//
+	// Downstream servers can use this alongside IsExternalIssuer() to route
+	// to an impersonation path rather than bearer passthrough.
+	Issuer string
 }
 
 // IsSSO returns true if this user was authenticated via SSO token forwarding.
@@ -240,4 +262,20 @@ func (u *UserInfo) IsOAuth() bool {
 // this OAuth server, not the upstream.
 func (u *UserInfo) IsJWT() bool {
 	return u != nil && u.TokenSource == TokenSourceJWT
+}
+
+// IsExternalIssuer returns true if this user was authenticated via a Bearer
+// JWT validated against a WithTrustedIssuers entry — i.e. the token was
+// issued by an external IdP, not by this server's own Dex/OAuth flow.
+//
+// Returns false for nil receivers, OAuth tokens, SSO tokens, JWT tokens,
+// empty TokenSource, and unknown/invalid TokenSource values.
+//
+// Downstream servers that receive an external-issuer token MUST NOT pass
+// it directly as a Bearer to a resource server (e.g. kube-apiserver) whose
+// audience differs from the token's aud claim. Use an impersonation or
+// token-exchange path instead. Check UserInfo.Issuer to identify the
+// originating cluster/IdP.
+func (u *UserInfo) IsExternalIssuer() bool {
+	return u != nil && u.TokenSource == TokenSourceTrustedIssuer
 }

--- a/server/options.go
+++ b/server/options.go
@@ -105,6 +105,26 @@ func WithTokenRefreshHandler(handler TokenRefreshHandler) Option {
 //     ResourceIdentifier when empty); the typ header is checked against
 //     AcceptedTypHeaders (default RFC 9068 typ=at+jwt).
 //
+// WithTrustedAudiences sets additional OAuth client IDs whose tokens are
+// accepted by ValidateToken, alongside the server's own ResourceIdentifier.
+// This covers SSO token forwarding: an aggregator (e.g. muster) issues tokens
+// with its own client_id as audience; adding that client_id here lets downstream
+// servers accept forwarded tokens without a separate auth flow.
+//
+// Equivalent to setting Config.TrustedAudiences; provided as a functional
+// option for symmetry with WithTrustedIssuers. If both are used, the option
+// takes precedence over the Config field.
+//
+// Empty slice is a no-op.
+func WithTrustedAudiences(audiences []string) Option {
+	return func(s *Server) {
+		if len(audiences) == 0 {
+			return
+		}
+		s.Config.TrustedAudiences = audiences
+	}
+}
+
 // Use TrustedIssuer.AllowedClaims to constrain accepted subjects per issuer.
 // Empty list is a no-op.
 func WithTrustedIssuers(issuers []TrustedIssuer) Option {

--- a/server/validate.go
+++ b/server/validate.go
@@ -447,6 +447,8 @@ func (s *Server) validateTrustedIssuerJWT(ctx context.Context, accessToken strin
 		return nil, fmt.Errorf("trusted issuer JWT: %w", err)
 	}
 	userInfo := s.idTokenClaimsToUserInfo(identity.Claims)
+	userInfo.Issuer = identity.Issuer
+	userInfo.TokenSource = providers.TokenSourceTrustedIssuer
 	s.logTrustedIssuerJWTAccepted(ctx, accessToken, identity.Issuer, userInfo)
 	return userInfo, nil
 }

--- a/server/validate_trusted_issuer_test.go
+++ b/server/validate_trusted_issuer_test.go
@@ -65,7 +65,10 @@ func TestValidateToken_TrustedIssuer_Accepts(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, userInfo)
 	require.Equal(t, testSubject, userInfo.ID)
-	require.Equal(t, providers.TokenSourceSSO, userInfo.TokenSource)
+	require.Equal(t, providers.TokenSourceTrustedIssuer, userInfo.TokenSource)
+	require.True(t, userInfo.IsExternalIssuer(), "IsExternalIssuer() must be true for trusted-issuer token")
+	require.False(t, userInfo.IsSSO(), "IsSSO() must be false for trusted-issuer token")
+	require.Equal(t, testIssuer, userInfo.Issuer, "Issuer must be propagated from the trusted-issuer entry")
 }
 
 func TestValidateToken_TrustedIssuer_DefaultsAudienceToResourceIdentifier(t *testing.T) {


### PR DESCRIPTION
## What

Downstream servers (mcp-kubernetes) that accept machine tokens from external IdPs (Kubernetes ServiceAccount JWTs) need to distinguish them from Dex-forwarded SSO tokens, because the two require different handling:
- SSO tokens: pass the bearer directly to the kube-apiserver (the token was issued for that audience).
- External-issuer tokens: cannot be passed through — their `aud` is the muster STS, not the apiserver. They require impersonation or token-exchange.

Until now, `validateTrustedIssuerJWT` called `idTokenClaimsToUserInfo` which unconditionally tagged every result `TokenSourceSSO`, making the two paths indistinguishable. The verified issuer URL was only logged, never surfaced.

### Changes

**`providers/provider.go`**
- `TokenSourceTrustedIssuer TokenSource = "trusted-issuer"` — new constant for Bearer tokens validated against a `WithTrustedIssuers` entry.
- `UserInfo.Issuer string` — populated on the trusted-issuer path with the originating issuer URL. Empty for SSO and OAuth tokens.
- `UserInfo.IsExternalIssuer() bool` — returns true when `TokenSource == TokenSourceTrustedIssuer`.

**`server/validate.go`**
- `validateTrustedIssuerJWT` now sets `userInfo.TokenSource = TokenSourceTrustedIssuer` and `userInfo.Issuer = identity.Issuer` after `idTokenClaimsToUserInfo`. The Dex-forwarded path (`idTokenClaimsToUserInfo` itself) is unchanged — it still returns `TokenSourceSSO`.

**`server/options.go`**
- `WithTrustedAudiences([]string) Option` — functional option setting `Config.TrustedAudiences`, for symmetry with `WithTrustedIssuers`.

### Compatibility

`IsSSO()` now returns `false` for trusted-issuer tokens (it returned `true` before). There are no non-test production callers of `IsSSO()` in this repo. The one test asserting the old behavior (`TestValidateToken_TrustedIssuer_Accepts`) is updated; the `TestValidateToken_TokenSource_SSO` test (which exercises `idTokenClaimsToUserInfo` directly) is unchanged and still passes.

## Context

Part of the kagent → muster → mcp-kubernetes machine-identity auth chain (giantswarm/giantswarm#36917). mcp-kubernetes will consume `IsExternalIssuer()` and `UserInfo.Issuer` to route to its impersonation path once this is released.