### PR TITLE
feat(server): per-issuer SubjectClaim to source the canonical subject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `server.TrustedIssuer.SubjectClaim string`: names the verified claim whose value becomes `SubjectIdentity.Subject` (and thus the `sub` of any token minted from the identity, and the value matched by `ActorDelegationPolicy`). Empty keeps the standard `sub` claim. Use it when an issuer's `sub` is opaque but another claim (e.g. `email`) carries the canonical subject the downstream relies on. Fail-closed: a token whose configured claim is absent or not a non-empty string is rejected.
+
 - `server.Server.AcceptTrustedIssuerToken(ctx, bearerToken)`: validates a Bearer JWT against the `WithTrustedIssuers` configuration and returns a `ForwardedIDTokenAcceptance` (same shape as `AcceptForwardedIDToken`, including the `ext-<hex>` session ID). Intended as a fallback for aggregators that receive `ErrTrustedAudienceMismatch` from `AcceptForwardedIDToken` — e.g. a raw Kubernetes ServiceAccount projected token whose `aud` is the server's own resource identifier rather than a `TrustedAudiences` entry.
 
 - `server.LocalMintExchanger` and `NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error)`: an `Exchanger` implementation that mints a signed JWT access token locally using the server's own RSA/EC key. Intended for broker-routed targets where the broker is the authoritative issuer. Requires JWT access token mode; returns an error otherwise.

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -58,6 +58,14 @@ type TrustedIssuer struct {
 	// (numbers, arrays, objects) are rejected. Nil or empty means no claim
 	// restrictions.
 	AllowedClaims map[string]string
+	// SubjectClaim names the verified claim whose value becomes
+	// SubjectIdentity.Subject (and thus the sub of any token minted from this
+	// identity, and the value matched by ActorDelegationPolicy). Empty keeps the
+	// standard sub claim. Use this when the issuer's sub is an opaque identifier
+	// but a different claim (e.g. "email") carries the canonical subject the
+	// downstream relies on. Fail-closed: if set and the claim is absent or not a
+	// non-empty string, the token is rejected.
+	SubjectClaim string
 	// AllowPrivateIPJWKS allows JwksURL to resolve to a private or loopback IP
 	// address. Set this when the JWKS endpoint is an in-cluster service (e.g.
 	// the Kubernetes API server's /openid/v1/jwks) that is not reachable via a
@@ -175,8 +183,19 @@ func (v *OIDCValidator) Validate(ctx context.Context, tokenString string, defaul
 		return nil, err
 	}
 
+	// rawClaims is authentic here: ValidateIDToken verified the signature over
+	// the same token, so reading an additional claim from it is sound.
+	subject := claims.Subject
+	if ti.SubjectClaim != "" {
+		mapped, ok := rawClaims[ti.SubjectClaim].(string)
+		if !ok || mapped == "" {
+			return nil, fmt.Errorf("subjectClaim %q: not present as a non-empty string", ti.SubjectClaim)
+		}
+		subject = mapped
+	}
+
 	return &SubjectIdentity{
-		Subject:       claims.Subject,
+		Subject:       subject,
 		Issuer:        claims.Issuer,
 		AllowedScopes: ti.AllowedScopes,
 		Claims:        claims,

--- a/server/subject_validator_test.go
+++ b/server/subject_validator_test.go
@@ -380,6 +380,105 @@ func TestOIDCValidator_AllowedClaims_NonStringValue(t *testing.T) {
 	require.Contains(t, err.Error(), "non-string type")
 }
 
+func TestOIDCValidator_SubjectClaim(t *testing.T) {
+	key := newTestECKey(t)
+	const kid = "test-key-1"
+	jwksURL, jwksClient := serveStaticJWKS(t, key, kid)
+
+	const opaqueSub = "CgcweDEyMzQ1Eg"
+	const email = "alice@giantswarm.io"
+
+	signingKey := jose.SigningKey{
+		Algorithm: jose.ES256,
+		Key: jose.JSONWebKey{
+			Key:       key,
+			KeyID:     kid,
+			Algorithm: string(jose.ES256),
+			Use:       "sig",
+		},
+	}
+
+	makeToken := func(t *testing.T, extra map[string]any) string {
+		t.Helper()
+		opts := &jose.SignerOptions{}
+		opts.WithType("JWT")
+		opts.WithHeader(jose.HeaderKey("kid"), kid)
+		signer, err := jose.NewSigner(signingKey, opts)
+		require.NoError(t, err)
+		b := josejwt.Signed(signer).Claims(josejwt.Claims{
+			Issuer:   testIssuer,
+			Subject:  opaqueSub,
+			Audience: josejwt.Audience{testAudience},
+			Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+			IssuedAt: josejwt.NewNumericDate(time.Now()),
+		})
+		if extra != nil {
+			b = b.Claims(extra)
+		}
+		token, err := b.Serialize()
+		require.NoError(t, err)
+		return token
+	}
+
+	t.Run("maps subject from configured claim", func(t *testing.T) {
+		v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+			Issuer:           testIssuer,
+			JwksURL:          jwksURL,
+			AllowedAudiences: []string{testAudience},
+			SubjectClaim:     "email",
+		}}, jwksClient)
+		require.NoError(t, err)
+
+		identity, err := v.Validate(t.Context(), makeToken(t, map[string]any{"email": email}), nil)
+		require.NoError(t, err)
+		require.Equal(t, email, identity.Subject)
+	})
+
+	t.Run("unset keeps the sub claim", func(t *testing.T) {
+		v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+			Issuer:           testIssuer,
+			JwksURL:          jwksURL,
+			AllowedAudiences: []string{testAudience},
+		}}, jwksClient)
+		require.NoError(t, err)
+
+		identity, err := v.Validate(t.Context(), makeToken(t, map[string]any{"email": email}), nil)
+		require.NoError(t, err)
+		require.Equal(t, opaqueSub, identity.Subject)
+	})
+
+	t.Run("absent mapped claim is rejected", func(t *testing.T) {
+		v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+			Issuer:           testIssuer,
+			JwksURL:          jwksURL,
+			AllowedAudiences: []string{testAudience},
+			SubjectClaim:     "email",
+		}}, jwksClient)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), makeToken(t, nil), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "subjectClaim")
+	})
+
+	t.Run("non-string mapped claim is rejected", func(t *testing.T) {
+		// A custom (non-typed) claim name reaches the SubjectClaim check; a
+		// non-string value of a typed claim like email is already rejected by
+		// ValidateIDToken's typed unmarshalling.
+		v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+			Issuer:           testIssuer,
+			JwksURL:          jwksURL,
+			AllowedAudiences: []string{testAudience},
+			SubjectClaim:     "custom_sub",
+		}}, jwksClient)
+		require.NoError(t, err)
+
+		_, err = v.Validate(t.Context(), makeToken(t, map[string]any{"custom_sub": 42}), nil)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "subjectClaim")
+	})
+}
+
 func TestWithTrustedIssuers_RegistersValidators(t *testing.T) {
 	key := newTestECKey(t)
 	const kid = "test-key-1"


### PR DESCRIPTION
## What

Adds `TrustedIssuer.SubjectClaim string`. When set, `OIDCValidator.Validate` sources `SubjectIdentity.Subject` from that verified claim instead of the token's `sub`. Empty keeps current behaviour (`sub` unchanged).

`SubjectIdentity.Subject` is what becomes the `sub` of any token minted from the identity and the value matched by `ActorDelegationPolicy`, so this lets a deployment key its subject on a non-`sub` claim.

## Why

Dex issues an opaque `sub` (e.g. `Cgc…`), but downstreams that impersonate on the user's email and trust `sub=*@giantswarm.io` need the email as the canonical subject. Without this, an OBO token minted from a Dex subject token carries the opaque id and is rejected by `subjectSubject=*@giantswarm.io` in the delegation policy. Setting `subjectClaim: email` on the Dex `TrustedIssuer` fixes the human path.

## Behaviour

- The mapped claim is read from the post-verification claims (signature already checked by `ValidateIDToken`, same precedent as `AllowedClaims`).
- Fail-closed: if `SubjectClaim` is set and the claim is absent or not a non-empty string, the token is rejected.

## Tests

`TestOIDCValidator_SubjectClaim`: mapped subject, unset (unchanged), absent claim rejected, non-string claim rejected. Full `./server/` suite green.