### PR TITLE
feat(token-exchange): mint OBO token with validated actor; surface actor on UserInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `server.LocalMintExchanger` and `NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error)`: an `Exchanger` implementation that mints a signed JWT access token locally using the server's own RSA/EC key. Intended for broker-routed targets where the broker is the authoritative issuer. Requires JWT access token mode; returns an error otherwise.
+
+- `actor_token` / `actor_token_type` support on the direct token-exchange path (`ExchangeSubjectToken`): when an actor token is presented, it is validated against the server's trusted issuers and the resulting actor identity is written as the `act` claim of the issued JWT (`act.iss` = actor issuer, `act.sub` = actor subject). The `ActorDelegationPolicy` must explicitly permit the (actor, subject) pair; a nil or empty policy denies all delegated exchanges.
+
+- `providers.UserInfo.ActorIssuer string` and `providers.UserInfo.ActorSubject string`: actor identity fields populated when a validated token carries an RFC 8693 §4.4 `act` claim. Empty for tokens without delegation.
+
+- `providers.UserInfo.IsDelegated() bool`: reports whether the token represents a delegated exchange; true when `ActorSubject` is non-empty.
+
+- `oidc.IDTokenClaims.Act *oidc.ActorClaim` and `oidc.ActorClaim` (`Issuer string`, `Subject string`): decoded automatically from the `act` claim of a JWT when present.
+
 - `providers.TokenSourceTrustedIssuer` (`"trusted-issuer"`) constant and `UserInfo.IsExternalIssuer() bool` method. A Bearer validated against a `WithTrustedIssuers` entry is now tagged with this source instead of `TokenSourceSSO`, so downstream servers can distinguish an external-IdP token (requires impersonation or token-exchange) from a Dex-forwarded SSO token (can be passed through as a bearer).
 
 - `providers.UserInfo.Issuer string` field, populated on the `TokenSourceTrustedIssuer` path with the originating issuer URL (e.g. the cluster's SA OIDC issuer). Empty for `TokenSourceSSO` and `TokenSourceOAuth`.
@@ -16,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `server.WithTrustedAudiences([]string) Option`: functional option equivalent to setting `Config.TrustedAudiences`, for symmetry with `WithTrustedIssuers`.
 
 ### Changed
+
+- `server.ExchangeSubjectToken` signature gains two new parameters: `actorToken string` and `actorTokenType string` (inserted after `subjectTokenType`, before `resource`). Callers passing no actor token must supply empty strings. The issued JWT no longer carries a self-referential `act` claim; `act` is omitted when no actor token is presented and set to the validated actor identity when one is.
 
 - `server.validateTrustedIssuerJWT` now sets `UserInfo.TokenSource = TokenSourceTrustedIssuer` and `UserInfo.Issuer` instead of the previous `TokenSourceSSO`. Callers that relied on `userInfo.IsSSO()` being true for trusted-issuer tokens must switch to `userInfo.IsExternalIssuer()`.
 

--- a/handler/token_exchange.go
+++ b/handler/token_exchange.go
@@ -89,7 +89,7 @@ func (h *Handler) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	result, err := h.server.ExchangeSubjectToken(r.Context(), subjectToken, subjectTokenType, resource, scope, dpopJKT)
+	result, err := h.server.ExchangeSubjectToken(r.Context(), subjectToken, subjectTokenType, actorToken, actorTokenType, resource, scope, dpopJKT)
 	if err != nil {
 		h.handleTokenExchangeError(w, r, err, clientIP, startTime, span)
 		return

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -357,6 +357,15 @@ func GetAudienceFromClaims(claims map[string]any) []string {
 	return nil
 }
 
+// ActorClaim is the RFC 8693 §4.4 act claim decoded from an OIDC token or
+// mcp-oauth-minted access token. It identifies the acting party in a
+// delegation chain: Issuer and Subject correspond to the agent service account
+// that obtained the token on behalf of the human subject.
+type ActorClaim struct {
+	Issuer  string `json:"iss,omitempty"`
+	Subject string `json:"sub,omitempty"`
+}
+
 // IDTokenClaims represents the standard claims in an OIDC ID token. The
 // embedded josejwt.Claims carries the registered claims (iss, sub, aud, exp,
 // nbf, iat, jti); the additional fields are OIDC-specific extensions defined
@@ -376,6 +385,10 @@ type IDTokenClaims struct {
 	// Nonce is the OIDC `nonce` claim. Callers compare it to the expected value
 	// via ValidateNonceClaim; this struct does not enforce equality.
 	Nonce string `json:"nonce,omitempty"`
+
+	// Act is the RFC 8693 §4.4 delegation claim. Non-nil only in tokens that
+	// were minted via a token-exchange with a validated actor_token.
+	Act *ActorClaim `json:"act,omitempty"`
 }
 
 // ErrKeyNotFound is returned (wrapped) when a JWT's kid header does not match

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -227,8 +227,7 @@ type UserInfo struct {
 
 	// ActorSubject is the sub field from the RFC 8693 §4.4 act claim. Non-empty
 	// only when the token was minted via a delegated token exchange with a
-	// validated actor_token. Identifies the agent service account that obtained
-	// the token on behalf of the human subject (UserInfo.ID).
+	// validated actor_token. Use IsDelegated() as a presence check.
 	ActorSubject string
 }
 
@@ -291,13 +290,14 @@ func (u *UserInfo) IsExternalIssuer() bool {
 	return u != nil && u.TokenSource == TokenSourceTrustedIssuer
 }
 
-// IsDelegated returns true when the token carries an RFC 8693 §4.4 act claim
-// — i.e. it was minted via a delegated token exchange with a validated
-// actor_token. When true, ActorSubject and ActorIssuer identify the acting
-// agent service account; ID identifies the human subject on whose behalf the
-// token was obtained.
+// IsDelegated returns true when the token was produced by a delegated token
+// exchange (RFC 8693 §4.4): it carries an act claim and was validated on the
+// trusted-issuer path (TokenSourceTrustedIssuer). When true, ActorSubject and
+// ActorIssuer identify the acting party; ID identifies the human subject on
+// whose behalf the token was obtained.
 //
-// Returns false for nil receivers or tokens without delegation.
+// Returns false for nil receivers, tokens without an act claim, and tokens
+// that were not validated as trusted-issuer tokens (e.g. plain SSO tokens).
 func (u *UserInfo) IsDelegated() bool {
-	return u != nil && u.ActorSubject != ""
+	return u != nil && u.ActorSubject != "" && u.TokenSource == TokenSourceTrustedIssuer
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -219,6 +219,17 @@ type UserInfo struct {
 	// Downstream servers can use this alongside IsExternalIssuer() to route
 	// to an impersonation path rather than bearer passthrough.
 	Issuer string
+
+	// ActorIssuer is the iss field from the RFC 8693 §4.4 act claim. Non-empty
+	// only when the token was minted via a delegated token exchange with a
+	// validated actor_token. Use IsDelegated() as a presence check.
+	ActorIssuer string
+
+	// ActorSubject is the sub field from the RFC 8693 §4.4 act claim. Non-empty
+	// only when the token was minted via a delegated token exchange with a
+	// validated actor_token. Identifies the agent service account that obtained
+	// the token on behalf of the human subject (UserInfo.ID).
+	ActorSubject string
 }
 
 // IsSSO returns true if this user was authenticated via SSO token forwarding.
@@ -278,4 +289,15 @@ func (u *UserInfo) IsJWT() bool {
 // originating cluster/IdP.
 func (u *UserInfo) IsExternalIssuer() bool {
 	return u != nil && u.TokenSource == TokenSourceTrustedIssuer
+}
+
+// IsDelegated returns true when the token carries an RFC 8693 §4.4 act claim
+// — i.e. it was minted via a delegated token exchange with a validated
+// actor_token. When true, ActorSubject and ActorIssuer identify the acting
+// agent service account; ID identifies the human subject on whose behalf the
+// token was obtained.
+//
+// Returns false for nil receivers or tokens without delegation.
+func (u *UserInfo) IsDelegated() bool {
+	return u != nil && u.ActorSubject != ""
 }

--- a/server/local_mint_exchanger.go
+++ b/server/local_mint_exchanger.go
@@ -10,20 +10,17 @@ import (
 // LocalMintExchanger implements Exchanger by minting an mcp-oauth-signed JWT
 // access token locally, without delegating to a downstream issuer. It is the
 // recommended implementation for token-exchange targets where the broker itself
-// is the authoritative issuer — muster uses it to mint OBO tokens for each
-// audience-routed target.
+// is the authoritative issuer.
 //
-// The broker (BrokerExchangeSubjectToken / WorkloadExchangeSubjectToken) has
-// already validated the subject and actor tokens and enforced
-// ActorDelegationPolicy before Exchange is called; LocalMintExchanger does not
+// Callers are responsible for validating subject and actor tokens and enforcing
+// ActorDelegationPolicy before calling Exchange; LocalMintExchanger does not
 // re-run policy.
 //
 // Requires JWT access token mode (Config.IsJWTAccessTokenFormat() must be
 // true); NewLocalMintExchanger returns an error otherwise.
 type LocalMintExchanger struct {
-	issuer    AccessTokenIssuer
-	issuerURL string
-	ttl       time.Duration
+	issuer AccessTokenIssuer
+	ttl    time.Duration
 }
 
 // NewLocalMintExchanger constructs a LocalMintExchanger from a validated
@@ -43,9 +40,8 @@ func NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error) {
 		ttl = 10 * time.Minute
 	}
 	return &LocalMintExchanger{
-		issuer:    issuer,
-		issuerURL: cfg.Issuer,
-		ttl:       ttl,
+		issuer: issuer,
+		ttl:    ttl,
 	}, nil
 }
 
@@ -57,6 +53,9 @@ func NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error) {
 //   - scope = intersection of req.Scope and req.Subject.AllowedScopes
 //   - iss = the Issuer URL from the Config used to build LocalMintExchanger
 func (l *LocalMintExchanger) Exchange(ctx context.Context, req *ExchangerRequest) (*ExchangerResult, error) {
+	if req.Subject == nil {
+		return nil, fmt.Errorf("local mint: ExchangerRequest.Subject must not be nil")
+	}
 	var act *Actor
 	if req.Actor != nil {
 		act = &Actor{Iss: req.Actor.Issuer, Sub: req.Actor.Subject}

--- a/server/local_mint_exchanger.go
+++ b/server/local_mint_exchanger.go
@@ -1,0 +1,94 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// LocalMintExchanger implements Exchanger by minting an mcp-oauth-signed JWT
+// access token locally, without delegating to a downstream issuer. It is the
+// recommended implementation for token-exchange targets where the broker itself
+// is the authoritative issuer — muster uses it to mint OBO tokens for each
+// audience-routed target.
+//
+// The broker (BrokerExchangeSubjectToken / WorkloadExchangeSubjectToken) has
+// already validated the subject and actor tokens and enforced
+// ActorDelegationPolicy before Exchange is called; LocalMintExchanger does not
+// re-run policy.
+//
+// Requires JWT access token mode (Config.IsJWTAccessTokenFormat() must be
+// true); NewLocalMintExchanger returns an error otherwise.
+type LocalMintExchanger struct {
+	issuer    AccessTokenIssuer
+	issuerURL string
+	ttl       time.Duration
+}
+
+// NewLocalMintExchanger constructs a LocalMintExchanger from a validated
+// Config. cfg must be in JWT access token mode; an error is returned otherwise.
+// The TTL is taken from cfg.AccessTokenTTL (default 10 minutes when zero or
+// negative), matching the behaviour of ExchangeSubjectToken.
+func NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error) {
+	if !cfg.IsJWTAccessTokenFormat() {
+		return nil, fmt.Errorf("LocalMintExchanger requires JWT access token mode (set AccessTokenFormat=jwt)")
+	}
+	issuer, err := newJWTIssuer(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create local mint issuer: %w", err)
+	}
+	ttl := time.Duration(cfg.AccessTokenTTL) * time.Second
+	if ttl <= 0 {
+		ttl = 10 * time.Minute
+	}
+	return &LocalMintExchanger{
+		issuer:    issuer,
+		issuerURL: cfg.Issuer,
+		ttl:       ttl,
+	}, nil
+}
+
+// Exchange mints a signed JWT access token for the request. The issued token
+// carries:
+//   - sub = req.Subject.Subject (human subject)
+//   - act = {iss: req.Actor.Issuer, sub: req.Actor.Subject} when req.Actor != nil
+//   - aud = req.Resource when non-empty, else req.Audience
+//   - scope = intersection of req.Scope and req.Subject.AllowedScopes
+//   - iss = the Issuer URL from the Config used to build LocalMintExchanger
+func (l *LocalMintExchanger) Exchange(ctx context.Context, req *ExchangerRequest) (*ExchangerResult, error) {
+	var act *Actor
+	if req.Actor != nil {
+		act = &Actor{Iss: req.Actor.Issuer, Sub: req.Actor.Subject}
+	}
+
+	audience := req.Resource
+	if audience == "" {
+		audience = req.Audience
+	}
+
+	grantedScope := grantedExchangeScope(req.Scope, req.Subject.AllowedScopes)
+
+	now := time.Now().UTC()
+	expiresAt := now.Add(l.ttl)
+
+	tokenStr, err := l.issuer.Issue(ctx, AccessTokenClaims{
+		Subject:   req.Subject.Subject,
+		Audience:  audience,
+		Scopes:    strings.Fields(grantedScope),
+		IssuedAt:  now,
+		ExpiresAt: expiresAt,
+		JTI:       generateRandomToken(),
+		Act:       act,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("local mint: issue token: %w", err)
+	}
+
+	return &ExchangerResult{
+		AccessToken:     tokenStr,
+		ExpiresAt:       expiresAt,
+		Scope:           grantedScope,
+		IssuedTokenType: SubjectTokenTypeAccessToken,
+	}, nil
+}

--- a/server/local_mint_exchanger_test.go
+++ b/server/local_mint_exchanger_test.go
@@ -65,6 +65,20 @@ func TestNewLocalMintExchanger_RejectsOpaqueMode(t *testing.T) {
 	require.Contains(t, err.Error(), "JWT access token mode")
 }
 
+func TestLocalMintExchanger_Exchange_NilSubject(t *testing.T) {
+	cfg, _ := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	_, err = lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Scope:    "read",
+		Subject:  nil,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Subject must not be nil")
+}
+
 func TestLocalMintExchanger_Exchange_NoActor(t *testing.T) {
 	cfg, signingKey := localMintCfg(t)
 	lme, err := NewLocalMintExchanger(cfg)

--- a/server/local_mint_exchanger_test.go
+++ b/server/local_mint_exchanger_test.go
@@ -1,0 +1,200 @@
+package server
+
+import (
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// localMintCfg returns a JWT-mode Config and its RSA signing key for LocalMintExchanger tests.
+func localMintCfg(t *testing.T) (*Config, *rsa.PrivateKey) {
+	t.Helper()
+	key := generateRSAKey(t)
+	return &Config{
+		Issuer:                      "https://mcp.example.com",
+		AccessTokenFormat:           AccessTokenFormatJWT,
+		AccessTokenSigningKey:       key,
+		AccessTokenSigningKeyID:     "lme-test-kid",
+		AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
+		AccessTokenTTL:              600,
+	}, key
+}
+
+// serveStaticRSAJWKS starts a TLS test server serving the RSA public key as a JWKS.
+// The returned URL and JWKSClient are configured to allow private IPs (localhost).
+func serveStaticRSAJWKS(t *testing.T, key *rsa.PrivateKey, kid string) (jwksURL string, client *oidc.JWKSClient) {
+	t.Helper()
+	jwks := jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{{
+			Key:       key.Public(),
+			KeyID:     kid,
+			Algorithm: string(jose.RS256),
+			Use:       "sig",
+		}},
+	}
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(srv.Close)
+	c := oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+		HTTPClient:     srv.Client(),
+		AllowPrivateIP: true,
+	})
+	return srv.URL, c
+}
+
+func TestNewLocalMintExchanger_RejectsOpaqueMode(t *testing.T) {
+	cfg := &Config{
+		Issuer:            "https://mcp.example.com",
+		AccessTokenFormat: AccessTokenFormatOpaque,
+	}
+	_, err := NewLocalMintExchanger(cfg)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "JWT access token mode")
+}
+
+func TestLocalMintExchanger_Exchange_NoActor(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Scope:    "read write",
+		Subject: &SubjectIdentity{
+			Subject:       "user@example.com",
+			Issuer:        testIssuer,
+			AllowedScopes: []string{"read", "write"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.AccessToken)
+	require.Equal(t, SubjectTokenTypeAccessToken, result.IssuedTokenType)
+	require.True(t, result.ExpiresAt.After(time.Now()))
+
+	parsed, err := josejwt.ParseSigned(result.AccessToken, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var claims rfc9068Claims
+	require.NoError(t, parsed.Claims(signingKey.Public(), &claims))
+
+	require.Equal(t, "user@example.com", claims.Subject)
+	require.Equal(t, cfg.Issuer, claims.Issuer)
+	require.Contains(t, []string(claims.Audience), "https://api.example.com")
+	require.Nil(t, claims.Act, "act claim must be absent when no actor is present")
+	require.Equal(t, "read write", claims.Scope)
+}
+
+func TestLocalMintExchanger_Exchange_WithActor(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	const actorSub = "agent-sa@cluster.example.com"
+	const actorIss = "https://k8s.example.com"
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Scope:    "read",
+		Subject: &SubjectIdentity{
+			Subject:       "user@example.com",
+			Issuer:        testIssuer,
+			AllowedScopes: []string{"read", "write"},
+		},
+		Actor: &SubjectIdentity{Subject: actorSub, Issuer: actorIss},
+	})
+	require.NoError(t, err)
+
+	parsed, err := josejwt.ParseSigned(result.AccessToken, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var claims rfc9068Claims
+	require.NoError(t, parsed.Claims(signingKey.Public(), &claims))
+
+	require.Equal(t, "user@example.com", claims.Subject)
+	require.NotNil(t, claims.Act, "act claim must be set for delegated exchange")
+	require.Equal(t, actorIss, claims.Act.Iss)
+	require.Equal(t, actorSub, claims.Act.Sub)
+}
+
+func TestLocalMintExchanger_Exchange_ScopeIntersection(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Scope:    "read write admin",
+		Subject: &SubjectIdentity{
+			Subject:       "user@example.com",
+			Issuer:        testIssuer,
+			AllowedScopes: []string{"read", "write"},
+		},
+	})
+	require.NoError(t, err)
+
+	parsed, err := josejwt.ParseSigned(result.AccessToken, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var claims rfc9068Claims
+	require.NoError(t, parsed.Claims(signingKey.Public(), &claims))
+
+	require.NotContains(t, claims.Scope, "admin", "scope must be intersected with AllowedScopes")
+}
+
+// TestLocalMintExchanger_RoundTrip_IsDelegated mints a token with an actor and
+// validates it back through an OIDCValidator (trusted-issuer path) to verify that
+// UserInfo.IsDelegated() and ActorSubject/ActorIssuer are populated on the resource-server side.
+func TestLocalMintExchanger_RoundTrip_IsDelegated(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	const actorSub = "agent-sa@cluster.example.com"
+	const actorIss = "https://k8s.example.com"
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: cfg.Issuer,
+		Scope:    "read",
+		Subject:  &SubjectIdentity{Subject: "user@example.com", Issuer: testIssuer},
+		Actor:    &SubjectIdentity{Subject: actorSub, Issuer: actorIss},
+	})
+	require.NoError(t, err)
+
+	jwksURL, jwksClient := serveStaticRSAJWKS(t, signingKey, "lme-test-kid")
+
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	srv, _, _ := setupFlowTestServer(t)
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             cfg.Issuer,
+		JwksURL:            jwksURL,
+		AllowedAudiences:   []string{cfg.Issuer},
+		AllowPrivateIPJWKS: true,
+		AcceptedTypHeaders: []string{"at+jwt"},
+	}}, jwksClient)
+	require.NoError(t, err)
+	srv.trustedIssuerValidator = v
+
+	userInfo, err := srv.ValidateToken(t.Context(), result.AccessToken)
+	require.NoError(t, err)
+	require.NotNil(t, userInfo)
+	require.Equal(t, "user@example.com", userInfo.ID)
+	require.Equal(t, providers.TokenSourceTrustedIssuer, userInfo.TokenSource)
+	require.True(t, userInfo.IsDelegated(), "IsDelegated must be true for OBO token")
+	require.Equal(t, actorSub, userInfo.ActorSubject)
+	require.Equal(t, actorIss, userInfo.ActorIssuer)
+}

--- a/server/sso.go
+++ b/server/sso.go
@@ -144,8 +144,11 @@ func (s *Server) getJWKSClient() *oidc.JWKSClient {
 
 // idTokenClaimsToUserInfo converts validated ID token claims to UserInfo.
 // Sets TokenSource to TokenSourceSSO since this is called for SSO-forwarded tokens.
+// ActorIssuer/ActorSubject are populated from claims.Act when the token carries
+// an RFC 8693 §4.4 delegation claim (mcp-oauth-minted OBO tokens only; ordinary
+// SSO ID tokens never carry act).
 func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.UserInfo {
-	return &providers.UserInfo{
+	info := &providers.UserInfo{
 		ID:            claims.Subject,
 		Email:         claims.Email,
 		EmailVerified: claims.EmailVerified,
@@ -157,6 +160,11 @@ func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.
 		Groups:        claims.Groups,
 		TokenSource:   providers.TokenSourceSSO,
 	}
+	if claims.Act != nil {
+		info.ActorIssuer = claims.Act.Issuer
+		info.ActorSubject = claims.Act.Subject
+	}
+	return info
 }
 
 // logForwardedIDTokenAccepted logs a security event when a forwarded ID token is accepted.

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -48,13 +48,21 @@ type ExchangeOptions struct {
 // validated DPoP proof; when non-empty it is written into the cnf.jkt claim of the
 // issued JWT per RFC 9449 §6.1. Pass empty string when no DPoP proof was presented.
 //
+// actorToken and actorTokenType are RFC 8693 §4.4 delegation parameters. When
+// actorToken is non-empty it is validated against the server's trusted issuers
+// and the resulting actor identity is written as the act claim of the issued
+// JWT (act.sub = agent SA, act.iss = agent issuer). The ActorDelegationPolicy
+// must explicitly allow the (actor, subject) pair; nil/empty policy denies all
+// delegated exchanges. Pass empty strings for both when no delegation is
+// required — the issued token will carry no act claim.
+//
 // opts is an optional ExchangeOptions whose identity fields are emitted as
 // standard JWT claims (email, email_verified, name, groups) and whose Extra
 // map is merged verbatim into the JWT body. Omitting opts adds no identity
 // claims. Only the first element is used when multiple are provided.
 func (s *Server) ExchangeSubjectToken(
 	ctx context.Context,
-	subjectToken, subjectTokenType, resource, scope, dpopJKT string,
+	subjectToken, subjectTokenType, actorToken, actorTokenType, resource, scope, dpopJKT string,
 	opts ...ExchangeOptions,
 ) (*TokenExchangeResult, error) {
 	if !s.Config.IsJWTAccessTokenFormat() {
@@ -73,6 +81,29 @@ func (s *Server) ExchangeSubjectToken(
 		return nil, err
 	}
 
+	var act *Actor
+	if actorToken != "" {
+		actor, err := s.validateExchangeActorToken(ctx, actorToken, actorTokenType, nil)
+		if err != nil {
+			return nil, err
+		}
+		if !s.actorDelegationAllowed(actor.Issuer, actor.Subject, identity.Issuer, identity.Subject) {
+			s.Auditor.LogEvent(ctx, security.Event{
+				Type:   security.EventAuthFailure,
+				UserID: identity.Subject,
+				Details: map[string]any{
+					"reason":     "actor_delegation_not_authorized",
+					"grant_type": GrantTypeTokenExchange,
+					"actor_sub":  actor.Subject,
+					"actor_iss":  actor.Issuer,
+					"sub":        identity.Subject,
+				},
+			})
+			return nil, fmt.Errorf("actor %q is not authorized to act for subject %q", actor.Subject, identity.Subject)
+		}
+		act = &Actor{Iss: actor.Issuer, Sub: actor.Subject}
+	}
+
 	grantedScope := grantedExchangeScope(scope, identity.AllowedScopes)
 
 	now := time.Now().UTC()
@@ -87,6 +118,17 @@ func (s *Server) ExchangeSubjectToken(
 		o = opts[0]
 	}
 
+	auditDetails := map[string]any{
+		"grant_type":         GrantTypeTokenExchange,
+		"subject_token_type": subjectTokenType,
+		"audience":           resource,
+		"scope":              grantedScope,
+	}
+	if act != nil {
+		auditDetails["actor_iss"] = act.Iss
+		auditDetails["actor_sub"] = act.Sub
+	}
+
 	tokenStr, err := s.accessTokenIssuer.Issue(ctx, AccessTokenClaims{
 		Subject:       identity.Subject,
 		Audience:      resource,
@@ -94,7 +136,7 @@ func (s *Server) ExchangeSubjectToken(
 		IssuedAt:      now,
 		ExpiresAt:     expiresAt,
 		JTI:           generateRandomToken(),
-		Act:           &Actor{Iss: identity.Issuer, Sub: identity.Subject},
+		Act:           act,
 		JKT:           dpopJKT,
 		Email:         o.Email,
 		EmailVerified: o.EmailVerified,
@@ -111,7 +153,6 @@ func (s *Server) ExchangeSubjectToken(
 				"grant_type":         GrantTypeTokenExchange,
 				"subject_token_type": subjectTokenType,
 				"audience":           resource,
-				"act_iss":            identity.Issuer,
 				"error":              err.Error(),
 			},
 		})
@@ -119,19 +160,13 @@ func (s *Server) ExchangeSubjectToken(
 	}
 
 	s.Logger.Debug("token exchange: issued token",
-		"sub", identity.Subject, "iss_act", identity.Issuer,
-		"aud", resource, "scope", grantedScope, "exp", expiresAt)
+		"sub", identity.Subject, "aud", resource, "scope", grantedScope, "exp", expiresAt,
+		"delegated", act != nil)
 
 	s.Auditor.LogEvent(ctx, security.Event{
-		Type:   security.EventTokenIssued,
-		UserID: identity.Subject,
-		Details: map[string]any{
-			"grant_type":         GrantTypeTokenExchange,
-			"subject_token_type": subjectTokenType,
-			"audience":           resource,
-			"scope":              grantedScope,
-			"act_iss":            identity.Issuer,
-		},
+		Type:    security.EventTokenIssued,
+		UserID:  identity.Subject,
+		Details: auditDetails,
 	})
 
 	return &TokenExchangeResult{

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -145,16 +145,12 @@ func (s *Server) ExchangeSubjectToken(
 		Extra:         o.Extra,
 	})
 	if err != nil {
+		auditDetails["reason"] = "access_token_issue_failed"
+		auditDetails["error"] = err.Error()
 		s.Auditor.LogEvent(ctx, security.Event{
-			Type:   security.EventAuthFailure,
-			UserID: identity.Subject,
-			Details: map[string]any{
-				"reason":             "access_token_issue_failed",
-				"grant_type":         GrantTypeTokenExchange,
-				"subject_token_type": subjectTokenType,
-				"audience":           resource,
-				"error":              err.Error(),
-			},
+			Type:    security.EventAuthFailure,
+			UserID:  identity.Subject,
+			Details: auditDetails,
 		})
 		return nil, fmt.Errorf("failed to issue exchange token: %w", err)
 	}

--- a/server/token_exchange_test.go
+++ b/server/token_exchange_test.go
@@ -68,6 +68,7 @@ func TestExchangeSubjectToken_IssuedToken(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -87,9 +88,7 @@ func TestExchangeSubjectToken_IssuedToken(t *testing.T) {
 
 	require.Equal(t, testSubject, standard.Subject)
 	require.Equal(t, josejwt.Audience{"https://api.example.com"}, standard.Audience)
-	require.NotNil(t, private.Act)
-	require.Equal(t, testIssuer, private.Act.Iss)
-	require.Equal(t, testSubject, private.Act.Sub)
+	require.Nil(t, private.Act, "act claim must be absent when no actor_token is provided")
 	require.Equal(t, "read", private.Scope)
 }
 
@@ -140,13 +139,13 @@ func TestExchangeSubjectToken_ScopeIntersection(t *testing.T) {
 	}
 
 	t.Run("requested scope within allowed", func(t *testing.T) {
-		result, err := srv.ExchangeSubjectToken(t.Context(), makeToken(), SubjectTokenTypeIDToken, "https://api.example.com", "read", "")
+		result, err := srv.ExchangeSubjectToken(t.Context(), makeToken(), SubjectTokenTypeIDToken, "", "", "https://api.example.com", "read", "")
 		require.NoError(t, err)
 		require.Equal(t, "read", result.Scope)
 	})
 
 	t.Run("requested scope outside allowed", func(t *testing.T) {
-		result, err := srv.ExchangeSubjectToken(t.Context(), makeToken(), SubjectTokenTypeIDToken, "https://api.example.com", "admin", "")
+		result, err := srv.ExchangeSubjectToken(t.Context(), makeToken(), SubjectTokenTypeIDToken, "", "", "https://api.example.com", "admin", "")
 		require.NoError(t, err)
 		// intersection of [admin] ∩ [read write] = empty
 		require.Equal(t, "", result.Scope)
@@ -197,7 +196,7 @@ func TestExchangeSubjectToken_NoAllowedScopes(t *testing.T) {
 		IssuedAt: josejwt.NewNumericDate(time.Now()),
 	})
 
-	result, err := srv.ExchangeSubjectToken(t.Context(), subjectToken, SubjectTokenTypeIDToken, "https://api.example.com", "read write admin", "")
+	result, err := srv.ExchangeSubjectToken(t.Context(), subjectToken, SubjectTokenTypeIDToken, "", "", "https://api.example.com", "read write admin", "")
 	require.NoError(t, err)
 	// Full requested scope granted when no per-issuer restriction.
 	scopes := strings.Fields(result.Scope)
@@ -225,7 +224,7 @@ func TestExchangeSubjectToken_UnknownTokenType(t *testing.T) {
 	require.NoError(t, err)
 	// No validators registered.
 
-	_, err = srv.ExchangeSubjectToken(t.Context(), "sometoken", "urn:ietf:params:oauth:token-type:saml2", "https://api.example.com", "", "")
+	_, err = srv.ExchangeSubjectToken(t.Context(), "sometoken", "urn:ietf:params:oauth:token-type:saml2", "", "", "https://api.example.com", "", "")
 	require.Error(t, err)
 
 	var unsupported *TokenExchangeUnsupportedTypeError
@@ -236,7 +235,7 @@ func TestExchangeSubjectToken_UnknownTokenType(t *testing.T) {
 func TestExchangeSubjectToken_RequiresJWTMode(t *testing.T) {
 	srv, _, _ := setupFlowTestServer(t) // opaque mode
 
-	_, err := srv.ExchangeSubjectToken(t.Context(), "tok", SubjectTokenTypeIDToken, "https://api.example.com", "", "")
+	_, err := srv.ExchangeSubjectToken(t.Context(), "tok", SubjectTokenTypeIDToken, "", "", "https://api.example.com", "", "")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "JWT access token mode")
 }
@@ -311,6 +310,7 @@ func TestExchangeSubjectToken_Audit_Success(t *testing.T) {
 		t.Context(),
 		makeAuditSubjectToken(t, key),
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -325,7 +325,6 @@ func TestExchangeSubjectToken_Audit_Success(t *testing.T) {
 		"audit event must carry grant_type so dashboards can split exchange issuances")
 	require.Contains(t, out, "https://api.example.com",
 		"audit event must record the audience")
-	require.Contains(t, out, "act_iss")
 }
 
 func TestExchangeSubjectToken_Audit_JWTModeRequired(t *testing.T) {
@@ -344,7 +343,7 @@ func TestExchangeSubjectToken_Audit_JWTModeRequired(t *testing.T) {
 	srv.Auditor = security.NewAuditor(logger, true)
 
 	_, err = srv.ExchangeSubjectToken(t.Context(), "tok", SubjectTokenTypeIDToken,
-		"https://api.example.com", "", "")
+		"", "", "https://api.example.com", "", "")
 	require.Error(t, err)
 
 	out := buf.String()
@@ -376,7 +375,7 @@ func TestExchangeSubjectToken_Audit_UnsupportedSubjectTokenType(t *testing.T) {
 
 	const badType = "urn:ietf:params:oauth:token-type:saml2"
 	_, err = srv.ExchangeSubjectToken(t.Context(), "tok", badType,
-		"https://api.example.com", "", "")
+		"", "", "https://api.example.com", "", "")
 	require.Error(t, err)
 	var unsupported *TokenExchangeUnsupportedTypeError
 	require.ErrorAs(t, err, &unsupported)
@@ -394,7 +393,7 @@ func TestExchangeSubjectToken_Audit_SubjectTokenValidationFailure(t *testing.T) 
 	srv, buf, _ := newAuditExchangeTestServer(t)
 
 	_, err := srv.ExchangeSubjectToken(t.Context(), "not-a-real-token",
-		SubjectTokenTypeIDToken, "https://api.example.com", "", "")
+		SubjectTokenTypeIDToken, "", "", "https://api.example.com", "", "")
 	require.Error(t, err)
 
 	out := buf.String()
@@ -410,7 +409,7 @@ func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure(t *testing.T) {
 	srv.accessTokenIssuer = failingAccessTokenIssuer{err: fmt.Errorf("signer down")}
 
 	_, err := srv.ExchangeSubjectToken(t.Context(), makeAuditSubjectToken(t, key),
-		SubjectTokenTypeIDToken, "https://api.example.com", "read", "")
+		SubjectTokenTypeIDToken, "", "", "https://api.example.com", "read", "")
 	require.Error(t, err)
 
 	out := buf.String()
@@ -418,8 +417,6 @@ func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure(t *testing.T) {
 		"missing access_token_issue_failed audit failure in: %s", out)
 	require.Contains(t, out, "https://api.example.com",
 		"audit event must record the audience on issuance failure")
-	require.Contains(t, out, "act_iss",
-		"audit event must record the upstream actor issuer on issuance failure")
 }
 
 func TestExchangeSubjectToken_DPoP(t *testing.T) {
@@ -474,6 +471,7 @@ func TestExchangeSubjectToken_DPoP(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		jkt,
@@ -546,6 +544,7 @@ func TestExchangeSubjectToken_WithIdentityClaims(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -569,7 +568,7 @@ func TestExchangeSubjectToken_WithIdentityClaims(t *testing.T) {
 	require.True(t, *private.EmailVerified)
 	require.Equal(t, "Klaus SRE Agent", private.Name)
 	require.Equal(t, []string{"klaus-sre", "machine"}, private.Groups)
-	require.NotNil(t, private.Act, "act claim must still be set after identity injection")
+	require.Nil(t, private.Act, "act claim must be absent when no actor_token is provided")
 }
 
 func TestExchangeSubjectToken_WithExtraClaims(t *testing.T) {
@@ -579,6 +578,7 @@ func TestExchangeSubjectToken_WithExtraClaims(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -608,6 +608,7 @@ func TestExchangeSubjectToken_NoOptions_BackwardCompat(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -633,6 +634,7 @@ func TestExchangeSubjectToken_EmailVerifiedFalseWithEmail(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -661,6 +663,7 @@ func TestExchangeSubjectToken_ExtraOverridesEmailVerified(t *testing.T) {
 		t.Context(),
 		subjectToken,
 		SubjectTokenTypeIDToken,
+		"", "",
 		"https://api.example.com",
 		"read",
 		"",
@@ -679,4 +682,92 @@ func TestExchangeSubjectToken_ExtraOverridesEmailVerified(t *testing.T) {
 	require.NoError(t, parsed.Claims(signingKey.Public(), &rawClaims))
 
 	require.Equal(t, true, rawClaims["email_verified"])
+}
+
+const actorIssuerURL = "https://actor.example.com"
+const actorTestSub = "agent-sa@cluster.example.com"
+
+// newActorExchangeServer builds a Server wired with a stubTokenValidator for
+// actor-delegation tests. The stub maps "sub-tok" → (testIssuer, testSubject)
+// and "act-tok" → (actorIssuerURL, actorTestSub) so no JWKS round-trip is
+// needed. policy is installed as ActorDelegationPolicy.
+func newActorExchangeServer(t *testing.T, policy []DelegationGrant) (srv *Server, signingKey *rsa.PrivateKey) {
+	t.Helper()
+	store := memory.New()
+	t.Cleanup(func() { store.Stop() })
+
+	signingKey = generateRSAKey(t)
+	cfg := &Config{
+		Issuer:                      "https://auth.example.com",
+		ResourceIdentifier:          "https://api.example.com",
+		SupportedScopes:             []string{"read"},
+		AccessTokenTTL:              600,
+		AccessTokenFormat:           AccessTokenFormatJWT,
+		AccessTokenSigningKey:       signingKey,
+		AccessTokenSigningKeyID:     "actor-test-kid",
+		AccessTokenSigningAlgorithm: SigningAlgorithmRS256,
+		DisableNonceEchoRequirement: true,
+		ActorDelegationPolicy:       policy,
+	}
+	srv, err := New(mock.NewProvider(), store, store, store, cfg, nil)
+	require.NoError(t, err)
+
+	// validateExchangeActorToken uses the same SubjectValidatorFor dispatch as
+	// the subject path, so both tokens must live under the same type key.
+	srv.subjectValidators = map[string]SubjectTokenValidator{
+		SubjectTokenTypeIDToken: &stubTokenValidator{
+			byToken: map[string]*SubjectIdentity{
+				"sub-tok": {Subject: testSubject, Issuer: testIssuer},
+				"act-tok": {Subject: actorTestSub, Issuer: actorIssuerURL},
+			},
+		},
+	}
+	return srv, signingKey
+}
+
+// TestExchangeSubjectToken_WithActor verifies that when a valid actor_token is
+// presented and an ActorDelegationPolicy permits the (actor, subject) pair, the
+// issued JWT carries act.sub = actor subject and act.iss = actor issuer.
+func TestExchangeSubjectToken_WithActor(t *testing.T) {
+	srv, signingKey := newActorExchangeServer(t, []DelegationGrant{
+		{ActorIssuer: actorIssuerURL, ActorSubject: "*", SubjectIssuer: testIssuer, SubjectSubject: "*"},
+	})
+
+	result, err := srv.ExchangeSubjectToken(
+		t.Context(),
+		"sub-tok", SubjectTokenTypeIDToken,
+		"act-tok", SubjectTokenTypeIDToken,
+		"https://api.example.com",
+		"read",
+		"",
+	)
+	require.NoError(t, err)
+
+	parsed, err := josejwt.ParseSigned(result.AccessToken, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var private rfc9068Claims
+	require.NoError(t, parsed.Claims(signingKey.Public(), &private))
+
+	require.Equal(t, testSubject, private.Subject)
+	require.NotNil(t, private.Act, "act claim must be set for delegated exchange")
+	require.Equal(t, actorIssuerURL, private.Act.Iss, "act.iss must be the actor token issuer")
+	require.Equal(t, actorTestSub, private.Act.Sub, "act.sub must be the agent SA subject")
+}
+
+// TestExchangeSubjectToken_ActorDeniedWhenNoPolicy verifies that presenting
+// an actor_token without an ActorDelegationPolicy entry is denied.
+func TestExchangeSubjectToken_ActorDeniedWhenNoPolicy(t *testing.T) {
+	srv, _ := newActorExchangeServer(t, nil)
+
+	_, err := srv.ExchangeSubjectToken(
+		t.Context(),
+		"sub-tok", SubjectTokenTypeIDToken,
+		"act-tok", SubjectTokenTypeIDToken,
+		"https://api.example.com",
+		"read",
+		"",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not authorized to act for subject")
 }

--- a/server/token_exchange_test.go
+++ b/server/token_exchange_test.go
@@ -419,6 +419,30 @@ func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure(t *testing.T) {
 		"audit event must record the audience on issuance failure")
 }
 
+func TestExchangeSubjectToken_Audit_AccessTokenIssueFailure_WithActor(t *testing.T) {
+	srv, _ := newActorExchangeServer(t, []DelegationGrant{
+		{ActorIssuer: actorIssuerURL, ActorSubject: "*", SubjectIssuer: testIssuer, SubjectSubject: "*"},
+	})
+
+	logger, buf := captureLogger()
+	srv.Auditor = security.NewAuditor(logger, true)
+	srv.accessTokenIssuer = failingAccessTokenIssuer{err: fmt.Errorf("signer down")}
+
+	_, err := srv.ExchangeSubjectToken(t.Context(),
+		"sub-tok", SubjectTokenTypeIDToken,
+		"act-tok", SubjectTokenTypeIDToken,
+		"https://api.example.com", "read", "")
+	require.Error(t, err)
+
+	out := buf.String()
+	require.True(t, containsAuthFailure(out, "access_token_issue_failed"),
+		"missing access_token_issue_failed audit failure in: %s", out)
+	require.Contains(t, out, actorIssuerURL,
+		"failure audit must record actor_iss for delegated exchange")
+	require.Contains(t, out, actorTestSub,
+		"failure audit must record actor_sub for delegated exchange")
+}
+
 func TestExchangeSubjectToken_DPoP(t *testing.T) {
 	key := newTestECKey(t)
 	const kid = "dpop-exchange-key"


### PR DESCRIPTION
## Summary

- `ExchangeSubjectToken` gains `actorToken`/`actorTokenType` parameters. When an actor token is present it is validated via the server's trusted-issuer validators, gated by `ActorDelegationPolicy`, and the actor identity is written as `act.{iss,sub}` in the issued JWT. No actor token → no `act` claim (removes the prior self-referential `act` that was set unconditionally).
- New `server.LocalMintExchanger` / `NewLocalMintExchanger`: an `Exchanger` implementation for broker-routed targets that mints a locally-signed JWT. Carries the `act` claim when `ExchangerRequest.Actor` is non-nil. Requires JWT access token mode.
- `oidc.IDTokenClaims` gains `Act *ActorClaim`, decoded automatically from the `act` JWT claim. `providers.UserInfo` gains `ActorIssuer string`, `ActorSubject string`, and `IsDelegated() bool`; `idTokenClaimsToUserInfo` populates them on the trusted-issuer validation path.
- `handler/token_exchange.go`: forward `actor_token`/`actor_token_type` from the HTTP form to the direct (no-audience) `ExchangeSubjectToken` call.

Closes #457.