### PR TITLE
feat(server): opt-in DelegationDefaultResource for resource-less exchange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `server.Config.DelegationDefaultResource string`: RFC 8707 resource applied to a local token-exchange request that carries an `actor_token` but omits both `audience` and `resource`. The minted token is bound to this value (typically the server's own resource identifier), so an on-behalf-of caller that cannot set a resource itself still gets a token accepted back at this server. Gated to the delegation path: a resource-less exchange with no `actor_token` is still rejected with `invalid_request`. Empty (the default) disables it.
+
 - `oidc.JWKSClientOptions.AllowPrivateIPHosts []string`: host-scoped alternative to `AllowPrivateIP`. When set, the JWKS client allows private-IP resolution only for the explicitly listed hostnames; all other hosts retain the SSRF/DNS-rebinding guard. `NewJWKSClientWithOptions` wires a `NewHostScopedPrivateIPHTTPClient` when this field is non-empty and `AllowPrivateIP` is false.
 
 - `oidc.NewHostScopedPrivateIPHTTPClient(allowedHosts []string, timeout time.Duration) *http.Client` and `oidc.HostScopedPrivateIPDialContext(dialer, allowedHosts)`: HTTP client and dial context that enforce the normal SSRF guard for all hosts except the listed ones, which are permitted to resolve to private IPs.

--- a/handler/token_exchange.go
+++ b/handler/token_exchange.go
@@ -61,6 +61,15 @@ func (h *Handler) handleTokenExchangeGrant(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// A delegation (on-behalf-of) caller may omit resource when it cannot set one
+	// itself; bind the mint to the configured default (this server's own resource
+	// identifier) so the token is accepted back here and re-minted per-backend.
+	// Gated to the actor path and opt-in: a resource-less exchange with no
+	// actor_token still errors below.
+	if resource == "" && actorToken != "" && h.server.Config.DelegationDefaultResource != "" {
+		resource = h.server.Config.DelegationDefaultResource
+	}
+
 	if resource == "" {
 		h.logAuthFailure(r.Context(), "", clientIP, "token_exchange_resource_missing",
 			"token exchange: resource missing")

--- a/handler/token_exchange_test.go
+++ b/handler/token_exchange_test.go
@@ -41,9 +41,11 @@ func (f *fakeSubjectValidator) Validate(_ context.Context, _ string, _ []string)
 type tokenExchangeHarnessOption func(*tokenExchangeHarnessConfig)
 
 type tokenExchangeHarnessConfig struct {
-	validator          server.SubjectTokenValidator
-	maxRequestBodySize int64
-	nonceProvider      server.DPoPNonceProvider
+	validator                 server.SubjectTokenValidator
+	maxRequestBodySize        int64
+	nonceProvider             server.DPoPNonceProvider
+	delegationDefaultResource string
+	actorDelegationPolicy     []server.DelegationGrant
 }
 
 func withSubjectValidator(v server.SubjectTokenValidator) tokenExchangeHarnessOption {
@@ -52,6 +54,14 @@ func withSubjectValidator(v server.SubjectTokenValidator) tokenExchangeHarnessOp
 
 func withMaxRequestBodySize(n int64) tokenExchangeHarnessOption {
 	return func(c *tokenExchangeHarnessConfig) { c.maxRequestBodySize = n }
+}
+
+func withDelegationDefaultResource(resource string) tokenExchangeHarnessOption {
+	return func(c *tokenExchangeHarnessConfig) { c.delegationDefaultResource = resource }
+}
+
+func withActorDelegationPolicy(grants ...server.DelegationGrant) tokenExchangeHarnessOption {
+	return func(c *tokenExchangeHarnessConfig) { c.actorDelegationPolicy = grants }
 }
 
 func withDPoPNonceProvider(p server.DPoPNonceProvider) tokenExchangeHarnessOption {
@@ -86,6 +96,8 @@ func setupTokenExchangeHandler(t *testing.T, opts ...tokenExchangeHarnessOption)
 		AccessTokenSigningAlgorithm: server.SigningAlgorithmRS256,
 		DisableNonceEchoRequirement: true,
 		MaxRequestBodySize:          cfg.maxRequestBodySize,
+		DelegationDefaultResource:   cfg.delegationDefaultResource,
+		ActorDelegationPolicy:       cfg.actorDelegationPolicy,
 	}
 
 	srvOpts := []server.Option{
@@ -292,6 +304,74 @@ func TestHandleTokenExchangeGrant(t *testing.T) {
 			}
 		})
 	}
+}
+
+// DelegationDefaultResource lets an on-behalf-of caller omit resource: the
+// local exchange binds the mint to the configured default. Gated to the actor
+// path and opt-in.
+func TestHandleTokenExchangeGrant_DelegationDefaultResource(t *testing.T) {
+	const selfResource = "https://api.example.com" // matches harness ResourceIdentifier
+
+	identity := server.SubjectIdentity{
+		Subject: "system:serviceaccount:kagent:sre-agent",
+		Issuer:  "https://oidc.example.com",
+	}
+	allowSelf := server.DelegationGrant{
+		ActorIssuer:    identity.Issuer,
+		ActorSubject:   identity.Subject,
+		SubjectIssuer:  identity.Issuer,
+		SubjectSubject: identity.Subject,
+	}
+	delegationForm := func() url.Values {
+		v := happyExchangeForm()
+		v.Del("resource")
+		v.Set("actor_token", "opaque-actor-token")
+		v.Set("actor_token_type", server.SubjectTokenTypeIDToken)
+		return v
+	}
+
+	t.Run("delegation defaults missing resource and mints", func(t *testing.T) {
+		h, buf := setupTokenExchangeHandler(t,
+			withSubjectValidator(&fakeSubjectValidator{identity: identity}),
+			withDelegationDefaultResource(selfResource),
+			withActorDelegationPolicy(allowSelf),
+		)
+		w := httptest.NewRecorder()
+		h.ServeToken(w, newTokenExchangeRequest(delegationForm()))
+
+		require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+		require.True(t, auditEventLogged(t, buf, security.EventTokenIssued),
+			"missing token_issued audit in: %s", buf.String())
+	})
+
+	t.Run("no actor token still requires resource", func(t *testing.T) {
+		h, buf := setupTokenExchangeHandler(t,
+			withSubjectValidator(&fakeSubjectValidator{identity: identity}),
+			withDelegationDefaultResource(selfResource),
+		)
+		form := happyExchangeForm()
+		form.Del("resource") // no actor_token: not a delegation request
+		w := httptest.NewRecorder()
+		h.ServeToken(w, newTokenExchangeRequest(form))
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.True(t, auditAuthFailureWithReason(t, buf, "token_exchange_resource_missing"),
+			"want resource_missing in: %s", buf.String())
+	})
+
+	t.Run("disabled default still requires resource", func(t *testing.T) {
+		h, buf := setupTokenExchangeHandler(t,
+			withSubjectValidator(&fakeSubjectValidator{identity: identity}),
+			withActorDelegationPolicy(allowSelf),
+			// opt-in off: no withDelegationDefaultResource
+		)
+		w := httptest.NewRecorder()
+		h.ServeToken(w, newTokenExchangeRequest(delegationForm()))
+
+		require.Equal(t, http.StatusBadRequest, w.Code)
+		require.True(t, auditAuthFailureWithReason(t, buf, "token_exchange_resource_missing"),
+			"want resource_missing in: %s", buf.String())
+	})
 }
 
 // The 405 comes from ServeToken before handleTokenExchangeGrant runs.

--- a/server/config.go
+++ b/server/config.go
@@ -843,6 +843,18 @@ type Config struct {
 	// rejected with invalid_client (existing behaviour).
 	EnableWorkloadTokenExchange bool
 
+	// DelegationDefaultResource sets the RFC 8707 resource for a local
+	// token-exchange request that carries an actor_token but omits both audience
+	// and resource. It exists for delegation (on-behalf-of) callers that cannot
+	// set a resource themselves: the minted token is bound to this value
+	// (typically this server's own resource identifier) so it is accepted back
+	// at this server and re-minted per-backend downstream.
+	//
+	// Gated to the delegation path: a request with no actor_token still requires
+	// an explicit resource. Empty (the default) disables the behaviour — a
+	// resource-less local exchange is rejected with invalid_request.
+	DelegationDefaultResource string
+
 	// SessionIDHMACKey optionally replaces the default SHA-256 session-ID derivation
 	// in Server.AcceptForwardedIDToken with HMAC-SHA-256 keyed by this value.
 	//


### PR DESCRIPTION
## What

Adds `server.Config.DelegationDefaultResource string` (opt-in, empty by default). On the local token-exchange flow, when a request carries an `actor_token` but omits both `audience` and `resource`, the handler defaults `resource` to this value instead of rejecting with `resource_missing`.

## Why

On-behalf-of callers that can't set an RFC 8707 `resource` themselves (e.g. a kagent agent's STS plugin that posts `subject=human` + `actor=SA` but no resource) currently fail with `token_exchange_resource_missing`. Binding the mint to the server's own resource identifier yields a token the server accepts back at its own front door and re-mints per-backend (preserving the `act` chain via the existing localMint exchanger).

## Security

- Authorization is unchanged: subject + actor validation and `ActorDelegationPolicy` still gate the mint. `resource` is a targeting parameter, not an authorization one.
- Gated to the delegation path: a resource-less exchange with **no** `actor_token` still errors.
- Opt-in: empty default preserves current behavior.
- The minted audience is the server's own resource identifier (narrow), not a wildcard.

## Tests

`TestHandleTokenExchangeGrant_DelegationDefaultResource`: mints with defaulted resource on the delegation path; still requires resource when no actor; still requires resource when the option is unset.