### PR TITLE
feat(server): assign a session ID to every validated token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The resource-server `ValidateToken` middleware now assigns a session ID to every validated token, not only those backed by stored refresh-token-family metadata. A token with a family still uses its `FamilyID`; any other validated token (forwarded ID token, trusted-issuer M2M/OBO, self-issued exchange-minted JWT) falls back to `SessionIDForBearer`. Self-issued exchange-minted JWTs previously reached downstream handlers with no session, so resource servers could not session-scope an on-behalf-of bearer re-presented at the front door; they now carry one.
+
 ### Added
+
+- `server.Server.SessionIDForBearer(bearerToken string) string`: returns the deterministic `ext-<hex>` session identifier for a validated bearer with no refresh-token family. Same derivation the forwarded-token and workload-exchange paths use, so the value agrees across hops.
 
 - `server.Config.DelegationDefaultResource string`: RFC 8707 resource applied to a local token-exchange request that carries an `actor_token` but omits both `audience` and `resource`. The minted token is bound to this value (typically the server's own resource identifier), so an on-behalf-of caller that cannot set a resource itself still gets a token accepted back at this server. Gated to the delegation path: a resource-less exchange with no `actor_token` is still rejected with `invalid_request`. Empty (the default) disables it.
 

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -66,23 +66,34 @@ func (h *Handler) ValidateToken(next http.Handler) http.Handler {
 		}
 
 		ctx := contextWithValidatedToken(r.Context(), userInfo, metadata)
+		ctx = ContextWithSessionID(ctx, h.sessionIDForToken(accessToken, metadata))
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
-// contextWithValidatedToken stamps the authenticated UserInfo on ctx and,
-// when metadata is available, also propagates the session ID (refresh-token
-// family) and the access token's granted scopes. Zero-valued metadata fields
-// are skipped so downstream consumers can distinguish "absent" from "empty".
+// sessionIDForToken is the single source of session identity for a validated
+// access token. A token backed by a refresh-token family (interactive login or
+// refresh, opaque or JWT) uses that family ID. Every other validated token —
+// forwarded ID token, trusted-issuer M2M/OBO, self-issued exchange-minted JWT —
+// has no family and falls back to the deterministic bearer-derived ID. Both the
+// forwarded-token and workload-exchange paths compute the same fallback, so the
+// value agrees across hops. Returning it for every token (not only those with
+// stored metadata) is what lets resource servers session-scope a self-issued
+// on-behalf-of bearer re-presented at the front door.
+func (h *Handler) sessionIDForToken(accessToken string, metadata *storage.TokenMetadata) string {
+	if metadata != nil && metadata.FamilyID != "" {
+		return metadata.FamilyID
+	}
+	return h.server.SessionIDForBearer(accessToken)
+}
+
+// contextWithValidatedToken stamps the authenticated UserInfo on ctx and, when
+// metadata is available, the access token's granted scopes. The session ID is
+// assigned separately by the caller via sessionIDForToken so that every
+// validated token gets one, not only those with stored metadata.
 func contextWithValidatedToken(ctx context.Context, userInfo *providers.UserInfo, metadata *storage.TokenMetadata) context.Context {
 	ctx = ContextWithUserInfo(ctx, userInfo)
-	if metadata == nil {
-		return ctx
-	}
-	if metadata.FamilyID != "" {
-		ctx = ContextWithSessionID(ctx, metadata.FamilyID)
-	}
-	if len(metadata.Scopes) > 0 {
+	if metadata != nil && len(metadata.Scopes) > 0 {
 		ctx = ContextWithScopes(ctx, metadata.Scopes)
 	}
 	return ctx

--- a/handler/middleware_test.go
+++ b/handler/middleware_test.go
@@ -1504,11 +1504,15 @@ func TestHandler_ValidateToken_SessionIDFromContext_WithoutFamilyID(t *testing.T
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", w.Code, http.StatusOK)
 	}
-	if sessionOK {
-		t.Error("SessionIDFromContext() should return false when no FamilyID is set")
+	// A validated token with no refresh-token family falls back to the
+	// deterministic bearer-derived session ID, so every validated token can be
+	// session-scoped downstream.
+	if !sessionOK {
+		t.Error("SessionIDFromContext() should return a bearer-derived session when no FamilyID is set")
 	}
-	if capturedSessionID != "" {
-		t.Errorf("SessionIDFromContext() = %q, want empty", capturedSessionID)
+	want := srv.SessionIDForBearer(accessToken)
+	if capturedSessionID != want {
+		t.Errorf("SessionIDFromContext() = %q, want %q", capturedSessionID, want)
 	}
 }
 

--- a/server/forwarded.go
+++ b/server/forwarded.go
@@ -269,6 +269,16 @@ func (s *Server) AcceptTrustedIssuerToken(ctx context.Context, bearerToken strin
 // for other keyed derivations without risking cross-purpose collisions.
 // hash.Hash.Write never returns an error — the doc on hash.Hash guarantees it —
 // so the results are ignored.
+// SessionIDForBearer returns the stable session identifier for a validated
+// bearer that has no refresh-token family: forwarded ID tokens, trusted-issuer
+// M2M/OBO tokens, and self-issued exchange-minted JWTs. It is the same
+// derivation the forwarded-token and workload-exchange paths use, exported so
+// the resource-server middleware can assign a session to every validated
+// token, not only those backed by stored family metadata.
+func (s *Server) SessionIDForBearer(bearerToken string) string {
+	return s.deriveForwardedSessionID(bearerToken)
+}
+
 func (s *Server) deriveForwardedSessionID(bearerToken string) string {
 	var digest []byte
 	if len(s.Config.SessionIDHMACKey) > 0 {

--- a/server/forwarded_test.go
+++ b/server/forwarded_test.go
@@ -360,6 +360,30 @@ func TestAcceptForwardedIDToken_HMACKeyChangesSessionID(t *testing.T) {
 	}
 }
 
+// TestSessionIDForBearer_MatchesForwardedDerivation locks the exported
+// SessionIDForBearer to the same derivation the forwarded-token and
+// workload-exchange paths use, so a session assigned to a self-issued token in
+// the resource-server middleware agrees with the audit/rate-limit session the
+// exchange computes for the same bearer.
+func TestSessionIDForBearer_MatchesForwardedDerivation(t *testing.T) {
+	h := newForwardedTokenHarness(t)
+	tok := h.signToken(t, h.validClaims())
+
+	got := h.srv.SessionIDForBearer(tok)
+	if got != h.srv.deriveForwardedSessionID(tok) {
+		t.Errorf("SessionIDForBearer diverged from deriveForwardedSessionID: %q", got)
+	}
+	if !strings.HasPrefix(got, "ext-") || len(got) != len("ext-")+16 {
+		t.Errorf("SessionIDForBearer shape unexpected: %q", got)
+	}
+	if again := h.srv.SessionIDForBearer(tok); got != again {
+		t.Errorf("SessionIDForBearer not deterministic: %q vs %q", got, again)
+	}
+	if other := h.srv.SessionIDForBearer(tok + "x"); other == got {
+		t.Error("SessionIDForBearer must differ for a different bearer")
+	}
+}
+
 // TestAcceptForwardedIDToken_EmptyBearer guards the explicit empty-token check
 // so callers get a clear error instead of a noisy parse_error metric on every
 // unauthenticated request.


### PR DESCRIPTION
## What

The resource-server `ValidateToken` middleware only derived a session ID from stored refresh-token-family metadata (`TokenMetadataStore` → `FamilyID`). Any validated token without a family — forwarded ID tokens, trusted-issuer M2M/OBO tokens, and **self-issued exchange-minted JWTs** — reached downstream handlers with no session.

That last case is the on-behalf-of path: an OBO bearer (`sub=human`, `act=agent`) minted by this broker and re-presented at its own front door is signature-validated with no token-store entry, so it carried no session. Resource servers (e.g. muster's aggregator) that session-scope per-caller state — backend connection pools, capability caches, the auth dispatch gate — then failed closed on those tokens, falling back to the agent ServiceAccount instead of acting as the human.

## Change

Assign the session uniformly for every validated token:

- token backed by a refresh-token family → its `FamilyID` (unchanged);
- any other validated token → deterministic bearer-derived ID via the new exported `Server.SessionIDForBearer`.

`SessionIDForBearer` is the same `deriveForwardedSessionID` the forwarded-token and workload-exchange paths already use, so the value now **agrees across hops** (the exchange's audit/rate-limit session, the forwarded-token session, and the middleware session are identical for the same bearer) instead of being computed by a separate rule in each place.

No mcp-oauth code consumes the session internally, so populating it for stateless tokens changes only what is handed to resource-server consumers; the M2M/forwarded session value is unchanged (same function, same bearer).

## Tests

- Updated `TestHandler_ValidateToken_SessionIDFromContext_WithoutFamilyID` to assert the new contract (a no-family token now carries the bearer-derived session).
- Added `TestSessionIDForBearer_MatchesForwardedDerivation` locking the exported API to the forwarded derivation (determinism, `ext-` shape, per-bearer uniqueness).
- Full `handler` + `server` suites green (1947).