### PR TITLE
feat(server): add EnsureConfidentialClient to seed a confidential client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `server.Server.EnsureConfidentialClient(ctx, clientID, clientSecret string, scopes []string) (seeded bool, err error)`: idempotently provisions a confidential OAuth client with a caller-supplied id and secret (unlike `RegisterClientV2`, which generates random ones). If the client already exists with a matching secret it is a no-op; otherwise the record is (re)written with a fresh bcrypt hash. Intended to declaratively seed a known confidential client — e.g. a token-exchange broker — from a mounted secret at startup, so a wiped client store self-heals.
+
 - `server.TrustedIssuer.SubjectClaim string`: names the verified claim whose value becomes `SubjectIdentity.Subject` (and thus the `sub` of any token minted from the identity, and the value matched by `ActorDelegationPolicy`). Empty keeps the standard `sub` claim. Use it when an issuer's `sub` is opaque but another claim (e.g. `email`) carries the canonical subject the downstream relies on. Fail-closed: a token whose configured claim is absent or not a non-empty string is rejected.
 
 - `server.Server.AcceptTrustedIssuerToken(ctx, bearerToken)`: validates a Bearer JWT against the `WithTrustedIssuers` configuration and returns a `ForwardedIDTokenAcceptance` (same shape as `AcceptForwardedIDToken`, including the `ext-<hex>` session ID). Intended as a fallback for aggregators that receive `ErrTrustedAudienceMismatch` from `AcceptForwardedIDToken` — e.g. a raw Kubernetes ServiceAccount projected token whose `aud` is the server's own resource identifier rather than a `TrustedAudiences` entry.

--- a/server/client.go
+++ b/server/client.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -112,6 +113,65 @@ func (s *Server) RegisterClientV2(ctx context.Context, clientName, clientType, t
 		ClientSecret:      clientSecret,
 		RegistrationToken: registrationToken,
 	}, nil
+}
+
+// EnsureConfidentialClient idempotently seeds a confidential OAuth client with
+// a caller-supplied id and secret. Unlike RegisterClientV2 (which generates a
+// random id and secret), this is used to declaratively provision a known
+// confidential client -- e.g. a token-exchange broker -- from a secret mounted
+// at startup, so that a wiped client store self-heals.
+//
+// It is idempotent: if a client with the given id already exists and its stored
+// secret hash matches the supplied secret, it is left untouched. Otherwise the
+// client record is (re)written with a fresh bcrypt hash of the supplied secret.
+// Returns whether the store was written (true) or already up to date (false).
+func (s *Server) EnsureConfidentialClient(ctx context.Context, clientID, clientSecret string, scopes []string) (seeded bool, err error) {
+	if clientID == "" || clientSecret == "" {
+		return false, fmt.Errorf("client id and secret are required")
+	}
+
+	existing, err := s.clientStore.GetClient(ctx, clientID)
+	if err != nil && !errors.Is(err, storage.ErrClientNotFound) {
+		return false, fmt.Errorf("failed to look up client %q: %w", clientID, err)
+	}
+
+	// Already present with a matching secret: nothing to do.
+	if existing != nil && existing.IsConfidential() && existing.ClientSecretHash != "" {
+		if bcrypt.CompareHashAndPassword([]byte(existing.ClientSecretHash), []byte(clientSecret)) == nil {
+			return false, nil
+		}
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(clientSecret), bcrypt.DefaultCost)
+	if err != nil {
+		return false, fmt.Errorf("failed to hash client secret: %w", err)
+	}
+
+	now := time.Now()
+	client := &storage.Client{
+		ClientID:                clientID,
+		ClientSecretHash:        string(hash),
+		ClientType:              ClientTypeConfidential,
+		TokenEndpointAuthMethod: TokenEndpointAuthMethodBasic,
+		GrantTypes:              []string{"client_credentials", "urn:ietf:params:oauth:grant-type:token-exchange"},
+		ClientName:              clientID,
+		Scopes:                  scopes,
+		UpdatedAt:               now,
+	}
+	if existing != nil {
+		client.CreatedAt = existing.CreatedAt
+		client.RedirectURIs = existing.RedirectURIs
+		client.RegistrationAccessTokenHash = existing.RegistrationAccessTokenHash
+	} else {
+		client.CreatedAt = now
+	}
+
+	if err := s.clientStore.SaveClient(ctx, client); err != nil {
+		return false, fmt.Errorf("failed to save client %q: %w", clientID, err)
+	}
+
+	s.Logger.Info("Seeded confidential OAuth client", "client_id", clientID)
+	return true, nil
 }
 
 // validateRedirectURIsWithAudit validates redirect URIs and logs failures for auditing.

--- a/server/ensure_client_test.go
+++ b/server/ensure_client_test.go
@@ -1,0 +1,74 @@
+package server
+
+import (
+	"context"
+	"testing"
+)
+
+func TestEnsureConfidentialClient(t *testing.T) {
+	setup := newTestServerSetup(false)
+	srv, err := setup.createServer(&Config{
+		Issuer:            "https://oauth.example.com",
+		AllowInsecureHTTP: false,
+	})
+	if err != nil {
+		t.Fatalf("createServer: %v", err)
+	}
+
+	ctx := context.Background()
+	const (
+		id     = "broker-client-id"
+		secret = "broker-client-secret"
+	)
+	scopes := []string{"openid"}
+
+	// First call seeds the client.
+	seeded, err := srv.EnsureConfidentialClient(ctx, id, secret, scopes)
+	if err != nil {
+		t.Fatalf("first EnsureConfidentialClient: %v", err)
+	}
+	if !seeded {
+		t.Fatal("expected first call to seed the client")
+	}
+
+	c, err := srv.GetClient(ctx, id)
+	if err != nil {
+		t.Fatalf("GetClient after seed: %v", err)
+	}
+	if !c.IsConfidential() {
+		t.Errorf("client type = %q, want confidential", c.ClientType)
+	}
+	if err := srv.ValidateClientCredentials(ctx, id, secret); err != nil {
+		t.Errorf("ValidateClientCredentials with correct secret: %v", err)
+	}
+
+	// Second call with the same credentials is a no-op.
+	seeded, err = srv.EnsureConfidentialClient(ctx, id, secret, scopes)
+	if err != nil {
+		t.Fatalf("idempotent EnsureConfidentialClient: %v", err)
+	}
+	if seeded {
+		t.Error("expected idempotent call to be a no-op")
+	}
+
+	// Changing the secret rewrites the record.
+	const newSecret = "rotated-secret"
+	seeded, err = srv.EnsureConfidentialClient(ctx, id, newSecret, scopes)
+	if err != nil {
+		t.Fatalf("rotating EnsureConfidentialClient: %v", err)
+	}
+	if !seeded {
+		t.Error("expected secret change to rewrite the record")
+	}
+	if err := srv.ValidateClientCredentials(ctx, id, newSecret); err != nil {
+		t.Errorf("ValidateClientCredentials with rotated secret: %v", err)
+	}
+
+	// Empty inputs are rejected.
+	if _, err := srv.EnsureConfidentialClient(ctx, "", secret, scopes); err == nil {
+		t.Error("expected error for empty client id")
+	}
+	if _, err := srv.EnsureConfidentialClient(ctx, id, "", scopes); err == nil {
+		t.Error("expected error for empty client secret")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `Server.EnsureConfidentialClient(ctx, clientID, clientSecret string, scopes []string) (seeded bool, err error)`: idempotently provisions a confidential OAuth client with a **caller-supplied** id and secret (unlike `RegisterClientV2`, which generates random ones). If the client already exists with a matching secret it is a no-op; otherwise the record is (re)written with a fresh bcrypt hash.

## Why

A token-exchange broker client's record (id to bcrypt secret hash) lives only in mcp-oauth's backing store (e.g. Valkey). A store wipe leaves the audience allowlist in config and the credentials in the holder's secret, but the client record gone -- so every exchange returns `invalid_client`. This method lets a consumer (muster) declaratively re-seed the known confidential broker client from a mounted secret at startup, so a store wipe self-heals.

## Test plan

- [x] New unit test `server/ensure_client_test.go` (seed, idempotent no-op, secret rotation rewrite, empty-input rejection)
- [x] `go test ./server/ ./storage/...` green
- [x] golangci-lint (v2.9.0, CI-pinned) clean

Made with [Cursor](https://cursor.com)