### PR TITLE
fix(token-exchange): rate-limit mint path; drop unconsumed ActorChain API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `providers.UserInfo.IsDelegated() bool`: reports whether the token represents a delegated exchange; true when `ActorSubject` is non-empty.
 
-- `oidc.IDTokenClaims.Act *oidc.ActorClaim` and `oidc.ActorClaim` (`Issuer string`, `Subject string`, `Act *oidc.ActorClaim`): decoded automatically from the `act` claim of a JWT when present. The nested `Act` field carries a multi-hop RFC 8693 §4.4 delegation chain (`act.act…`); `oidc.ActorClaim.Chain()` flattens it to a slice ordered from the outermost (most recent) actor to the innermost.
-
-- `providers.UserInfo.ActorChain []oidc.ActorClaim`: the full delegation chain decoded from the `act` claim, outermost first; `ActorIssuer`/`ActorSubject` mirror its first element. Resource servers authorizing a multi-hop A2A call walk this slice to match any actor in the chain, not only the leaf.
+- `oidc.IDTokenClaims.Act *oidc.ActorClaim` and `oidc.ActorClaim` (`Issuer string`, `Subject string`, `Act *oidc.ActorClaim`): decoded automatically from the `act` claim of a JWT when present. The nested `Act` field carries a multi-hop RFC 8693 §4.4 delegation chain (`act.act…`), so a token minted for a second A2A hop decodes with `Act` = the most recent actor and `Act.Act` = the prior one.
 
 - `LocalMintExchanger` now copies `email`, `email_verified`, and `groups` from the validated subject token into the minted access token (`email_verified` only alongside a non-empty `email`), and nests any `act` chain already on the subject token beneath the new actor so a multi-hop A2A delegation chain is preserved. A chain exceeding the maximum nesting depth is rejected.
 
@@ -82,6 +80,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Federation-escalation guard on the workload token-exchange path.** A token this broker minted that already carries an `act` claim can no longer be re-exchanged on the impersonation path (no `actor_token`). Doing so would re-authorize the token on its minted human `sub` and drop the acting principal recorded in `act`. Such a token may only be re-exchanged with a fresh `actor_token` (the delegation path), which re-evaluates `ActorDelegationPolicy` and `WorkloadAudiences` against that actor. The rejection emits an `auth_failure` audit event with reason `self_minted_delegated_token_impersonation`.
 
 - **Minted actor chains are bounded.** `LocalMintExchanger` rejects an `act` chain deeper than 10 hops, capping token size and parser load on every downstream that validates the token.
+
+- **Mint path honours the rate limiter when called in-process.** `BrokerExchangeSubjectToken` and `WorkloadExchangeSubjectToken` now consult the configured `UserRateLimiter` (keyed on the per-session ID) before minting, so a caller invoking these methods directly (e.g. an aggregator, bypassing the HTTP middleware) cannot flood mints from a single compromised session. New exported sentinel `server.ErrExchangeRateLimited`; the rejection emits an `auth_failure` audit event with reason `token_exchange_rate_limited`. A nil `UserRateLimiter` leaves the path unrestricted as before.
 
 ## [0.2.199] - 2026-06-10
 

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -371,18 +371,6 @@ type ActorClaim struct {
 	Act     *ActorClaim `json:"act,omitempty"`
 }
 
-// Chain flattens a nested act claim into a slice ordered from the outermost
-// (most recent) actor to the innermost, each element stripped of its own nested
-// Act. Returns nil for a nil receiver. Resource servers authorizing a multi-hop
-// delegation match any element rather than only the leaf.
-func (c *ActorClaim) Chain() []ActorClaim {
-	var chain []ActorClaim
-	for a := c; a != nil; a = a.Act {
-		chain = append(chain, ActorClaim{Issuer: a.Issuer, Subject: a.Subject})
-	}
-	return chain
-}
-
 // IDTokenClaims represents the standard claims in an OIDC ID token. The
 // embedded josejwt.Claims carries the registered claims (iss, sub, aud, exp,
 // nbf, iat, jti); the additional fields are OIDC-specific extensions defined

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -6,8 +6,6 @@ import (
 	"context"
 
 	"golang.org/x/oauth2"
-
-	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
 
 // AuthorizationURLOptions contains optional OIDC parameters for the authorization request.
@@ -231,14 +229,6 @@ type UserInfo struct {
 	// only when the token was minted via a delegated token exchange with a
 	// validated actor_token. Use IsDelegated() as a presence check.
 	ActorSubject string
-
-	// ActorChain is the full RFC 8693 §4.4 delegation chain decoded from the
-	// act claim, ordered outermost (most recent actor) first; ActorIssuer and
-	// ActorSubject mirror its first element. Empty for tokens without
-	// delegation. Resource servers authorizing a multi-hop A2A call (human →
-	// agentA → agentB → backend) walk this slice to match any actor in the
-	// chain rather than only the leaf.
-	ActorChain []oidc.ActorClaim
 }
 
 // IsSSO returns true if this user was authenticated via SSO token forwarding.

--- a/server/local_mint_exchanger_test.go
+++ b/server/local_mint_exchanger_test.go
@@ -367,9 +367,10 @@ func TestLocalMintExchanger_Exchange_RejectsTooDeepChain(t *testing.T) {
 }
 
 // TestLocalMintExchanger_RoundTrip_ActorChain mints a two-hop OBO token and
-// validates it back through an OIDCValidator, asserting the full delegation
-// chain surfaces on UserInfo.ActorChain (outermost actor first) so backends can
-// authorize on any actor in the chain, not only the leaf.
+// validates it back through an OIDCValidator, asserting the full nested act
+// chain survives signature validation and decodes intact (outermost actor
+// first) so a downstream can authorize on any actor in the chain, not only the
+// leaf.
 func TestLocalMintExchanger_RoundTrip_ActorChain(t *testing.T) {
 	cfg, signingKey := localMintCfg(t)
 	lme, err := NewLocalMintExchanger(cfg)
@@ -389,7 +390,6 @@ func TestLocalMintExchanger_RoundTrip_ActorChain(t *testing.T) {
 	require.NoError(t, err)
 
 	jwksURL, jwksClient := serveStaticRSAJWKS(t, signingKey, "lme-test-kid")
-	srv, _, _ := setupFlowTestServer(t)
 	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
 		Issuer:             cfg.Issuer,
 		JwksURL:            jwksURL,
@@ -398,15 +398,15 @@ func TestLocalMintExchanger_RoundTrip_ActorChain(t *testing.T) {
 		AcceptedTypHeaders: []string{"at+jwt"},
 	}}, jwksClient)
 	require.NoError(t, err)
-	srv.trustedIssuerValidator = v
 
-	userInfo, err := srv.ValidateToken(t.Context(), result.AccessToken)
+	identity, err := v.Validate(t.Context(), result.AccessToken, []string{cfg.Issuer})
 	require.NoError(t, err)
-	require.NotNil(t, userInfo)
-	require.Equal(t, "agentB", userInfo.ActorSubject, "leaf mirrors the most recent actor")
-	require.Len(t, userInfo.ActorChain, 2)
-	require.Equal(t, "agentB", userInfo.ActorChain[0].Subject)
-	require.Equal(t, "agentA", userInfo.ActorChain[1].Subject)
+	require.Equal(t, "user@example.com", identity.Subject)
+	require.NotNil(t, identity.Claims.Act, "leaf actor decoded")
+	require.Equal(t, "agentB", identity.Claims.Act.Subject, "outermost act is the most recent actor")
+	require.NotNil(t, identity.Claims.Act.Act, "nested actor decoded")
+	require.Equal(t, "agentA", identity.Claims.Act.Act.Subject)
+	require.Nil(t, identity.Claims.Act.Act.Act, "chain ends at the first hop")
 }
 
 // TestLocalMintExchanger_RoundTrip_ForgedChainUntrustedIssuerRejected asserts a

--- a/server/sso.go
+++ b/server/sso.go
@@ -163,7 +163,6 @@ func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.
 	if claims.Act != nil {
 		info.ActorIssuer = claims.Act.Issuer
 		info.ActorSubject = claims.Act.Subject
-		info.ActorChain = claims.Act.Chain()
 	}
 	return info
 }

--- a/server/token_exchange_broker.go
+++ b/server/token_exchange_broker.go
@@ -18,6 +18,15 @@ import (
 // §2.2.2 invalid_target error response.
 var ErrInvalidTarget = errors.New("requested audience is not allowed for this client")
 
+// ErrExchangeRateLimited is returned by BrokerExchangeSubjectToken and
+// WorkloadExchangeSubjectToken when the configured UserRateLimiter rejects the
+// request. The HTTP handler rate-limits authenticated requests in middleware,
+// but these methods are also called in-process (e.g. by an aggregator minting
+// per-backend tokens), so the same limiter is enforced here keyed on the
+// per-session ID. Callers invoking the methods directly should surface this as
+// a 429-equivalent.
+var ErrExchangeRateLimited = errors.New("token exchange rate limit exceeded")
+
 // ExchangerRequest carries the validated inputs of a brokered RFC 8693
 // token exchange to the host's Exchanger implementation. The subject and
 // actor tokens have already been validated (signature, issuer, audience,
@@ -123,6 +132,10 @@ func (s *Server) BrokerExchangeSubjectToken(
 ) (*TokenExchangeResult, error) {
 	sessionID := s.deriveForwardedSessionID(subjectToken)
 
+	if s.exchangeRateLimited(ctx, "brokered", clientID, audience, sessionID) {
+		return nil, ErrExchangeRateLimited
+	}
+
 	if s.exchanger == nil {
 		s.auditExchangeFailure(ctx, "brokered", clientID, audience, sessionID, "token_exchange_no_exchanger", nil)
 		return nil, fmt.Errorf("%w: no exchanger configured", ErrInvalidTarget)
@@ -190,6 +203,10 @@ func (s *Server) WorkloadExchangeSubjectToken(
 	subjectToken, subjectTokenType, actorToken, actorTokenType, audience, resource, scope string,
 ) (*TokenExchangeResult, error) {
 	sessionID := s.deriveForwardedSessionID(subjectToken)
+
+	if s.exchangeRateLimited(ctx, "workload", "", audience, sessionID) {
+		return nil, ErrExchangeRateLimited
+	}
 
 	if s.exchanger == nil {
 		s.auditExchangeFailure(ctx, "workload", "", audience, sessionID, "token_exchange_no_exchanger", nil)
@@ -401,6 +418,21 @@ func (s *Server) dispatchDownstreamExchange(
 		Scope:           result.Scope,
 		IssuedTokenType: issuedTokenType,
 	}, nil
+}
+
+// exchangeRateLimited reports whether the mint path is currently rate-limited
+// for sessionID and audits the rejection when it is. The HTTP handler
+// rate-limits authenticated requests in middleware keyed on the user, but the
+// brokered and workload methods are also called in-process, so the same
+// UserRateLimiter is enforced here keyed on the per-session ID, so a compromised
+// session cannot flood mints regardless of entry point. A nil UserRateLimiter
+// disables the check.
+func (s *Server) exchangeRateLimited(ctx context.Context, exchange, clientID, audience, sessionID string) bool {
+	if s.UserRateLimiter == nil || s.UserRateLimiter.Allow(sessionID) {
+		return false
+	}
+	s.auditExchangeFailure(ctx, exchange, clientID, audience, sessionID, "token_exchange_rate_limited", nil)
+	return true
 }
 
 // auditExchangeFailure emits the auth-failure audit event for brokered and

--- a/server/token_exchange_broker_test.go
+++ b/server/token_exchange_broker_test.go
@@ -461,6 +461,39 @@ func TestBrokerExchangeSubjectToken_ActorDelegationDeniedWhenNoPolicyConfigured(
 
 // Workload-authenticated exchange tests.
 
+// TestWorkloadExchangeSubjectToken_RateLimited asserts the mint path honours the
+// configured UserRateLimiter when the method is called directly (not via the
+// HTTP middleware): a second request from the same session is rejected before
+// any mint, keyed on the per-session ID.
+func TestWorkloadExchangeSubjectToken_RateLimited(t *testing.T) {
+	ex := &stubExchanger{result: &ExchangerResult{
+		AccessToken: "workload-token",
+		ExpiresAt:   time.Now().Add(time.Minute),
+	}}
+	const sub = "system:serviceaccount:ns:robot"
+	validator := &stubSubjectValidator{identity: SubjectIdentity{Subject: sub, Issuer: "https://kube.example.com"}}
+	srv, buf := newWorkloadTestServer(t, ex,
+		[]WorkloadGrant{{Issuer: "*", Subject: sub, Audiences: []string{"target-service"}}}, validator)
+	srv.UserRateLimiter = security.NewRateLimiter(0, 1, nil) // burst of 1, no refill
+	t.Cleanup(srv.UserRateLimiter.Stop)
+
+	// First call consumes the single token and mints.
+	_, err := srv.WorkloadExchangeSubjectToken(t.Context(),
+		"sa-jwt", SubjectTokenTypeIDToken, "", "", "target-service", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, ex.gotReq)
+
+	ex.gotReq = nil
+	// Second call from the same session (same subject token) is rate-limited.
+	_, err = srv.WorkloadExchangeSubjectToken(t.Context(),
+		"sa-jwt", SubjectTokenTypeIDToken, "", "", "target-service", "", "")
+	require.ErrorIs(t, err, ErrExchangeRateLimited)
+	require.Nil(t, ex.gotReq, "exchanger must not be invoked when rate-limited")
+
+	details := auditDetails(t, buf, security.EventAuthFailure)
+	require.Equal(t, "token_exchange_rate_limited", details["reason"])
+}
+
 func TestWorkloadExchangeSubjectToken_HappyPath(t *testing.T) {
 	expiry := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
 	ex := &stubExchanger{result: &ExchangerResult{


### PR DESCRIPTION
Follow-up to #464, resolving two flags raised on that PR.

## Rate-limit the mint path for in-process callers (subplan 11 #5)
`UserRateLimiter` was only enforced in the HTTP middleware (keyed on user). The brokered/workload exchange methods are also called in-process by an aggregator minting per-backend tokens, which bypassed it, so a single compromised session could flood mints. `BrokerExchangeSubjectToken` and `WorkloadExchangeSubjectToken` now consult the same `UserRateLimiter` keyed on the per-session ID before minting, returning the new `server.ErrExchangeRateLimited` and auditing reason `token_exchange_rate_limited`. A nil limiter leaves the path unrestricted (no behaviour change for deployments without one).

Revocation needs nothing new: the subject and actor tokens are validated (signature/issuer/audience/expiry) before every mint, and minted OBO tokens carry no `family_id`, so there is no separate session denylist to wire.

## Drop the unconsumed ActorChain API
`providers.UserInfo.ActorChain` and `oidc.ActorClaim.Chain()` were added in #464 with no consumer in this repo (the backends that walk the chain live in subplans 04/06). Removed to avoid shipping production API whose only caller is the test suite. The nested-act decode (`oidc.ActorClaim.Act`) stays — the mint nesting consumes it and the chain survives validation on `SubjectIdentity.Claims.Act`. The `UserInfo` chain accessor lands with the backend that authorizes on the chain (mcp-kubernetes, subplan 04).

Both are unreleased (no tag cut since #464), so the API removal affects no released consumer.