### PR TITLE
feat(server): AcceptTrustedIssuerToken for TrustedIssuers-validated bearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `server.Server.AcceptTrustedIssuerToken(ctx, bearerToken)`: validates a Bearer JWT against the `WithTrustedIssuers` configuration and returns a `ForwardedIDTokenAcceptance` (same shape as `AcceptForwardedIDToken`, including the `ext-<hex>` session ID). Intended as a fallback for aggregators that receive `ErrTrustedAudienceMismatch` from `AcceptForwardedIDToken` — e.g. a raw Kubernetes ServiceAccount projected token whose `aud` is the server's own resource identifier rather than a `TrustedAudiences` entry.
+
 - `server.LocalMintExchanger` and `NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error)`: an `Exchanger` implementation that mints a signed JWT access token locally using the server's own RSA/EC key. Intended for broker-routed targets where the broker is the authoritative issuer. Requires JWT access token mode; returns an error otherwise.
 
 - `actor_token` / `actor_token_type` support on the direct token-exchange path (`ExchangeSubjectToken`): when an actor token is presented, it is validated against the server's trusted issuers and the resulting actor identity is written as the `act` claim of the issued JWT (`act.iss` = actor issuer, `act.sub` = actor subject). The `ActorDelegationPolicy` must explicitly permit the (actor, subject) pair; a nil or empty policy denies all delegated exchanges.

--- a/server/accept_trusted_issuer_token_test.go
+++ b/server/accept_trusted_issuer_token_test.go
@@ -1,0 +1,158 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+)
+
+// newSATrustedIssuerServer wires a Server with a TrustedIssuer entry that
+// accepts Kubernetes ServiceAccount-style tokens (no typ header, sub glob).
+func newSATrustedIssuerServer(t *testing.T) (srv *Server, signFn func(claims josejwt.Claims) string, resourceID string) {
+	t.Helper()
+
+	ecKey := newTestECKey(t)
+	const kid = "sa-key"
+	jwksURL, jwksClient := serveStaticJWKS(t, ecKey, kid)
+
+	srv, _, _ = setupFlowTestServer(t)
+	resourceID = srv.Config.GetResourceIdentifier()
+
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             "https://kubernetes.default.svc.cluster.local",
+		JwksURL:            jwksURL,
+		AllowedAudiences:   []string{resourceID},
+		AllowPrivateIPJWKS: true,
+		// Kubernetes SA tokens carry no typ header.
+		AcceptedTypHeaders: []string{""},
+	}}, jwksClient)
+	require.NoError(t, err)
+	srv.trustedIssuerValidator = v
+
+	signFn = func(claims josejwt.Claims) string {
+		t.Helper()
+		// Use signSubjectToken which omits the typ header (sets "JWT") —
+		// but for AcceptedTypHeaders: [""] we need NO typ header at all.
+		// Use the helper that supports a custom typ, passing empty string.
+		return signSubjectTokenWithType(t, ecKey, kid, "", claims)
+	}
+	return srv, signFn, resourceID
+}
+
+func saTokenClaims(issuer, sub, audience string) josejwt.Claims {
+	now := time.Now()
+	return josejwt.Claims{
+		Issuer:   issuer,
+		Subject:  sub,
+		Audience: josejwt.Audience{audience},
+		IssuedAt: josejwt.NewNumericDate(now),
+		Expiry:   josejwt.NewNumericDate(now.Add(time.Hour)),
+	}
+}
+
+func TestAcceptTrustedIssuerToken_HappyPath(t *testing.T) {
+	srv, sign, resourceID := newSATrustedIssuerServer(t)
+
+	const (
+		k8sIssuer = "https://kubernetes.default.svc.cluster.local"
+		sub       = "system:serviceaccount:ai-platform:my-svc"
+	)
+	tok := sign(saTokenClaims(k8sIssuer, sub, resourceID))
+
+	acc, err := srv.AcceptTrustedIssuerToken(context.Background(), tok)
+	require.NoError(t, err)
+	require.NotNil(t, acc)
+
+	require.Equal(t, sub, acc.Subject)
+	require.Equal(t, k8sIssuer, acc.Issuer)
+	require.Equal(t, resourceID, acc.Audience)
+	require.True(t, strings.HasPrefix(acc.SessionID, "ext-"), "SessionID must start with ext-")
+	require.Len(t, acc.SessionID, len("ext-")+16, "SessionID must be ext-<16 hex>")
+	require.False(t, acc.ExpiresAt.IsZero(), "ExpiresAt must be populated from JWT exp")
+
+	require.NotNil(t, acc.UserInfo)
+	require.Equal(t, sub, acc.UserInfo.ID)
+	require.Equal(t, k8sIssuer, acc.UserInfo.Issuer)
+	require.Equal(t, providers.TokenSourceTrustedIssuer, acc.UserInfo.TokenSource)
+	require.True(t, acc.UserInfo.IsExternalIssuer())
+	require.False(t, acc.UserInfo.IsSSO())
+	require.Empty(t, acc.UserInfo.Email, "SA tokens carry no email")
+}
+
+func TestAcceptTrustedIssuerToken_Determinism(t *testing.T) {
+	srv, sign, resourceID := newSATrustedIssuerServer(t)
+	tok := sign(saTokenClaims("https://kubernetes.default.svc.cluster.local", "system:serviceaccount:ns:sa", resourceID))
+
+	ctx := context.Background()
+	a1, err := srv.AcceptTrustedIssuerToken(ctx, tok)
+	require.NoError(t, err)
+	a2, err := srv.AcceptTrustedIssuerToken(ctx, tok)
+	require.NoError(t, err)
+
+	require.Equal(t, a1.SessionID, a2.SessionID, "SessionID must be deterministic for the same token")
+}
+
+func TestAcceptTrustedIssuerToken_SessionIDMatchesForwardedPath(t *testing.T) {
+	// The ext-<hex> derivation must be identical regardless of which Accept*
+	// method produced the acceptance, so an aggregator that receives the same
+	// bearer via different paths always correlates to the same session.
+	srv, sign, resourceID := newSATrustedIssuerServer(t)
+	tok := sign(saTokenClaims("https://kubernetes.default.svc.cluster.local", "system:serviceaccount:ns:sa", resourceID))
+
+	acc, err := srv.AcceptTrustedIssuerToken(context.Background(), tok)
+	require.NoError(t, err)
+
+	expected := srv.deriveForwardedSessionID(tok)
+	require.Equal(t, expected, acc.SessionID)
+}
+
+func TestAcceptTrustedIssuerToken_NilValidator(t *testing.T) {
+	srv, _, _ := setupFlowTestServer(t)
+	// trustedIssuerValidator is nil by default — no WithTrustedIssuers configured.
+
+	_, err := srv.AcceptTrustedIssuerToken(context.Background(), "any.token.value")
+	require.ErrorIs(t, err, ErrIssuerNotTrusted)
+}
+
+func TestAcceptTrustedIssuerToken_UntrustedIssuer(t *testing.T) {
+	srv, sign, resourceID := newSATrustedIssuerServer(t)
+	// Token issued by an issuer not in the configured set.
+	tok := sign(saTokenClaims("https://other.issuer.example", "system:serviceaccount:ns:sa", resourceID))
+
+	_, err := srv.AcceptTrustedIssuerToken(context.Background(), tok)
+	require.ErrorIs(t, err, ErrIssuerNotTrusted)
+}
+
+func TestAcceptTrustedIssuerToken_ExpiredToken(t *testing.T) {
+	srv, sign, resourceID := newSATrustedIssuerServer(t)
+
+	past := time.Now().Add(-2 * time.Hour)
+	claims := josejwt.Claims{
+		Issuer:   "https://kubernetes.default.svc.cluster.local",
+		Subject:  "system:serviceaccount:ns:sa",
+		Audience: josejwt.Audience{resourceID},
+		IssuedAt: josejwt.NewNumericDate(past),
+		Expiry:   josejwt.NewNumericDate(past.Add(time.Hour)), // expired an hour ago
+	}
+	tok := sign(claims)
+
+	_, err := srv.AcceptTrustedIssuerToken(context.Background(), tok)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, oidc.ErrTokenExpired), "want ErrTokenExpired, got: %v", err)
+}
+
+func TestAcceptTrustedIssuerToken_EmptyToken(t *testing.T) {
+	srv, _, _ := newSATrustedIssuerServer(t)
+
+	_, err := srv.AcceptTrustedIssuerToken(context.Background(), "")
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrIssuerNotTrusted), "empty token should not return ErrIssuerNotTrusted")
+}

--- a/server/forwarded.go
+++ b/server/forwarded.go
@@ -191,6 +191,76 @@ func (s *Server) AcceptForwardedIDToken(ctx context.Context, bearerToken string)
 	return acceptance, nil
 }
 
+// AcceptTrustedIssuerToken validates a Bearer JWT against the server's
+// WithTrustedIssuers configuration and returns a [ForwardedIDTokenAcceptance]
+// identical in shape to [AcceptForwardedIDToken]. This lets aggregators treat a
+// raw TrustedIssuers-validated token (e.g. a Kubernetes ServiceAccount projected
+// token) as a forwarded credential — the same ext-<hex> session-ID derivation
+// applies, so cross-hop audit-log correlation is preserved.
+//
+// Intended call pattern: an aggregator first calls [AcceptForwardedIDToken]; when
+// that returns [ErrTrustedAudienceMismatch] (the token's aud is the server's own
+// resource identifier, not a TrustedAudiences entry), it falls back here.
+//
+// Preconditions:
+//
+//  1. WithTrustedIssuers must be configured; otherwise [ErrIssuerNotTrusted] is
+//     returned and the caller should fall through.
+//  2. The token's iss must match a configured [TrustedIssuer] entry.
+//  3. Audience and AllowedClaims checks for that entry pass.
+//  4. The typ header matches [TrustedIssuer.AcceptedTypHeaders] (empty string ""
+//     is needed for Kubernetes ServiceAccount tokens, which carry no typ header).
+//
+// Returns [ErrIssuerNotTrusted] when no TrustedIssuers validator is configured or
+// the token's iss is not recognised. Other errors (signature invalid, audience
+// rejected, AllowedClaims mismatch, typ mismatch, JWT expired) are returned wrapped.
+func (s *Server) AcceptTrustedIssuerToken(ctx context.Context, bearerToken string) (*ForwardedIDTokenAcceptance, error) {
+	if s.trustedIssuerValidator == nil {
+		return nil, ErrIssuerNotTrusted
+	}
+	if bearerToken == "" {
+		return nil, errors.New("trusted issuer token must not be empty")
+	}
+
+	identity, err := s.trustedIssuerValidator.Validate(ctx, bearerToken, []string{s.Config.GetResourceIdentifier()})
+	if errors.Is(err, ErrIssuerNotTrusted) {
+		return nil, ErrIssuerNotTrusted
+	}
+	if err != nil {
+		s.Auditor.LogAuthFailure(ctx, "", "", "", "trusted_issuer_token_invalid")
+		return nil, fmt.Errorf("trusted issuer token validation failed: %w", err)
+	}
+
+	if err := checkTypeHeader(bearerToken, s.trustedIssuerValidator.BearerTypHeaders(identity.Issuer)); err != nil {
+		s.Auditor.LogAuthFailure(ctx, identity.Subject, "", "", "trusted_issuer_typ_invalid")
+		return nil, fmt.Errorf("trusted issuer token: %w", err)
+	}
+
+	userInfo := s.idTokenClaimsToUserInfo(identity.Claims)
+	userInfo.Issuer = identity.Issuer
+	userInfo.TokenSource = providers.TokenSourceTrustedIssuer
+
+	var expiresAt time.Time
+	if identity.Claims != nil && identity.Claims.Expiry != nil {
+		expiresAt = identity.Claims.Expiry.Time()
+	}
+
+	resourceID := s.Config.GetResourceIdentifier()
+	acceptance := &ForwardedIDTokenAcceptance{
+		SessionID: s.deriveForwardedSessionID(bearerToken),
+		Subject:   identity.Subject,
+		UserInfo:  userInfo,
+		Issuer:    identity.Issuer,
+		Audience:  resourceID,
+		ExpiresAt: expiresAt,
+	}
+
+	s.logTrustedIssuerJWTAccepted(ctx, bearerToken, identity.Issuer, userInfo)
+	s.recordForwardedIDTokenAccepted(ctx, identity.Issuer, identity.Issuer, resourceID, instrumentation.ForwardedIDTokenResultOK)
+
+	return acceptance, nil
+}
+
 // deriveForwardedSessionID produces the deterministic "ext-<hex>" session
 // identifier. See the SessionID field godoc and docs/security.md for the
 // correlation property and the SessionIDHMACKey operator caveat.


### PR DESCRIPTION
## What

Add `server.Server.AcceptTrustedIssuerToken(ctx, bearerToken)` — a companion to `AcceptForwardedIDToken` for the `WithTrustedIssuers` validation path.

`AcceptForwardedIDToken` handles Dex-forwarded ID tokens (validated against `TrustedAudiences`). A raw Kubernetes ServiceAccount projected token takes the `TrustedIssuers` path instead: its `aud` is the server's own resource identifier, not a `TrustedAudiences` entry, so `AcceptForwardedIDToken` returns `ErrTrustedAudienceMismatch`. Aggregators need a way to accept such tokens without reimplementing the validation logic.

`AcceptTrustedIssuerToken` uses the same `trustedIssuerValidator.Validate()` call as `validateTrustedIssuerJWT` in `ValidateToken`, runs the per-issuer typ-header check, and returns a `ForwardedIDTokenAcceptance` with:
- the same `ext-<hex>` session ID (cross-hop audit correlation preserved)
- `UserInfo.TokenSource = TokenSourceTrustedIssuer` and `UserInfo.Issuer` set (distinguishable from a Dex-forwarded `TokenSourceSSO` token)
- `Audience` set to the server's resource identifier (the matched default audience for TrustedIssuers)

Intended call pattern:
```go
acc, err := srv.AcceptForwardedIDToken(ctx, bearer)
if errors.Is(err, ErrTrustedAudienceMismatch) {
    acc, err = srv.AcceptTrustedIssuerToken(ctx, bearer)
}
```

## Why

Unblocks muster issue [#805](https://github.com/giantswarm/muster/issues/805) Issue 3: a raw SA token validated via `trustedIssuers` in muster cannot currently drive per-target RFC 8693 token exchange because the bearer is never injected as the subject token. The muster fix (in flight) uses this method to close that gap.