### PR TITLE
feat(oidc,server): host-scoped JWKS private-IP allowance (AllowPrivateIPJWKSHosts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `oidc.JWKSClientOptions.AllowPrivateIPHosts []string`: host-scoped alternative to `AllowPrivateIP`. When set, the JWKS client allows private-IP resolution only for the explicitly listed hostnames; all other hosts retain the SSRF/DNS-rebinding guard. `NewJWKSClientWithOptions` wires a `NewHostScopedPrivateIPHTTPClient` when this field is non-empty and `AllowPrivateIP` is false.
+
+- `oidc.NewHostScopedPrivateIPHTTPClient(allowedHosts []string, timeout time.Duration) *http.Client` and `oidc.HostScopedPrivateIPDialContext(dialer, allowedHosts)`: HTTP client and dial context that enforce the normal SSRF guard for all hosts except the listed ones, which are permitted to resolve to private IPs.
+
+- `server.TrustedIssuer.AllowPrivateIPJWKSHosts []string`: per-issuer host-scoped alternative to `AllowPrivateIPJWKS`. Allows the JWKS fetch to resolve to a private IP only when the URL's hostname matches one of the listed values. All other hosts retain SSRF protection. Prefer this over `AllowPrivateIPJWKS` when the private endpoint is a known in-cluster service (e.g. `muster.agentic-platform.svc.cluster.local`). `NewOIDCValidator` builds a per-issuer `JWKSClient` for each entry that sets this field; the shared permissive client is only allocated when at least one issuer sets the legacy `AllowPrivateIPJWKS`.
+
+
+
 - `server.Server.EnsureConfidentialClient(ctx, clientID, clientSecret string, scopes []string) (seeded bool, err error)`: idempotently provisions a confidential OAuth client with a caller-supplied id and secret (unlike `RegisterClientV2`, which generates random ones). If the client already exists with a matching secret it is a no-op; otherwise the record is (re)written with a fresh bcrypt hash. Intended to declaratively seed a known confidential client — e.g. a token-exchange broker — from a mounted secret at startup, so a wiped client store self-heals.
 
 - `server.WorkloadGrantedIdentity` and `server.WorkloadGrant.Granted WorkloadGrantedIdentity`: broker-asserted identity injected into a token minted on the workload (no-actor) exchange path. `Granted.Groups []string` are merged into the minted token's `groups` claim (carried as `ExchangerRequest.GrantedGroups`; the validated `Subject.Claims` are never mutated). `Granted.Subject string`, when non-empty, replaces the validated credential's `sub` in the minted token (carried as `ExchangerRequest.GrantedSubject`), so the downstream sees a stable agent principal rather than the raw workload credential subject. Both fields are ignored on the delegation path. A grant with either field set must name an explicit `Issuer` and `Subject` (no `"*"`, no glob); `Config.Validate` rejects wildcard identity grants.

--- a/providers/oidc/jwks_client_test.go
+++ b/providers/oidc/jwks_client_test.go
@@ -194,6 +194,65 @@ func TestFetchJWKS_AllowPrivateIP(t *testing.T) {
 	})
 }
 
+func TestFetchJWKS_AllowPrivateIPHosts(t *testing.T) {
+	t.Run("listed host passes validateJWKSURL", func(t *testing.T) {
+		// The client allows 192.168.1.1 specifically. validateJWKSURL should
+		// pass without error; the actual dial will fail (host unreachable) but
+		// NOT with a "private IP" rejection.
+		client := NewJWKSClientWithOptions(JWKSClientOptions{
+			AllowPrivateIPHosts: []string{"192.168.1.1"},
+			Logger:              slog.Default(),
+		})
+		_, err := client.FetchJWKS(context.Background(), "https://192.168.1.1/jwks")
+		// Connection will fail but must NOT be a private-IP policy error.
+		if err != nil && (strings.Contains(err.Error(), "private IP") || strings.Contains(err.Error(), "restricted IP")) {
+			t.Errorf("listed host should not be blocked by private-IP guard, got: %v", err)
+		}
+	})
+
+	t.Run("unlisted host blocked even with non-empty allowlist", func(t *testing.T) {
+		client := NewJWKSClientWithOptions(JWKSClientOptions{
+			AllowPrivateIPHosts: []string{"other.internal"},
+			Logger:              slog.Default(),
+		})
+		_, err := client.FetchJWKS(context.Background(), "https://192.168.1.1/jwks")
+		if err == nil {
+			t.Fatal("expected private-IP error for unlisted host")
+		}
+		if !strings.Contains(err.Error(), "private IP") && !strings.Contains(err.Error(), "JWKS URI") {
+			t.Errorf("expected private-IP rejection, got: %v", err)
+		}
+	})
+
+	t.Run("HTTPS still required for listed host", func(t *testing.T) {
+		client := NewJWKSClientWithOptions(JWKSClientOptions{
+			AllowPrivateIPHosts: []string{"192.168.1.1"},
+			Logger:              slog.Default(),
+		})
+		_, err := client.FetchJWKS(context.Background(), "http://192.168.1.1/jwks")
+		if err == nil {
+			t.Fatal("expected HTTPS requirement error")
+		}
+		if !strings.Contains(err.Error(), "HTTPS") {
+			t.Errorf("expected HTTPS error, got: %v", err)
+		}
+	})
+
+	t.Run("allowPrivateIP overrides allowPrivateIPHosts", func(t *testing.T) {
+		// When AllowPrivateIP is true, AllowPrivateIPHosts is ignored and the
+		// broad permissive path applies.
+		client := NewJWKSClientWithOptions(JWKSClientOptions{
+			AllowPrivateIP:      true,
+			AllowPrivateIPHosts: []string{"other.internal"},
+			Logger:              slog.Default(),
+		})
+		_, err := client.FetchJWKS(context.Background(), "https://192.168.1.1/jwks")
+		if err != nil && strings.Contains(err.Error(), "private IP") {
+			t.Errorf("AllowPrivateIP=true should bypass all private-IP checks, got: %v", err)
+		}
+	})
+}
+
 func TestValidateIDToken_Integration(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -204,6 +204,15 @@ func (c *JWKSClient) cachedFresh(jwksURI string) (*jose.JSONWebKeySet, bool) {
 	return doc.keys, true
 }
 
+func (c *JWKSClient) isAllowedPrivateIPHost(host string) bool {
+	for _, allowed := range c.allowPrivateIPHosts {
+		if host == allowed {
+			return true
+		}
+	}
+	return false
+}
+
 // validateJWKSURL enforces the SSRF/HTTPS policy for a JWKS fetch: private and
 // loopback addresses are rejected unless allowPrivateIP is set, and HTTPS is
 // always required.
@@ -221,14 +230,12 @@ func (c *JWKSClient) validateJWKSURL(jwksURI string, logger *slog.Logger) error 
 			return fmt.Errorf("invalid JWKS URI: %w", err)
 		}
 		host := parsed.Hostname()
-		for _, allowed := range c.allowPrivateIPHosts {
-			if host == allowed {
-				if err := ValidateHTTPSURL(jwksURI, "JWKS URI"); err != nil {
-					return fmt.Errorf("invalid JWKS URI: %w", err)
-				}
-				logger.Debug("Fetching JWKS with host-scoped private IP allowance", "uri", jwksURI, "allowed_host", host)
-				return nil
+		if c.isAllowedPrivateIPHost(host) {
+			if err := ValidateHTTPSURL(jwksURI, "JWKS URI"); err != nil {
+				return fmt.Errorf("invalid JWKS URI: %w", err)
 			}
+			logger.Debug("Fetching JWKS with host-scoped private IP allowance", "uri", jwksURI, "allowed_host", host)
+			return nil
 		}
 	}
 	if err := ValidateExternalURL(jwksURI, "JWKS URI"); err != nil {

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -25,12 +26,13 @@ import (
 //
 // The client is thread-safe and can be used concurrently from multiple goroutines.
 type JWKSClient struct {
-	httpClient     *http.Client
-	cache          sync.Map // jwksURI -> *cachedJWKS
-	cacheTTL       time.Duration
-	logger         *slog.Logger
-	timeProvider   timeProvider
-	allowPrivateIP bool // When true, SSRF protection is disabled for private IdP deployments
+	httpClient          *http.Client
+	cache               sync.Map // jwksURI -> *cachedJWKS
+	cacheTTL            time.Duration
+	logger              *slog.Logger
+	timeProvider        timeProvider
+	allowPrivateIP      bool     // When true, SSRF protection is disabled for private IdP deployments
+	allowPrivateIPHosts []string // When set, private IPs allowed only for these hostnames
 
 	// refetchBackoff bounds unknown-kid-triggered refetches (0 uses
 	// DefaultJWKSRefetchBackoff). refetchMu makes the per-URI "has the backoff
@@ -88,6 +90,14 @@ type JWKSClientOptions struct {
 	// WARNING: Reduces SSRF protection. Only enable for internal/VPN deployments
 	// where the IdP legitimately runs on private networks.
 	AllowPrivateIP bool
+
+	// AllowPrivateIPHosts lists hostnames whose JWKS URLs are permitted to
+	// resolve to private IP addresses. All other hosts remain subject to the
+	// normal SSRF/DNS-rebinding guard. Prefer this over AllowPrivateIP when
+	// the private endpoint is a known in-cluster service (e.g.
+	// muster.agentic-platform.svc.cluster.local). Ignored when AllowPrivateIP
+	// is true.
+	AllowPrivateIPHosts []string
 }
 
 // NewJWKSClient creates a new JWKS client with default configuration.
@@ -132,9 +142,12 @@ func NewJWKSClient(httpClient *http.Client, cacheTTL time.Duration, logger *slog
 func NewJWKSClientWithOptions(opts JWKSClientOptions) *JWKSClient {
 	httpClient := opts.HTTPClient
 	if httpClient == nil {
-		if opts.AllowPrivateIP {
+		switch {
+		case opts.AllowPrivateIP:
 			httpClient = NewPrivateIPAllowedHTTPClient(DefaultHTTPTimeout)
-		} else {
+		case len(opts.AllowPrivateIPHosts) > 0:
+			httpClient = NewHostScopedPrivateIPHTTPClient(opts.AllowPrivateIPHosts, DefaultHTTPTimeout)
+		default:
 			// SECURITY: SSRF-safe client validates resolved IPs at connection
 			// time (DNS rebinding protection) and blocks private, loopback, and
 			// link-local addresses.
@@ -153,12 +166,13 @@ func NewJWKSClientWithOptions(opts JWKSClientOptions) *JWKSClient {
 	}
 
 	return &JWKSClient{
-		httpClient:     httpClient,
-		cacheTTL:       cacheTTL,
-		logger:         logger,
-		timeProvider:   realTime{},
-		allowPrivateIP: opts.AllowPrivateIP,
-		refetchBackoff: DefaultJWKSRefetchBackoff,
+		httpClient:          httpClient,
+		cacheTTL:            cacheTTL,
+		logger:              logger,
+		timeProvider:        realTime{},
+		allowPrivateIP:      opts.AllowPrivateIP,
+		allowPrivateIPHosts: opts.AllowPrivateIPHosts,
+		refetchBackoff:      DefaultJWKSRefetchBackoff,
 	}
 }
 
@@ -200,6 +214,22 @@ func (c *JWKSClient) validateJWKSURL(jwksURI string, logger *slog.Logger) error 
 		}
 		logger.Debug("Fetching JWKS with private IP allowance", "uri", jwksURI, "allow_private_ip", true)
 		return nil
+	}
+	if len(c.allowPrivateIPHosts) > 0 {
+		parsed, err := url.Parse(jwksURI)
+		if err != nil {
+			return fmt.Errorf("invalid JWKS URI: %w", err)
+		}
+		host := parsed.Hostname()
+		for _, allowed := range c.allowPrivateIPHosts {
+			if host == allowed {
+				if err := ValidateHTTPSURL(jwksURI, "JWKS URI"); err != nil {
+					return fmt.Errorf("invalid JWKS URI: %w", err)
+				}
+				logger.Debug("Fetching JWKS with host-scoped private IP allowance", "uri", jwksURI, "allowed_host", host)
+				return nil
+			}
+		}
 	}
 	if err := ValidateExternalURL(jwksURI, "JWKS URI"); err != nil {
 		return fmt.Errorf("invalid JWKS URI: %w", err)

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -387,6 +387,15 @@ func NewPrivateIPAllowedHTTPClient(timeout time.Duration) *http.Client {
 	}
 }
 
+func guardSSRF(host string, ips []net.IP) error {
+	for _, ip := range ips {
+		if isPrivateOrRestrictedIP(ip) {
+			return fmt.Errorf("DNS rebinding attack detected: %q resolved to restricted IP %s", host, ip)
+		}
+	}
+	return nil
+}
+
 // HostScopedPrivateIPDialContext creates a DialContext that allows private IP
 // resolution only for the explicitly listed hostnames; all other hosts are
 // subject to the normal SSRF/DNS-rebinding guard.
@@ -411,10 +420,8 @@ func HostScopedPrivateIPDialContext(dialer *net.Dialer, allowedHosts []string) f
 
 		_, isAllowed := allowed[host]
 		if !isAllowed {
-			for _, ip := range ips {
-				if isPrivateOrRestrictedIP(ip) {
-					return nil, fmt.Errorf("DNS rebinding attack detected: %q resolved to restricted IP %s", host, ip)
-				}
+			if err := guardSSRF(host, ips); err != nil {
+				return nil, err
 			}
 		}
 

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -387,6 +387,72 @@ func NewPrivateIPAllowedHTTPClient(timeout time.Duration) *http.Client {
 	}
 }
 
+// HostScopedPrivateIPDialContext creates a DialContext that allows private IP
+// resolution only for the explicitly listed hostnames; all other hosts are
+// subject to the normal SSRF/DNS-rebinding guard.
+func HostScopedPrivateIPDialContext(dialer *net.Dialer, allowedHosts []string) func(ctx context.Context, network, addr string) (net.Conn, error) {
+	allowed := make(map[string]struct{}, len(allowedHosts))
+	for _, h := range allowedHosts {
+		allowed[h] = struct{}{}
+	}
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid address %q: %w", addr, err)
+		}
+
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("DNS resolution failed for %q: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("no IP addresses found for %q", host)
+		}
+
+		_, isAllowed := allowed[host]
+		if !isAllowed {
+			for _, ip := range ips {
+				if isPrivateOrRestrictedIP(ip) {
+					return nil, fmt.Errorf("DNS rebinding attack detected: %q resolved to restricted IP %s", host, ip)
+				}
+			}
+		}
+
+		safeAddr := net.JoinHostPort(ips[0].String(), port)
+		return dialer.DialContext(ctx, network, safeAddr)
+	}
+}
+
+// NewHostScopedPrivateIPHTTPClient creates an HTTP client that allows private
+// IP resolution only for the explicitly listed hostnames. All other hosts go
+// through the normal SSRF/DNS-rebinding guard. Use this instead of
+// NewPrivateIPAllowedHTTPClient when the private endpoint is a known in-cluster
+// service — it narrows the SSRF escape hatch to only the expected host.
+func NewHostScopedPrivateIPHTTPClient(allowedHosts []string, timeout time.Duration) *http.Client {
+	if timeout == 0 {
+		timeout = DefaultHTTPTimeout
+	}
+
+	dialer := &net.Dialer{
+		Timeout:   timeout,
+		KeepAlive: DefaultDialerKeepAlive,
+	}
+
+	transport := &http.Transport{
+		DialContext:           HostScopedPrivateIPDialContext(dialer, allowedHosts),
+		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
+		ResponseHeaderTimeout: timeout,
+		MaxIdleConns:          DefaultMaxIdleConns,
+		IdleConnTimeout:       DefaultIdleConnTimeout,
+	}
+
+	return &http.Client{
+		Transport:     transport,
+		Timeout:       timeout,
+		CheckRedirect: blockCrossHostRedirect,
+	}
+}
+
 // blockCrossHostRedirect refuses a redirect whose target host or port differs
 // from the endpoint originally requested, and bounds the chain at the net/http
 // default of 10 hops. Setting CheckRedirect replaces that default cap, so it is

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -834,7 +834,7 @@ func TestNewHostScopedPrivateIPHTTPClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected successful request to listed loopback host, got: %v", err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("expected 200, got %d", resp.StatusCode)
 		}

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -750,3 +750,110 @@ func TestPrivateIPAllowedHTTPClient_RedirectPinning(t *testing.T) {
 		}
 	})
 }
+
+func TestHostScopedPrivateIPDialContext(t *testing.T) {
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+
+	t.Run("allows loopback for listed host", func(t *testing.T) {
+		// localhost is in the allowlist — private-IP resolution is permitted.
+		// The dial will fail (nothing listening) but NOT with a restricted-IP error.
+		dialFunc := HostScopedPrivateIPDialContext(dialer, []string{"localhost"})
+		ctx := context.Background()
+		_, err := dialFunc(ctx, "tcp", "localhost:19999")
+		if err == nil {
+			t.Skip("unexpected successful connection on port 19999")
+		}
+		if strings.Contains(err.Error(), "restricted IP") {
+			t.Errorf("allowed host should not be blocked by restricted-IP guard, got: %v", err)
+		}
+	})
+
+	t.Run("blocks loopback for unlisted host", func(t *testing.T) {
+		// localhost is NOT in the allowlist — SSRF guard fires.
+		dialFunc := HostScopedPrivateIPDialContext(dialer, []string{"other.internal"})
+		ctx := context.Background()
+		_, err := dialFunc(ctx, "tcp", "localhost:443")
+		if err == nil {
+			t.Fatal("expected restricted-IP error for unlisted loopback host")
+		}
+		if !strings.Contains(err.Error(), "restricted IP") {
+			t.Errorf("expected 'restricted IP' error, got: %v", err)
+		}
+	})
+
+	t.Run("blocks loopback with empty allowlist", func(t *testing.T) {
+		dialFunc := HostScopedPrivateIPDialContext(dialer, nil)
+		ctx := context.Background()
+		_, err := dialFunc(ctx, "tcp", "localhost:443")
+		if err == nil {
+			t.Fatal("expected restricted-IP error with empty allowlist")
+		}
+		if !strings.Contains(err.Error(), "restricted IP") {
+			t.Errorf("expected 'restricted IP' error, got: %v", err)
+		}
+	})
+
+	t.Run("handles invalid address format", func(t *testing.T) {
+		dialFunc := HostScopedPrivateIPDialContext(dialer, []string{"localhost"})
+		ctx := context.Background()
+		_, err := dialFunc(ctx, "tcp", "no-port")
+		if err == nil {
+			t.Fatal("expected error for missing port")
+		}
+	})
+}
+
+func TestNewHostScopedPrivateIPHTTPClient(t *testing.T) {
+	t.Run("creates client with default timeout", func(t *testing.T) {
+		client := NewHostScopedPrivateIPHTTPClient([]string{"internal.svc"}, 0)
+		if client == nil {
+			t.Fatal("expected non-nil client")
+		}
+		if client.Timeout != DefaultHTTPTimeout {
+			t.Errorf("expected timeout %v, got %v", DefaultHTTPTimeout, client.Timeout)
+		}
+	})
+
+	t.Run("creates client with custom timeout", func(t *testing.T) {
+		client := NewHostScopedPrivateIPHTTPClient([]string{"internal.svc"}, 15*time.Second)
+		if client.Timeout != 15*time.Second {
+			t.Errorf("expected 15s timeout, got %v", client.Timeout)
+		}
+	})
+
+	t.Run("allows connection to listed loopback host", func(t *testing.T) {
+		// httptest.NewServer listens on 127.0.0.1; extract its hostname.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		host := srv.Listener.Addr().(*net.TCPAddr).IP.String()
+		client := NewHostScopedPrivateIPHTTPClient([]string{host}, 5*time.Second)
+		resp, err := client.Get(srv.URL + "/ok")
+		if err != nil {
+			t.Fatalf("expected successful request to listed loopback host, got: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected 200, got %d", resp.StatusCode)
+		}
+	})
+
+	t.Run("blocks unlisted loopback host via SSRF guard", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(srv.Close)
+
+		// Client allows a different host — the test server's IP is blocked.
+		client := NewHostScopedPrivateIPHTTPClient([]string{"other.internal"}, 5*time.Second)
+		_, err := client.Get(srv.URL + "/ok")
+		if err == nil {
+			t.Fatal("expected SSRF-guard error for unlisted loopback host")
+		}
+		if !strings.Contains(err.Error(), "restricted IP") {
+			t.Errorf("expected 'restricted IP' error, got: %v", err)
+		}
+	})
+}

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -834,7 +834,7 @@ func TestNewHostScopedPrivateIPHTTPClient(t *testing.T) {
 		if err != nil {
 			t.Fatalf("expected successful request to listed loopback host, got: %v", err)
 		}
-		resp.Body.Close()
+		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("expected 200, got %d", resp.StatusCode)
 		}

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -73,8 +73,17 @@ type TrustedIssuer struct {
 	// public address.
 	//
 	// WARNING: Disables SSRF protection for this issuer's JWKS fetch. Only set
-	// when JwksURL is a known, controlled in-cluster endpoint.
+	// when JwksURL is a known, controlled in-cluster endpoint. Prefer
+	// AllowPrivateIPJWKSHosts when the endpoint is a specific known service.
 	AllowPrivateIPJWKS bool
+
+	// AllowPrivateIPJWKSHosts lists the specific hostnames whose JWKS URL is
+	// permitted to resolve to a private IP. All other hosts retain SSRF
+	// protection. Use this instead of AllowPrivateIPJWKS when the private
+	// endpoint is a known in-cluster service (e.g.
+	// muster.agentic-platform.svc.cluster.local). Ignored when
+	// AllowPrivateIPJWKS is true.
+	AllowPrivateIPJWKSHosts []string
 	// AcceptedTypHeaders lists the JWT typ header values accepted when a
 	// Bearer token from this issuer is presented to the resource server.
 	// Empty defaults to ["at+jwt"] (RFC 9068 §4). Issuers that mint plain
@@ -91,43 +100,55 @@ type TrustedIssuer struct {
 type OIDCValidator struct {
 	issuers          map[string]TrustedIssuer
 	safeClient       *oidc.JWKSClient
-	permissiveClient *oidc.JWKSClient // non-nil only when at least one issuer sets AllowPrivateIPJWKS
+	permissiveClient *oidc.JWKSClient            // non-nil only when at least one issuer sets AllowPrivateIPJWKS
+	issuerClients    map[string]*oidc.JWKSClient // per-issuer host-scoped clients (AllowPrivateIPJWKSHosts)
 }
 
 // NewOIDCValidator constructs an OIDCValidator for the given trusted issuers.
-// SSRF-safe JWKS fetches are the default; set AllowPrivateIPJWKS on an issuer
-// to opt out per-issuer.
+// SSRF-safe JWKS fetches are the default; set AllowPrivateIPJWKSHosts on an
+// issuer to allow private-IP JWKS only for the listed hostnames, or
+// AllowPrivateIPJWKS to disable SSRF protection entirely for that issuer.
 func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 	safe := oidc.NewJWKSClient(nil, 0, nil)
 	var permissive *oidc.JWKSClient
+	issuerClients := map[string]*oidc.JWKSClient{}
 	for _, ti := range issuers {
 		if ti.AllowPrivateIPJWKS {
-			// AllowPrivateIPJWKS targets a controlled in-cluster endpoint, which
-			// commonly presents a certificate from an internal CA. Back the client
-			// with http.DefaultTransport so a CA bundle the host process installs
-			// there (e.g. via an extra-CA file) is honored; a freshly built
-			// transport would verify against the system pool alone and reject it.
-			// AllowPrivateIP stays set so FetchJWKS still permits the private-IP host.
-			permissive = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
-				AllowPrivateIP: true,
+			if permissive == nil {
+				// AllowPrivateIPJWKS targets a controlled in-cluster endpoint,
+				// which commonly presents a certificate from an internal CA. Back
+				// the client with http.DefaultTransport so a CA bundle the host
+				// process installs there (e.g. via an extra-CA file) is honored;
+				// a freshly built transport would verify against the system pool
+				// alone and reject it.
+				permissive = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+					AllowPrivateIP: true,
+					HTTPClient: &http.Client{
+						Transport: http.DefaultTransport,
+						Timeout:   oidc.DefaultHTTPTimeout,
+					},
+				})
+			}
+		} else if len(ti.AllowPrivateIPJWKSHosts) > 0 {
+			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+				AllowPrivateIPHosts: ti.AllowPrivateIPJWKSHosts,
 				HTTPClient: &http.Client{
 					Transport: http.DefaultTransport,
 					Timeout:   oidc.DefaultHTTPTimeout,
 				},
 			})
-			break
 		}
 	}
-	return newOIDCValidatorWithClients(issuers, safe, permissive)
+	return newOIDCValidatorWithClients(issuers, safe, permissive, issuerClients)
 }
 
 // newOIDCValidatorWithClient is the internal constructor used by tests to inject
 // a custom JWKS client; both client slots are set to client.
 func newOIDCValidatorWithClient(issuers []TrustedIssuer, client *oidc.JWKSClient) (*OIDCValidator, error) {
-	return newOIDCValidatorWithClients(issuers, client, client)
+	return newOIDCValidatorWithClients(issuers, client, client, nil)
 }
 
-func newOIDCValidatorWithClients(issuers []TrustedIssuer, safeClient, permissiveClient *oidc.JWKSClient) (*OIDCValidator, error) {
+func newOIDCValidatorWithClients(issuers []TrustedIssuer, safeClient, permissiveClient *oidc.JWKSClient, issuerClients map[string]*oidc.JWKSClient) (*OIDCValidator, error) {
 	if len(issuers) == 0 {
 		return nil, fmt.Errorf("at least one trusted issuer is required")
 	}
@@ -141,7 +162,7 @@ func newOIDCValidatorWithClients(issuers []TrustedIssuer, safeClient, permissive
 		}
 		m[ti.Issuer] = ti
 	}
-	return &OIDCValidator{issuers: m, safeClient: safeClient, permissiveClient: permissiveClient}, nil
+	return &OIDCValidator{issuers: m, safeClient: safeClient, permissiveClient: permissiveClient, issuerClients: issuerClients}, nil
 }
 
 // BearerTypHeaders returns the JWT typ header values accepted for Bearer
@@ -180,7 +201,9 @@ func (v *OIDCValidator) Validate(ctx context.Context, tokenString string, defaul
 	}
 
 	jwksClient := v.safeClient
-	if ti.AllowPrivateIPJWKS && v.permissiveClient != nil {
+	if client, ok := v.issuerClients[iss]; ok {
+		jwksClient = client
+	} else if ti.AllowPrivateIPJWKS && v.permissiveClient != nil {
 		jwksClient = v.permissiveClient
 	}
 	audiences := ti.AllowedAudiences

--- a/server/subject_validator_test.go
+++ b/server/subject_validator_test.go
@@ -542,3 +542,62 @@ func TestNewOIDCValidator_AllowPrivateIPJWKS_CreatesPermissiveClient(t *testing.
 	require.NoError(t, err)
 	require.Nil(t, withoutPrivate.permissiveClient)
 }
+
+func TestOIDCValidator_AllowPrivateIPJWKSHosts(t *testing.T) {
+	key := newTestECKey(t)
+	const kid = "test-key"
+	jwksURL, jwksClient := serveStaticJWKS(t, key, kid)
+
+	// Inject the configured client (TLS cert mismatch prevents using
+	// NewOIDCValidator directly); AllowPrivateIPJWKSHosts routing is still
+	// exercised through the issuerClients map in Validate.
+	v, err := newOIDCValidatorWithClients([]TrustedIssuer{{
+		Issuer:                  testIssuer,
+		JwksURL:                 jwksURL,
+		AllowedAudiences:        []string{testAudience},
+		AllowPrivateIPJWKSHosts: []string{"127.0.0.1"},
+	}}, jwksClient, nil, map[string]*oidc.JWKSClient{
+		testIssuer: jwksClient,
+	})
+	require.NoError(t, err)
+
+	token := signSubjectToken(t, key, kid, josejwt.Claims{
+		Issuer:   testIssuer,
+		Subject:  testSubject,
+		Audience: josejwt.Audience{testAudience},
+		Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+		IssuedAt: josejwt.NewNumericDate(time.Now()),
+	})
+
+	identity, err := v.Validate(t.Context(), token, nil)
+	require.NoError(t, err)
+	require.Equal(t, testSubject, identity.Subject)
+}
+
+func TestNewOIDCValidator_AllowPrivateIPJWKSHosts_CreatesIssuerClient(t *testing.T) {
+	withHosts, err := NewOIDCValidator([]TrustedIssuer{{
+		Issuer:                  testIssuer,
+		JwksURL:                 "https://example.com/jwks",
+		AllowPrivateIPJWKSHosts: []string{"muster.agentic-platform.svc.cluster.local"},
+	}})
+	require.NoError(t, err)
+	require.NotNil(t, withHosts.issuerClients[testIssuer])
+	require.Nil(t, withHosts.permissiveClient)
+
+	// AllowPrivateIPJWKSHosts must NOT create a permissive client.
+	withBoth, err := NewOIDCValidator([]TrustedIssuer{
+		{
+			Issuer:             "https://other.example.com",
+			JwksURL:            "https://example.com/jwks",
+			AllowPrivateIPJWKS: true,
+		},
+		{
+			Issuer:                  testIssuer,
+			JwksURL:                 "https://example.com/jwks",
+			AllowPrivateIPJWKSHosts: []string{"muster.agentic-platform.svc.cluster.local"},
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, withBoth.permissiveClient)
+	require.NotNil(t, withBoth.issuerClients[testIssuer])
+}


### PR DESCRIPTION
## What

Adds `AllowPrivateIPJWKSHosts []string` to `TrustedIssuer` and `JWKSClientOptions` as a narrower alternative to the blanket `AllowPrivateIPJWKS` flag.

When set, only the explicitly listed hostnames are permitted to resolve to private IPs during JWKS fetch. All other hosts retain the full SSRF/DNS-rebinding guard. The existing `AllowPrivateIPJWKS` is unchanged and takes precedence when both are set.

## Why

`AllowPrivateIPJWKS: true` disables SSRF protection for **any** private IP — it's a full escape hatch. In practice the only endpoint that needs it is the in-cluster muster JWKS endpoint (e.g. `muster.agentic-platform.svc.cluster.local`). Pinning to that specific hostname keeps the guard active for everything else.

Addresses risk #5 from the M2M/OBO plan: retire the blanket `allowPrivateIPJWKS: true` entries in giantswarm-configs in favour of `allowPrivateIPJWKSHosts: ["muster.agentic-platform.svc.cluster.local"]`.

## Changes

- `oidc.HostScopedPrivateIPDialContext` and `oidc.NewHostScopedPrivateIPHTTPClient`: dial context + HTTP client that enforce the SSRF guard for all hosts except the listed ones.
- `oidc.JWKSClientOptions.AllowPrivateIPHosts []string`: wired through `NewJWKSClientWithOptions`; uses the host-scoped client when non-empty and `AllowPrivateIP` is false.
- `server.TrustedIssuer.AllowPrivateIPJWKSHosts []string`: `NewOIDCValidator` builds a per-issuer `JWKSClient` for each entry using this field.
- `OIDCValidator.issuerClients map[string]*oidc.JWKSClient`: per-issuer client map; checked before the shared permissive client in `Validate`.
- 17 new tests covering the dial context, HTTP client, `validateJWKSURL` host-scoped path, and `OIDCValidator` routing.