### PR TITLE
feat(local-mint): emit identity claims, nest actor chains, harden broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `providers.UserInfo.IsDelegated() bool`: reports whether the token represents a delegated exchange; true when `ActorSubject` is non-empty.
 
-- `oidc.IDTokenClaims.Act *oidc.ActorClaim` and `oidc.ActorClaim` (`Issuer string`, `Subject string`): decoded automatically from the `act` claim of a JWT when present.
+- `oidc.IDTokenClaims.Act *oidc.ActorClaim` and `oidc.ActorClaim` (`Issuer string`, `Subject string`, `Act *oidc.ActorClaim`): decoded automatically from the `act` claim of a JWT when present. The nested `Act` field carries a multi-hop RFC 8693 §4.4 delegation chain (`act.act…`); `oidc.ActorClaim.Chain()` flattens it to a slice ordered from the outermost (most recent) actor to the innermost.
+
+- `providers.UserInfo.ActorChain []oidc.ActorClaim`: the full delegation chain decoded from the `act` claim, outermost first; `ActorIssuer`/`ActorSubject` mirror its first element. Resource servers authorizing a multi-hop A2A call walk this slice to match any actor in the chain, not only the leaf.
+
+- `LocalMintExchanger` now copies `email`, `email_verified`, and `groups` from the validated subject token into the minted access token (`email_verified` only alongside a non-empty `email`), and nests any `act` chain already on the subject token beneath the new actor so a multi-hop A2A delegation chain is preserved. A chain exceeding the maximum nesting depth is rejected.
+
+- `server.Actor.Act *server.Actor`: nests the prior actor when minting a token for a further delegation hop.
+
+- `server.ExchangerResult.JTI string`: lets an `Exchanger` surface the issued token's `jti` so the broker records it in the mint audit event; the broker's `token_issued` event now carries a `jti` detail when set.
 
 - `providers.TokenSourceTrustedIssuer` (`"trusted-issuer"`) constant and `UserInfo.IsExternalIssuer() bool` method. A Bearer validated against a `WithTrustedIssuers` entry is now tagged with this source instead of `TokenSourceSSO`, so downstream servers can distinguish an external-IdP token (requires impersonation or token-exchange) from a Dex-forwarded SSO token (can be passed through as a bearer).
 
@@ -68,6 +76,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Subject and actor token validation failures in the brokered flow produced audit events without `client_id`, `audience`, or `session_id`.** The early-rejection paths (no exchanger, audience not in allowlist) already carried those fields; validation failures did not. `validateExchangeToken` now accepts an extra-details map; `BrokerExchangeSubjectToken` passes the brokered flow context so every brokered failure event is fully correlated.
 
 - **Stale issuer JWKS broke every token after an issuer signing-key rotation.** `oidc.JWKSClient` cached a trusted issuer's JWKS for the full TTL (1h) and never refetched when a token presented a `kid` absent from the cached set, so a single Dex key rotation made `ValidateIDToken` (and therefore the token-exchange broker's subject-token validation) reject **every** current user token until the process was restarted ([muster#847](https://github.com/giantswarm/muster/issues/847)). The client now forces a single bounded refetch on an unknown `kid` and retries verification once. The refetch is rate-limited to at most one network fetch per `DefaultJWKSRefetchBackoff` (1m) per JWKS URI (negative caching), so a flood of tokens carrying genuinely bogus kids cannot hammer the issuer's JWKS endpoint. A legitimate rotation now self-heals on the first affected token without a restart. New exported sentinel `oidc.ErrKeyNotFound`.
+
+### Security
+
+- **Federation-escalation guard on the workload token-exchange path.** A token this broker minted that already carries an `act` claim can no longer be re-exchanged on the impersonation path (no `actor_token`). Doing so would re-authorize the token on its minted human `sub` and drop the acting principal recorded in `act`. Such a token may only be re-exchanged with a fresh `actor_token` (the delegation path), which re-evaluates `ActorDelegationPolicy` and `WorkloadAudiences` against that actor. The rejection emits an `auth_failure` audit event with reason `self_minted_delegated_token_impersonation`.
+
+- **Minted actor chains are bounded.** `LocalMintExchanger` rejects an `act` chain deeper than 10 hops, capping token size and parser load on every downstream that validates the token.
 
 ## [0.2.199] - 2026-06-10
 

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -361,9 +361,26 @@ func GetAudienceFromClaims(claims map[string]any) []string {
 // mcp-oauth-minted access token. It identifies the acting party in a
 // delegation chain: Issuer and Subject correspond to the agent service account
 // that obtained the token on behalf of the human subject.
+//
+// Act carries the next hop further from the subject (RFC 8693 §4.4 nested act):
+// in a multi-hop A2A chain human → agentA → agentB, a token minted for the
+// second hop has Act = agentB and Act.Act = agentA. Nil at the end of the chain.
 type ActorClaim struct {
-	Issuer  string `json:"iss,omitempty"`
-	Subject string `json:"sub,omitempty"`
+	Issuer  string      `json:"iss,omitempty"`
+	Subject string      `json:"sub,omitempty"`
+	Act     *ActorClaim `json:"act,omitempty"`
+}
+
+// Chain flattens a nested act claim into a slice ordered from the outermost
+// (most recent) actor to the innermost, each element stripped of its own nested
+// Act. Returns nil for a nil receiver. Resource servers authorizing a multi-hop
+// delegation match any element rather than only the leaf.
+func (c *ActorClaim) Chain() []ActorClaim {
+	var chain []ActorClaim
+	for a := c; a != nil; a = a.Act {
+		chain = append(chain, ActorClaim{Issuer: a.Issuer, Subject: a.Subject})
+	}
+	return chain
 }
 
 // IDTokenClaims represents the standard claims in an OIDC ID token. The

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -6,6 +6,8 @@ import (
 	"context"
 
 	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
 
 // AuthorizationURLOptions contains optional OIDC parameters for the authorization request.
@@ -229,6 +231,14 @@ type UserInfo struct {
 	// only when the token was minted via a delegated token exchange with a
 	// validated actor_token. Use IsDelegated() as a presence check.
 	ActorSubject string
+
+	// ActorChain is the full RFC 8693 §4.4 delegation chain decoded from the
+	// act claim, ordered outermost (most recent actor) first; ActorIssuer and
+	// ActorSubject mirror its first element. Empty for tokens without
+	// delegation. Resource servers authorizing a multi-hop A2A call (human →
+	// agentA → agentB → backend) walk this slice to match any actor in the
+	// chain rather than only the leaf.
+	ActorChain []oidc.ActorClaim
 }
 
 // IsSSO returns true if this user was authenticated via SSO token forwarding.

--- a/server/access_token.go
+++ b/server/access_token.go
@@ -93,9 +93,13 @@ type AccessTokenClaims struct {
 }
 
 // Actor is the RFC 8693 §4.4 act claim: the acting party in a delegation chain.
+// Act nests the prior actor so a multi-hop A2A chain (human → agentA → agentB)
+// is preserved: the outermost Act is the most recent actor, Act.Act the one
+// before it. Nil at the end of the chain.
 type Actor struct {
 	Iss string `json:"iss,omitempty"`
 	Sub string `json:"sub,omitempty"`
+	Act *Actor `json:"act,omitempty"`
 }
 
 // Confirmation is the RFC 9449 §6.1 cnf claim: proof-of-possession key binding.

--- a/server/local_mint_exchanger.go
+++ b/server/local_mint_exchanger.go
@@ -5,7 +5,15 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
+
+// maxActorChainDepth bounds RFC 8693 §4.4 act nesting in a minted token. A
+// chain deeper than this is rejected fail-closed: real A2A topologies are
+// shallow, and unbounded nesting is an abuse vector (token-size blowup and
+// parser pressure on every downstream that validates the token).
+const maxActorChainDepth = 10
 
 // LocalMintExchanger implements Exchanger by minting an mcp-oauth-signed JWT
 // access token locally, without delegating to a downstream issuer. It is the
@@ -48,7 +56,12 @@ func NewLocalMintExchanger(cfg *Config) (*LocalMintExchanger, error) {
 // Exchange mints a signed JWT access token for the request. The issued token
 // carries:
 //   - sub = req.Subject.Subject (human subject)
-//   - act = {iss: req.Actor.Issuer, sub: req.Actor.Subject} when req.Actor != nil
+//   - act = {iss: req.Actor.Issuer, sub: req.Actor.Subject} when req.Actor != nil,
+//     with any act chain already on the subject token nested beneath it so a
+//     multi-hop A2A delegation chain is preserved (RFC 8693 §4.4)
+//   - email / email_verified / groups copied from the validated subject token
+//     (req.Subject.Claims) so downstreams can authorize and attribute without
+//     an extra IdP round-trip; email_verified is only emitted alongside email
 //   - aud = req.Resource when non-empty, else req.Audience
 //   - scope = intersection of req.Scope and req.Subject.AllowedScopes
 //   - iss = the Issuer URL from the Config used to build LocalMintExchanger
@@ -56,9 +69,10 @@ func (l *LocalMintExchanger) Exchange(ctx context.Context, req *ExchangerRequest
 	if req.Subject == nil {
 		return nil, fmt.Errorf("local mint: ExchangerRequest.Subject must not be nil")
 	}
-	var act *Actor
-	if req.Actor != nil {
-		act = &Actor{Iss: req.Actor.Issuer, Sub: req.Actor.Subject}
+
+	act, err := buildActorChain(req.Actor, priorActorChain(req.Subject))
+	if err != nil {
+		return nil, fmt.Errorf("local mint: %w", err)
 	}
 
 	audience := req.Resource
@@ -70,16 +84,24 @@ func (l *LocalMintExchanger) Exchange(ctx context.Context, req *ExchangerRequest
 
 	now := time.Now().UTC()
 	expiresAt := now.Add(l.ttl)
+	jti := generateRandomToken()
 
-	tokenStr, err := l.issuer.Issue(ctx, AccessTokenClaims{
+	claims := AccessTokenClaims{
 		Subject:   req.Subject.Subject,
 		Audience:  audience,
 		Scopes:    strings.Fields(grantedScope),
 		IssuedAt:  now,
 		ExpiresAt: expiresAt,
-		JTI:       generateRandomToken(),
+		JTI:       jti,
 		Act:       act,
-	})
+	}
+	if identity := req.Subject.Claims; identity != nil {
+		claims.Email = identity.Email
+		claims.EmailVerified = identity.EmailVerified
+		claims.Groups = identity.Groups
+	}
+
+	tokenStr, err := l.issuer.Issue(ctx, claims)
 	if err != nil {
 		return nil, fmt.Errorf("local mint: issue token: %w", err)
 	}
@@ -89,5 +111,50 @@ func (l *LocalMintExchanger) Exchange(ctx context.Context, req *ExchangerRequest
 		ExpiresAt:       expiresAt,
 		Scope:           grantedScope,
 		IssuedTokenType: SubjectTokenTypeAccessToken,
+		JTI:             jti,
 	}, nil
+}
+
+// priorActorChain returns the act chain already present on the validated subject
+// token, converted to the mint-side Actor shape. Nil when the subject carries no
+// act (the common single-hop OBO case).
+func priorActorChain(subject *SubjectIdentity) *Actor {
+	if subject == nil || subject.Claims == nil {
+		return nil
+	}
+	return actorFromClaim(subject.Claims.Act)
+}
+
+// actorFromClaim recursively converts a decoded oidc.ActorClaim chain into the
+// mint-side Actor shape, preserving nesting order.
+func actorFromClaim(c *oidc.ActorClaim) *Actor {
+	if c == nil {
+		return nil
+	}
+	return &Actor{Iss: c.Issuer, Sub: c.Subject, Act: actorFromClaim(c.Act)}
+}
+
+// buildActorChain assembles the act claim for a minted token. When actor is
+// non-nil it becomes the outermost (most recent) actor and prior is nested
+// beneath it, extending a multi-hop delegation chain. When actor is nil the
+// prior chain is carried forward unchanged. The combined depth is bounded by
+// maxActorChainDepth and rejected fail-closed when exceeded.
+func buildActorChain(actor *SubjectIdentity, prior *Actor) (*Actor, error) {
+	act := prior
+	if actor != nil {
+		act = &Actor{Iss: actor.Issuer, Sub: actor.Subject, Act: prior}
+	}
+	if depth := actorChainDepth(act); depth > maxActorChainDepth {
+		return nil, fmt.Errorf("actor chain depth %d exceeds maximum %d", depth, maxActorChainDepth)
+	}
+	return act, nil
+}
+
+// actorChainDepth counts the hops in an act chain.
+func actorChainDepth(a *Actor) int {
+	n := 0
+	for ; a != nil; a = a.Act {
+		n++
+	}
+	return n
 }

--- a/server/local_mint_exchanger_test.go
+++ b/server/local_mint_exchanger_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"crypto/rsa"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +17,14 @@ import (
 	"github.com/giantswarm/mcp-oauth/providers/oidc"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
+
+// parseMintedClaims verifies the minted token's signature and decodes its claims.
+func parseMintedClaims(t *testing.T, token string, signingKey *rsa.PrivateKey, out any) {
+	t.Helper()
+	parsed, err := josejwt.ParseSigned(token, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+	require.NoError(t, parsed.Claims(signingKey.Public(), out))
+}
 
 // localMintCfg returns a JWT-mode Config and its RSA signing key for LocalMintExchanger tests.
 func localMintCfg(t *testing.T) (*Config, *rsa.PrivateKey) {
@@ -211,4 +220,229 @@ func TestLocalMintExchanger_RoundTrip_IsDelegated(t *testing.T) {
 	require.True(t, userInfo.IsDelegated(), "IsDelegated must be true for OBO token")
 	require.Equal(t, actorSub, userInfo.ActorSubject)
 	require.Equal(t, actorIss, userInfo.ActorIssuer)
+}
+
+// TestLocalMintExchanger_Exchange_EmitsIdentityClaims asserts the validated
+// subject's email/email_verified/groups are copied into the minted token so
+// downstreams can authorize and attribute without an extra IdP round-trip, and
+// that the issued jti is surfaced on the result for the mint audit record.
+func TestLocalMintExchanger_Exchange_EmitsIdentityClaims(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Scope:    "read",
+		Subject: &SubjectIdentity{
+			Subject:       "user@example.com",
+			Issuer:        testIssuer,
+			AllowedScopes: []string{"read"},
+			Claims: &oidc.IDTokenClaims{
+				Email:         "user@example.com",
+				EmailVerified: true,
+				Groups:        []string{"customer:Panamax_User", "customer:sre"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.JTI)
+
+	var claims rfc9068Claims
+	parseMintedClaims(t, result.AccessToken, signingKey, &claims)
+
+	require.Equal(t, "user@example.com", claims.Email)
+	require.NotNil(t, claims.EmailVerified)
+	require.True(t, *claims.EmailVerified)
+	require.Equal(t, []string{"customer:Panamax_User", "customer:sre"}, claims.Groups)
+	require.Equal(t, claims.ID, result.JTI, "surfaced JTI must equal the token's jti claim")
+}
+
+// TestLocalMintExchanger_Exchange_NoIdentityClaimsWithoutSubjectClaims asserts a
+// subject token without decoded Claims yields no email/groups on the mint, and
+// that email_verified is never emitted without an email.
+func TestLocalMintExchanger_Exchange_NoIdentityClaimsWithoutSubjectClaims(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Subject:  &SubjectIdentity{Subject: "user@example.com", Issuer: testIssuer},
+	})
+	require.NoError(t, err)
+
+	var claims rfc9068Claims
+	parseMintedClaims(t, result.AccessToken, signingKey, &claims)
+
+	require.Empty(t, claims.Email)
+	require.Nil(t, claims.EmailVerified)
+	require.Empty(t, claims.Groups)
+}
+
+// TestLocalMintExchanger_Exchange_NestsPriorActorChain asserts a second-hop mint
+// nests the actor already on the subject token (RFC 8693 §4.4) instead of
+// overwriting it, so a multi-hop A2A chain is preserved.
+func TestLocalMintExchanger_Exchange_NestsPriorActorChain(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Subject: &SubjectIdentity{
+			Subject: "user@example.com",
+			Issuer:  testIssuer,
+			Claims: &oidc.IDTokenClaims{
+				Act: &oidc.ActorClaim{Issuer: "https://k8s.example.com", Subject: "agentA"},
+			},
+		},
+		Actor: &SubjectIdentity{Issuer: "https://k8s.example.com", Subject: "agentB"},
+	})
+	require.NoError(t, err)
+
+	var claims rfc9068Claims
+	parseMintedClaims(t, result.AccessToken, signingKey, &claims)
+
+	require.Equal(t, "user@example.com", claims.Subject)
+	require.NotNil(t, claims.Act)
+	require.Equal(t, "agentB", claims.Act.Sub, "outermost act is the most recent actor")
+	require.NotNil(t, claims.Act.Act)
+	require.Equal(t, "agentA", claims.Act.Act.Sub, "prior actor nested beneath the new one")
+	require.Nil(t, claims.Act.Act.Act, "chain ends at the first hop")
+}
+
+// TestLocalMintExchanger_Exchange_PreservesChainWithoutNewActor asserts that
+// when no new actor delegates, an act chain already on the subject token is
+// carried forward unchanged rather than dropped.
+func TestLocalMintExchanger_Exchange_PreservesChainWithoutNewActor(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Subject: &SubjectIdentity{
+			Subject: "user@example.com",
+			Issuer:  testIssuer,
+			Claims: &oidc.IDTokenClaims{
+				Act: &oidc.ActorClaim{Issuer: "https://k8s.example.com", Subject: "agentA"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var claims rfc9068Claims
+	parseMintedClaims(t, result.AccessToken, signingKey, &claims)
+
+	require.NotNil(t, claims.Act)
+	require.Equal(t, "agentA", claims.Act.Sub)
+	require.Nil(t, claims.Act.Act)
+}
+
+// TestLocalMintExchanger_Exchange_RejectsTooDeepChain asserts an act chain that
+// would exceed maxActorChainDepth is rejected fail-closed, bounding abuse.
+func TestLocalMintExchanger_Exchange_RejectsTooDeepChain(t *testing.T) {
+	cfg, _ := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	// A prior chain already at the maximum depth; nesting a new actor exceeds it.
+	deep := &oidc.ActorClaim{Issuer: testIssuer, Subject: "a0"}
+	for i := 1; i < maxActorChainDepth; i++ {
+		deep = &oidc.ActorClaim{Issuer: testIssuer, Subject: fmt.Sprintf("a%d", i), Act: deep}
+	}
+
+	_, err = lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Subject: &SubjectIdentity{
+			Subject: "user@example.com",
+			Issuer:  testIssuer,
+			Claims:  &oidc.IDTokenClaims{Act: deep},
+		},
+		Actor: &SubjectIdentity{Issuer: testIssuer, Subject: "newAgent"},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "actor chain depth")
+}
+
+// TestLocalMintExchanger_RoundTrip_ActorChain mints a two-hop OBO token and
+// validates it back through an OIDCValidator, asserting the full delegation
+// chain surfaces on UserInfo.ActorChain (outermost actor first) so backends can
+// authorize on any actor in the chain, not only the leaf.
+func TestLocalMintExchanger_RoundTrip_ActorChain(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: cfg.Issuer,
+		Subject: &SubjectIdentity{
+			Subject: "user@example.com",
+			Issuer:  testIssuer,
+			Claims: &oidc.IDTokenClaims{
+				Act: &oidc.ActorClaim{Issuer: "https://k8s.example.com", Subject: "agentA"},
+			},
+		},
+		Actor: &SubjectIdentity{Issuer: "https://k8s.example.com", Subject: "agentB"},
+	})
+	require.NoError(t, err)
+
+	jwksURL, jwksClient := serveStaticRSAJWKS(t, signingKey, "lme-test-kid")
+	srv, _, _ := setupFlowTestServer(t)
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             cfg.Issuer,
+		JwksURL:            jwksURL,
+		AllowedAudiences:   []string{cfg.Issuer},
+		AllowPrivateIPJWKS: true,
+		AcceptedTypHeaders: []string{"at+jwt"},
+	}}, jwksClient)
+	require.NoError(t, err)
+	srv.trustedIssuerValidator = v
+
+	userInfo, err := srv.ValidateToken(t.Context(), result.AccessToken)
+	require.NoError(t, err)
+	require.NotNil(t, userInfo)
+	require.Equal(t, "agentB", userInfo.ActorSubject, "leaf mirrors the most recent actor")
+	require.Len(t, userInfo.ActorChain, 2)
+	require.Equal(t, "agentB", userInfo.ActorChain[0].Subject)
+	require.Equal(t, "agentA", userInfo.ActorChain[1].Subject)
+}
+
+// TestLocalMintExchanger_RoundTrip_ForgedChainUntrustedIssuerRejected asserts a
+// token carrying an act chain but signed by an issuer the validator does not
+// trust is rejected at the issuer-trust boundary. Inner hops are not
+// individually re-validated — the chain is only as trustworthy as the signer of
+// the token that carries it — so an untrusted signer fails the whole token
+// closed and a fabricated chain cannot be smuggled in.
+func TestLocalMintExchanger_RoundTrip_ForgedChainUntrustedIssuerRejected(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	result, err := lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: cfg.Issuer,
+		Subject: &SubjectIdentity{
+			Subject: "user@example.com",
+			Issuer:  testIssuer,
+			Claims: &oidc.IDTokenClaims{
+				Act: &oidc.ActorClaim{Issuer: "https://attacker.example", Subject: "agentA"},
+			},
+		},
+		Actor: &SubjectIdentity{Issuer: "https://attacker.example", Subject: "agentB"},
+	})
+	require.NoError(t, err)
+
+	jwksURL, jwksClient := serveStaticRSAJWKS(t, signingKey, "lme-test-kid")
+	// Validator trusts a different issuer than the token's iss.
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             "https://other-broker.example",
+		JwksURL:            jwksURL,
+		AllowPrivateIPJWKS: true,
+		AcceptedTypHeaders: []string{"at+jwt"},
+	}}, jwksClient)
+	require.NoError(t, err)
+
+	_, err = v.Validate(t.Context(), result.AccessToken, []string{cfg.Issuer})
+	require.ErrorIs(t, err, ErrIssuerNotTrusted)
 }

--- a/server/sso.go
+++ b/server/sso.go
@@ -163,6 +163,7 @@ func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.
 	if claims.Act != nil {
 		info.ActorIssuer = claims.Act.Issuer
 		info.ActorSubject = claims.Act.Subject
+		info.ActorChain = claims.Act.Chain()
 	}
 	return info
 }

--- a/server/token_exchange_broker.go
+++ b/server/token_exchange_broker.go
@@ -69,6 +69,11 @@ type ExchangerResult struct {
 	ExpiresAt time.Time
 	// Scope is the scope granted by the downstream issuer. May be empty.
 	Scope string
+	// JTI is the unique identifier of the issued token, when the Exchanger
+	// mints a JWT it controls (e.g. LocalMintExchanger). Surfaced so the broker
+	// can record it in the mint audit event; empty when the downstream token is
+	// opaque or minted by a remote issuer.
+	JTI string
 }
 
 // Exchanger maps a requested audience to a downstream token. Hosts (e.g. an
@@ -203,6 +208,20 @@ func (s *Server) WorkloadExchangeSubjectToken(
 	identity, err := s.validateExchangeSubjectToken(ctx, subjectToken, subjectTokenType, subjDefaultAud, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	// Federation-escalation guard: a token this broker minted that already
+	// carries a delegation chain (act) must not be re-exchanged on the
+	// impersonation path. Doing so would re-authorize it on the minted human
+	// sub and drop the original acting principal recorded in act. Such a token
+	// may only be re-exchanged with a fresh actor_token (the delegation path),
+	// which re-evaluates ActorDelegationPolicy and WorkloadAudiences against
+	// that actor.
+	if actorToken == "" && identity.Issuer == s.Config.Issuer && identity.Claims != nil && identity.Claims.Act != nil {
+		s.auditExchangeFailure(ctx, "workload", "", audience, sessionID, "self_minted_delegated_token_impersonation", map[string]any{
+			"sub": identity.Subject,
+		})
+		return nil, fmt.Errorf("%w: self-minted delegated token cannot be re-exchanged without an actor_token", ErrInvalidTarget)
 	}
 
 	var actor *SubjectIdentity
@@ -365,6 +384,9 @@ func (s *Server) dispatchDownstreamExchange(
 	if actor != nil {
 		successDetails["actor_iss"] = actor.Issuer
 		successDetails["actor_sub"] = actor.Subject
+	}
+	if result.JTI != "" {
+		successDetails["jti"] = result.JTI
 	}
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type:     security.EventTokenIssued,

--- a/server/token_exchange_broker_test.go
+++ b/server/token_exchange_broker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 	"github.com/giantswarm/mcp-oauth/security"
 	"github.com/giantswarm/mcp-oauth/storage/memory"
 )
@@ -493,6 +494,84 @@ func TestWorkloadExchangeSubjectToken_HappyPath(t *testing.T) {
 	require.Equal(t, "workload", details["exchange"])
 	require.Empty(t, details["__client_id"])
 	require.Equal(t, "target-service", details["audience"])
+}
+
+// TestWorkloadExchangeSubjectToken_AuditsMintJTI asserts the jti the Exchanger
+// surfaces on its result is recorded in the success audit event, so every mint
+// is attributable to a specific issued token.
+func TestWorkloadExchangeSubjectToken_AuditsMintJTI(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{
+		AccessToken: "workload-token",
+		ExpiresAt:   time.Now().Add(time.Minute),
+		JTI:         "jti-12345",
+	}}
+	const sub = "system:serviceaccount:ns:robot"
+	validator := &stubSubjectValidator{identity: SubjectIdentity{Subject: sub, Issuer: "https://kube.example.com"}}
+	srv, buf := newWorkloadTestServer(t, ex,
+		[]WorkloadGrant{{Issuer: "*", Subject: sub, Audiences: []string{"target-service"}}}, validator)
+
+	_, err := srv.WorkloadExchangeSubjectToken(t.Context(),
+		"sa-jwt", SubjectTokenTypeIDToken, "", "", "target-service", "", "")
+	require.NoError(t, err)
+
+	details := auditDetails(t, buf, security.EventTokenIssued)
+	require.Equal(t, "jti-12345", details["jti"])
+}
+
+// TestWorkloadExchangeSubjectToken_FederationEscalationGuardDeniesImpersonation
+// asserts a token this broker minted that already carries a delegation chain
+// cannot be re-exchanged on the impersonation path (no actor_token), which would
+// re-authorize it on the minted human sub and drop the acting principal.
+func TestWorkloadExchangeSubjectToken_FederationEscalationGuardDeniesImpersonation(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{AccessToken: "must-not-mint"}}
+	validator := &stubSubjectValidator{identity: SubjectIdentity{
+		Subject: brokerTestUserSub,
+		Issuer:  "https://broker.example.com", // self-minted: equals cfg.Issuer
+		Claims:  &oidc.IDTokenClaims{Act: &oidc.ActorClaim{Issuer: "https://kube.example.com", Subject: "agentA"}},
+	}}
+	srv, buf := newWorkloadTestServer(t, ex,
+		[]WorkloadGrant{{Issuer: "*", Subject: "*", Audiences: []string{"target-service"}}}, validator)
+
+	_, err := srv.WorkloadExchangeSubjectToken(t.Context(),
+		"self-minted-obo", SubjectTokenTypeIDToken, "", "", "target-service", "", "")
+	require.ErrorIs(t, err, ErrInvalidTarget)
+	require.Contains(t, err.Error(), "self-minted delegated token")
+	require.Nil(t, ex.gotReq, "exchanger must not be invoked when the guard fires")
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "self_minted_delegated_token_impersonation", details["reason"])
+}
+
+// TestWorkloadExchangeSubjectToken_FederationEscalationGuardAllowsDelegation
+// asserts the guard is narrow: the same self-minted delegated token re-exchanged
+// with a fresh actor_token (the delegation path) proceeds, re-evaluating policy
+// against that actor — this is the legitimate multi-hop A2A re-exchange.
+func TestWorkloadExchangeSubjectToken_FederationEscalationGuardAllowsDelegation(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{
+		AccessToken: "workload-token",
+		ExpiresAt:   time.Now().Add(time.Minute),
+	}}
+	const agentB = "system:serviceaccount:ns:agent-b"
+	validator := &stubTokenValidator{
+		byToken: map[string]*SubjectIdentity{
+			"agent-b-jwt": {Subject: agentB, Issuer: "https://kube.example.com"},
+		},
+		defaultIdentity: &SubjectIdentity{
+			Subject: brokerTestUserSub,
+			Issuer:  "https://broker.example.com", // self-minted subject
+			Claims:  &oidc.IDTokenClaims{Act: &oidc.ActorClaim{Issuer: "https://kube.example.com", Subject: "agentA"}},
+		},
+	}
+	srv, _ := newWorkloadTestServer(t, ex,
+		[]WorkloadGrant{{Issuer: "*", Subject: agentB, Audiences: []string{"target-service"}}}, validator)
+	srv.Config.ActorDelegationPolicy = []DelegationGrant{
+		{ActorIssuer: "*", ActorSubject: agentB, SubjectIssuer: "*", SubjectSubject: brokerTestUserSub},
+	}
+
+	_, err := srv.WorkloadExchangeSubjectToken(t.Context(),
+		"self-minted-obo", SubjectTokenTypeIDToken, "agent-b-jwt", SubjectTokenTypeIDToken, "target-service", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, ex.gotReq, "delegation re-exchange must proceed to the exchanger")
 }
 
 func TestWorkloadExchangeSubjectToken_ImpersonationSubjectBoundToBrokerIssuer(t *testing.T) {


### PR DESCRIPTION
## What

OBO foundation for the M2M + OBO plan (subplan 01). All changes are additive on top of the already-merged SubjectClaim / actor_token / TrustedIssuers work.

### LocalMintExchanger identity + delegation chain
- Copies `email` / `email_verified` / `groups` from the validated subject token into the minted access token (`email_verified` only alongside a non-empty `email`). Downstream backends (mcp-kubernetes by `email`, prometheus/observability by `groups`) can now authorize and attribute without an extra IdP round-trip.
- Preserves multi-hop A2A delegation: an `act` chain already on the subject token is nested beneath the new actor (RFC 8693 §4.4 `act.act…`) instead of overwritten. Depth is bounded at 10 hops and rejected fail-closed beyond that.
- The chain is decoded (`oidc.ActorClaim.Act`), flattened via `oidc.ActorClaim.Chain()`, and surfaced on `providers.UserInfo.ActorChain` so backends authorize on any actor in the chain, not only the leaf.

### Broker hardening (subplan 11)
- `ExchangerResult.JTI` lets the exchanger surface the issued token's `jti`; the broker `token_issued` audit event records it, so every aggregator mint is attributable to a specific token (#2).
- Federation-escalation guard on `WorkloadExchangeSubjectToken`: a self-minted token already carrying an `act` claim cannot be re-exchanged on the impersonation path (no `actor_token`), which would re-authorize it on the minted human `sub` and drop the acting principal. It may only be re-exchanged with a fresh `actor_token`, which re-evaluates `ActorDelegationPolicy` / `WorkloadAudiences` against that actor. Rejection audits reason `self_minted_delegated_token_impersonation` (#4).

### Confirmed release-ready
`SubjectClaim` (already on `main`, PR #460) is unchanged and shipping in this release window.

## Notes
- `WorkloadExchangeWithActor` was left out: the muster design uses the existing `WorkloadExchangeSubjectToken` actor_token flow (dual-token-on-call), so it is not on the critical path.
- Rate-limit / revocation (subplan 11 #5) apply at the HTTP handler layer; callers invoking the workload/broker methods directly (muster) own rate-limiting on that path. Documented in the downstream-adoption notes rather than changed here.
- Downstream bump + adoption notes for muster (02) and mcp-kubernetes (04) prepared alongside the plan.