### PR TITLE
feat(server): re-add actor-chain accessor; bound decode depth; verify email at mint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `oidc.IDTokenClaims.Act *oidc.ActorClaim` and `oidc.ActorClaim` (`Issuer string`, `Subject string`, `Act *oidc.ActorClaim`): decoded automatically from the `act` claim of a JWT when present. The nested `Act` field carries a multi-hop RFC 8693 §4.4 delegation chain (`act.act…`), so a token minted for a second A2A hop decodes with `Act` = the most recent actor and `Act.Act` = the prior one.
 
+- `oidc.ActorClaim.Chain() []oidc.ActorClaim` and `providers.UserInfo.ActorChain []oidc.ActorClaim`: the full delegation chain flattened from the nested `act` claim, ordered outermost (most recent actor) first; `UserInfo.ActorIssuer`/`ActorSubject` mirror its first element. Resource servers authorizing a multi-hop A2A call walk this slice to match any actor in the chain rather than only the leaf.
+
 - `LocalMintExchanger` now copies `email`, `email_verified`, and `groups` from the validated subject token into the minted access token (`email_verified` only alongside a non-empty `email`), and nests any `act` chain already on the subject token beneath the new actor so a multi-hop A2A delegation chain is preserved. A chain exceeding the maximum nesting depth is rejected.
 
 - `server.Actor.Act *server.Actor`: nests the prior actor when minting a token for a further delegation hop.
@@ -79,7 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Federation-escalation guard on the workload token-exchange path.** A token this broker minted that already carries an `act` claim can no longer be re-exchanged on the impersonation path (no `actor_token`). Doing so would re-authorize the token on its minted human `sub` and drop the acting principal recorded in `act`. Such a token may only be re-exchanged with a fresh `actor_token` (the delegation path), which re-evaluates `ActorDelegationPolicy` and `WorkloadAudiences` against that actor. The rejection emits an `auth_failure` audit event with reason `self_minted_delegated_token_impersonation`.
 
-- **Minted actor chains are bounded.** `LocalMintExchanger` rejects an `act` chain deeper than 10 hops, capping token size and parser load on every downstream that validates the token.
+- **Minted actor chains are bounded.** `LocalMintExchanger` rejects an `act` chain deeper than 10 hops, capping token size and parser load on every downstream that validates the token. The trusted-issuer validator (`OIDCValidator.Validate`) rejects an inbound token whose `act` chain exceeds the same limit, symmetric on the way in.
+
+- **`LocalMintExchanger` refuses to vouch for an unverified email.** When the validated subject asserts a non-empty `email` whose `email_verified` is false, the mint is rejected rather than emitting an identity-bearing token a downstream would trust. Subjects with no email (e.g. an M2M ServiceAccount) are unaffected.
 
 - **Mint path honours the rate limiter when called in-process.** `BrokerExchangeSubjectToken` and `WorkloadExchangeSubjectToken` now consult the configured `UserRateLimiter` (keyed on the per-session ID) before minting, so a caller invoking these methods directly (e.g. an aggregator, bypassing the HTTP middleware) cannot flood mints from a single compromised session. New exported sentinel `server.ErrExchangeRateLimited`; the rejection emits an `auth_failure` audit event with reason `token_exchange_rate_limited`. A nil `UserRateLimiter` leaves the path unrestricted as before.
 

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -371,6 +371,18 @@ type ActorClaim struct {
 	Act     *ActorClaim `json:"act,omitempty"`
 }
 
+// Chain flattens a nested act claim into a slice ordered from the outermost
+// (most recent) actor to the innermost, each element stripped of its own nested
+// Act. Returns nil for a nil receiver. Resource servers authorizing a multi-hop
+// delegation match any element rather than only the leaf.
+func (c *ActorClaim) Chain() []ActorClaim {
+	var chain []ActorClaim
+	for a := c; a != nil; a = a.Act {
+		chain = append(chain, ActorClaim{Issuer: a.Issuer, Subject: a.Subject})
+	}
+	return chain
+}
+
 // IDTokenClaims represents the standard claims in an OIDC ID token. The
 // embedded josejwt.Claims carries the registered claims (iss, sub, aud, exp,
 // nbf, iat, jti); the additional fields are OIDC-specific extensions defined

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -6,6 +6,8 @@ import (
 	"context"
 
 	"golang.org/x/oauth2"
+
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 )
 
 // AuthorizationURLOptions contains optional OIDC parameters for the authorization request.
@@ -229,6 +231,14 @@ type UserInfo struct {
 	// only when the token was minted via a delegated token exchange with a
 	// validated actor_token. Use IsDelegated() as a presence check.
 	ActorSubject string
+
+	// ActorChain is the full RFC 8693 §4.4 delegation chain decoded from the
+	// act claim, ordered outermost (most recent actor) first; ActorIssuer and
+	// ActorSubject mirror its first element. Empty for tokens without
+	// delegation. Resource servers authorizing a multi-hop A2A call (human →
+	// agentA → agentB → backend) walk this slice to match any actor in the
+	// chain rather than only the leaf.
+	ActorChain []oidc.ActorClaim
 }
 
 // IsSSO returns true if this user was authenticated via SSO token forwarding.

--- a/server/local_mint_exchanger.go
+++ b/server/local_mint_exchanger.go
@@ -96,6 +96,9 @@ func (l *LocalMintExchanger) Exchange(ctx context.Context, req *ExchangerRequest
 		Act:       act,
 	}
 	if identity := req.Subject.Claims; identity != nil {
+		if identity.Email != "" && !identity.EmailVerified {
+			return nil, fmt.Errorf("local mint: subject asserts an email but email_verified is false; refusing to mint an identity-bearing token")
+		}
 		claims.Email = identity.Email
 		claims.EmailVerified = identity.EmailVerified
 		claims.Groups = identity.Groups

--- a/server/local_mint_exchanger_test.go
+++ b/server/local_mint_exchanger_test.go
@@ -407,6 +407,17 @@ func TestLocalMintExchanger_RoundTrip_ActorChain(t *testing.T) {
 	require.NotNil(t, identity.Claims.Act.Act, "nested actor decoded")
 	require.Equal(t, "agentA", identity.Claims.Act.Act.Subject)
 	require.Nil(t, identity.Claims.Act.Act.Act, "chain ends at the first hop")
+
+	// The consumer-facing path surfaces the flattened chain on UserInfo so a
+	// backend can authorize on any actor in it, not only the leaf.
+	srv, _, _ := setupFlowTestServer(t)
+	srv.trustedIssuerValidator = v
+	userInfo, err := srv.ValidateToken(t.Context(), result.AccessToken)
+	require.NoError(t, err)
+	require.Equal(t, "agentB", userInfo.ActorSubject, "leaf mirrors the most recent actor")
+	require.Len(t, userInfo.ActorChain, 2)
+	require.Equal(t, "agentB", userInfo.ActorChain[0].Subject)
+	require.Equal(t, "agentA", userInfo.ActorChain[1].Subject)
 }
 
 // TestLocalMintExchanger_RoundTrip_ForgedChainUntrustedIssuerRejected asserts a
@@ -445,4 +456,65 @@ func TestLocalMintExchanger_RoundTrip_ForgedChainUntrustedIssuerRejected(t *test
 
 	_, err = v.Validate(t.Context(), result.AccessToken, []string{cfg.Issuer})
 	require.ErrorIs(t, err, ErrIssuerNotTrusted)
+}
+
+// TestLocalMintExchanger_Exchange_RejectsUnverifiedEmail asserts the mint
+// refuses to vouch for a subject that asserts an email the upstream did not
+// verify. A subject with no email (e.g. an M2M ServiceAccount) is unaffected,
+// which the other no-email tests cover.
+func TestLocalMintExchanger_Exchange_RejectsUnverifiedEmail(t *testing.T) {
+	cfg, _ := localMintCfg(t)
+	lme, err := NewLocalMintExchanger(cfg)
+	require.NoError(t, err)
+
+	_, err = lme.Exchange(t.Context(), &ExchangerRequest{
+		Resource: "https://api.example.com",
+		Subject: &SubjectIdentity{
+			Subject: "user@example.com",
+			Issuer:  testIssuer,
+			Claims:  &oidc.IDTokenClaims{Email: "user@example.com", EmailVerified: false},
+		},
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "email_verified")
+}
+
+// TestOIDCValidator_Validate_RejectsTooDeepActorChain asserts the validator
+// bounds inbound act nesting symmetrically with the mint-side limit: a signed
+// token whose chain exceeds maxActorChainDepth is rejected before any consumer
+// walks it.
+func TestOIDCValidator_Validate_RejectsTooDeepActorChain(t *testing.T) {
+	cfg, signingKey := localMintCfg(t)
+	issuer, err := newJWTIssuer(cfg)
+	require.NoError(t, err)
+
+	// Build an act chain one hop deeper than the limit and sign it directly,
+	// bypassing the mint-side depth guard.
+	act := &Actor{Iss: testIssuer, Sub: "a0"}
+	for i := 1; i <= maxActorChainDepth; i++ {
+		act = &Actor{Iss: testIssuer, Sub: fmt.Sprintf("a%d", i), Act: act}
+	}
+	now := time.Now().UTC()
+	token, err := issuer.Issue(t.Context(), AccessTokenClaims{
+		Subject:   "user@example.com",
+		Audience:  cfg.Issuer,
+		IssuedAt:  now,
+		ExpiresAt: now.Add(time.Minute),
+		Act:       act,
+	})
+	require.NoError(t, err)
+
+	jwksURL, jwksClient := serveStaticRSAJWKS(t, signingKey, "lme-test-kid")
+	v, err := newOIDCValidatorWithClient([]TrustedIssuer{{
+		Issuer:             cfg.Issuer,
+		JwksURL:            jwksURL,
+		AllowedAudiences:   []string{cfg.Issuer},
+		AllowPrivateIPJWKS: true,
+		AcceptedTypHeaders: []string{"at+jwt"},
+	}}, jwksClient)
+	require.NoError(t, err)
+
+	_, err = v.Validate(t.Context(), token, []string{cfg.Issuer})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "actor chain depth")
 }

--- a/server/sso.go
+++ b/server/sso.go
@@ -163,6 +163,7 @@ func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.
 	if claims.Act != nil {
 		info.ActorIssuer = claims.Act.Issuer
 		info.ActorSubject = claims.Act.Subject
+		info.ActorChain = claims.Act.Chain()
 	}
 	return info
 }

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -183,6 +183,13 @@ func (v *OIDCValidator) Validate(ctx context.Context, tokenString string, defaul
 		return nil, err
 	}
 
+	// Bound act nesting on the way in, symmetric with the mint-side limit:
+	// reject an absurdly deep delegation chain before it reaches any consumer
+	// that walks it.
+	if depth := len(claims.Act.Chain()); depth > maxActorChainDepth {
+		return nil, fmt.Errorf("actor chain depth %d exceeds maximum %d", depth, maxActorChainDepth)
+	}
+
 	// rawClaims is authentic here: ValidateIDToken verified the signature over
 	// the same token, so reading an additional claim from it is sound.
 	subject := claims.Subject


### PR DESCRIPTION
Completes the OBO foundation (subplans 01/11/12) with three controls that belong in mcp-oauth, the consumed library, rather than deferred to the backends.

## Re-add the flattened actor-chain accessor
`oidc.ActorClaim.Chain()` and `providers.UserInfo.ActorChain`. The chain itself was always preserved (mint nesting + `oidc.ActorClaim.Act` decode); #466 only dropped the convenience accessor, which would have forced a second mcp-oauth release once a backend (subplans 04/06) authorizes on the chain. Backends consume this library's `UserInfo`, so exposing the chain is mcp-oauth's job; the *matching policy* stays with the backend (mcp-oauth can't know its allowed-actor set).

## Bound act nesting on validation
`OIDCValidator.Validate` rejects an inbound token whose `act` chain exceeds `maxActorChainDepth`, symmetric with the existing mint-side bound. Closes the asymmetry where only minted tokens were depth-checked.

## Verify email at the mint (hardening 11 #3)
`LocalMintExchanger` rejects a mint when the validated subject asserts a non-empty `email` whose `email_verified` is false. The mint is the authoritative issuer and must not vouch for an unverified identity. M2M subjects (no email) are unaffected.

Tests: round-trip now also asserts `UserInfo.ActorChain`; new tests for the depth bound on validation and the unverified-email rejection. All unreleased (no tag since #464), so no released consumer is affected.