### PR TITLE
fix(broker): strip actor token when it resolves to the same identity as the subject

### DIFF
--- a/handler/token_exchange_broker_test.go
+++ b/handler/token_exchange_broker_test.go
@@ -40,6 +40,7 @@ type brokeredExchangeHarness struct {
 	logs         *bytes.Buffer
 	clientID     string
 	clientSecret string
+	validator    *fakeSubjectValidator
 }
 
 // setupBrokeredExchangeHandler builds a handler with a registered confidential
@@ -93,6 +94,7 @@ func setupBrokeredExchangeHandler(t *testing.T, exchanger server.Exchanger, allo
 		logs:         &buf,
 		clientID:     client.ClientID,
 		clientSecret: clientSecret,
+		validator:    validator,
 	}
 }
 
@@ -301,9 +303,14 @@ func TestHandleBrokeredTokenExchange_ActorTokenMissingType(t *testing.T) {
 func TestHandleBrokeredTokenExchange_ActorTokenForwarded(t *testing.T) {
 	ex := &stubExchanger{result: happyDownstreamResult()}
 	h := setupBrokeredExchangeHandler(t, ex, []string{"gaggle"}, "confidential")
-	// fakeSubjectValidator returns "user@example.com" for both tokens; allow that actor for that subject.
+	// Use distinct identities for subject and actor so the self-delegation short-circuit
+	// does not trigger and the actor is forwarded with an act claim.
+	h.validator.byToken = map[string]*server.SubjectIdentity{
+		"subject-id-token": {Subject: "user@example.com", Issuer: "https://dex.example.com"},
+		"actor-jwt":        {Subject: "agent@example.com", Issuer: "https://dex.example.com"},
+	}
 	h.srv.Config.ActorDelegationPolicy = []server.DelegationGrant{
-		{ActorIssuer: "*", ActorSubject: "user@example.com", SubjectIssuer: "*", SubjectSubject: "user@example.com"},
+		{ActorIssuer: "*", ActorSubject: "agent@example.com", SubjectIssuer: "*", SubjectSubject: "user@example.com"},
 	}
 
 	form := brokeredExchangeForm()
@@ -318,8 +325,8 @@ func TestHandleBrokeredTokenExchange_ActorTokenForwarded(t *testing.T) {
 	require.NotNil(t, ex.gotReq)
 	require.Equal(t, "actor-jwt", ex.gotReq.ActorToken)
 	require.Equal(t, server.SubjectTokenTypeIDToken, ex.gotReq.ActorTokenType)
-	// Actor identity comes from the same fakeSubjectValidator used for the subject.
 	require.NotNil(t, ex.gotReq.Actor)
+	require.Equal(t, "agent@example.com", ex.gotReq.Actor.Subject)
 }
 
 // Workload-authenticated handler tests.

--- a/handler/token_exchange_test.go
+++ b/handler/token_exchange_test.go
@@ -28,12 +28,16 @@ import (
 
 type fakeSubjectValidator struct {
 	identity server.SubjectIdentity
+	byToken  map[string]*server.SubjectIdentity
 	err      error
 }
 
-func (f *fakeSubjectValidator) Validate(_ context.Context, _ string, _ []string) (*server.SubjectIdentity, error) {
+func (f *fakeSubjectValidator) Validate(_ context.Context, token string, _ []string) (*server.SubjectIdentity, error) {
 	if f.err != nil {
 		return nil, f.err
+	}
+	if id, ok := f.byToken[token]; ok {
+		return id, nil
 	}
 	return &f.identity, nil
 }

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -87,21 +87,27 @@ func (s *Server) ExchangeSubjectToken(
 		if err != nil {
 			return nil, err
 		}
-		if !s.actorDelegationAllowed(actor.Issuer, actor.Subject, identity.Issuer, identity.Subject) {
-			s.Auditor.LogEvent(ctx, security.Event{
-				Type:   security.EventAuthFailure,
-				UserID: identity.Subject,
-				Details: map[string]any{
-					"reason":     "actor_delegation_not_authorized",
-					"grant_type": GrantTypeTokenExchange,
-					"actor_sub":  actor.Subject,
-					"actor_iss":  actor.Issuer,
-					"sub":        identity.Subject,
-				},
-			})
-			return nil, fmt.Errorf("actor %q is not authorized to act for subject %q", actor.Subject, identity.Subject)
+		// When actor resolves to the same identity as subject, treat as pure M2M —
+		// strip the actor so the minted token carries no act claim and delegation
+		// checks are skipped. This lets a static SA token be sent as X-Actor-Token
+		// without requiring an explicit SA→SA delegation rule.
+		if actor.Issuer != identity.Issuer || actor.Subject != identity.Subject {
+			if !s.actorDelegationAllowed(actor.Issuer, actor.Subject, identity.Issuer, identity.Subject) {
+				s.Auditor.LogEvent(ctx, security.Event{
+					Type:   security.EventAuthFailure,
+					UserID: identity.Subject,
+					Details: map[string]any{
+						"reason":     "actor_delegation_not_authorized",
+						"grant_type": GrantTypeTokenExchange,
+						"actor_sub":  actor.Subject,
+						"actor_iss":  actor.Issuer,
+						"sub":        identity.Subject,
+					},
+				})
+				return nil, fmt.Errorf("actor %q is not authorized to act for subject %q", actor.Subject, identity.Subject)
+			}
+			act = &Actor{Iss: actor.Issuer, Sub: actor.Subject}
 		}
-		act = &Actor{Iss: actor.Issuer, Sub: actor.Subject}
 	}
 
 	grantedScope := grantedExchangeScope(scope, identity.AllowedScopes)

--- a/server/token_exchange_broker.go
+++ b/server/token_exchange_broker.go
@@ -176,7 +176,12 @@ func (s *Server) BrokerExchangeSubjectToken(
 		if err != nil {
 			return nil, err
 		}
-		if !s.actorDelegationAllowed(actor.Issuer, actor.Subject, identity.Issuer, identity.Subject) {
+		// Self-delegation is a no-op: strip the actor and proceed as pure M2M.
+		if actor.Issuer == identity.Issuer && actor.Subject == identity.Subject {
+			actor = nil
+			actorToken = ""
+			actorTokenType = ""
+		} else if !s.actorDelegationAllowed(actor.Issuer, actor.Subject, identity.Issuer, identity.Subject) {
 			s.auditExchangeFailure(ctx, "brokered", clientID, audience, sessionID, "actor_delegation_not_authorized", map[string]any{
 				"actor_sub": actor.Subject,
 				"sub":       identity.Subject,
@@ -310,6 +315,13 @@ func (s *Server) validateWorkloadActor(ctx context.Context, actorToken, actorTok
 	actor, err := s.validateExchangeActorToken(ctx, actorToken, actorTokenType, nil)
 	if err != nil {
 		return nil, err
+	}
+	// When actor resolves to the same identity as subject, treat as pure M2M.
+	// Strip the actor so downstream minting skips the act claim and delegation
+	// checks. This lets a static headersFrom SA token be sent as X-Actor-Token
+	// without needing an explicit SA→SA delegation rule.
+	if actor.Issuer == subject.Issuer && actor.Subject == subject.Subject {
+		return nil, nil
 	}
 	if !s.actorDelegationAllowed(actor.Issuer, actor.Subject, subject.Issuer, subject.Subject) {
 		s.auditExchangeFailure(ctx, "workload", "", audience, sessionID, "actor_delegation_not_authorized", map[string]any{

--- a/server/token_exchange_broker_test.go
+++ b/server/token_exchange_broker_test.go
@@ -459,6 +459,32 @@ func TestBrokerExchangeSubjectToken_ActorDelegationDeniedWhenNoPolicyConfigured(
 	require.Equal(t, brokerTestUserSub, details["sub"])
 }
 
+func TestBrokerExchangeSubjectToken_SelfDelegationIsNoOp(t *testing.T) {
+	// When actor token resolves to the same identity as the subject token, the
+	// actor must be silently dropped: the exchange proceeds as pure M2M with no
+	// act claim and no delegation-policy check.
+	const sub = "service-a"
+	const iss = "https://idp.example.com"
+	identity := SubjectIdentity{Subject: sub, Issuer: iss}
+	validator := &stubTokenValidator{
+		byToken: map[string]*SubjectIdentity{
+			"actor-jwt":   &identity,
+			"subject-jwt": &identity,
+		},
+	}
+	ex := &stubExchanger{result: &ExchangerResult{AccessToken: "downstream-token", ExpiresAt: time.Now().Add(time.Minute)}}
+	srv, _ := newBrokerTestServer(t, ex,
+		map[string][]string{"backstage": {"gaggle"}}, validator)
+	// No ActorDelegationPolicy — would fail if the actor reached the delegation check.
+
+	tok, err := srv.BrokerExchangeSubjectToken(t.Context(),
+		"backstage", "subject-jwt", SubjectTokenTypeIDToken, "actor-jwt", SubjectTokenTypeIDToken, "gaggle", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	require.NotNil(t, ex.gotReq)
+	require.Nil(t, ex.gotReq.Actor, "actor must be stripped when actor==subject")
+}
+
 // Workload-authenticated exchange tests.
 
 // TestWorkloadExchangeSubjectToken_RateLimited asserts the mint path honours the
@@ -831,6 +857,35 @@ func TestWorkloadExchangeSubjectToken_DelegationDeniedByPolicy(t *testing.T) {
 		"user-jwt", SubjectTokenTypeIDToken, "actor-jwt", SubjectTokenTypeIDToken, "target-service", "", "")
 	require.ErrorIs(t, err, ErrInvalidTarget)
 	require.Nil(t, ex.gotReq)
+}
+
+func TestWorkloadExchangeSubjectToken_SelfDelegationIsNoOp(t *testing.T) {
+	// When subject and actor tokens resolve to the same identity, the actor must
+	// be stripped and the exchange proceeds as pure M2M with no act claim and no
+	// delegation-policy check.
+	const sub = "system:serviceaccount:ns:robot"
+	const iss = "https://kube.example.com"
+	identity := SubjectIdentity{Subject: sub, Issuer: iss}
+	validator := &stubTokenValidator{
+		byToken: map[string]*SubjectIdentity{
+			"subject-jwt": &identity,
+			"actor-jwt":   &identity,
+		},
+	}
+	ex := &stubExchanger{result: &ExchangerResult{
+		AccessToken: "workload-token",
+		ExpiresAt:   time.Now().Add(time.Minute),
+	}}
+	// No ActorDelegationPolicy — would fail if the actor reached the delegation check.
+	srv, _ := newWorkloadTestServer(t, ex,
+		[]WorkloadGrant{{Issuer: "*", Subject: sub, Audiences: []string{"target-service"}}}, validator)
+
+	tok, err := srv.WorkloadExchangeSubjectToken(t.Context(),
+		"subject-jwt", SubjectTokenTypeIDToken, "actor-jwt", SubjectTokenTypeIDToken, "target-service", "", "")
+	require.NoError(t, err)
+	require.NotNil(t, tok)
+	require.NotNil(t, ex.gotReq)
+	require.Nil(t, ex.gotReq.Actor, "actor must be stripped when actor==subject")
 }
 
 func TestWorkloadExchangeSubjectToken_NoExchanger(t *testing.T) {

--- a/server/token_exchange_test.go
+++ b/server/token_exchange_test.go
@@ -829,3 +829,41 @@ func TestExchangeSubjectToken_ActorTokenValidationFailure(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "actor token validation")
 }
+
+// TestExchangeSubjectToken_SelfDelegationIsNoOp verifies that when the actor
+// token resolves to the same identity as the subject token, the actor is
+// silently stripped and the exchange succeeds with no act claim — even when
+// no ActorDelegationPolicy is configured.
+func TestExchangeSubjectToken_SelfDelegationIsNoOp(t *testing.T) {
+	// Wire the server with no delegation policy.
+	srv, signingKey := newActorExchangeServer(t, nil)
+
+	// Both "sub-tok" and "act-tok" now resolve to the same identity.
+	srv.subjectValidators = map[string]SubjectTokenValidator{
+		SubjectTokenTypeIDToken: &stubTokenValidator{
+			byToken: map[string]*SubjectIdentity{
+				"sub-tok": {Subject: testSubject, Issuer: testIssuer},
+				"act-tok": {Subject: testSubject, Issuer: testIssuer},
+			},
+		},
+	}
+
+	result, err := srv.ExchangeSubjectToken(
+		t.Context(),
+		"sub-tok", SubjectTokenTypeIDToken,
+		"act-tok", SubjectTokenTypeIDToken,
+		"https://api.example.com",
+		"read",
+		"",
+	)
+	require.NoError(t, err)
+
+	parsed, err := josejwt.ParseSigned(result.AccessToken, []jose.SignatureAlgorithm{jose.RS256})
+	require.NoError(t, err)
+
+	var private rfc9068Claims
+	require.NoError(t, parsed.Claims(signingKey.Public(), &private))
+
+	require.Equal(t, testSubject, private.Subject)
+	require.Nil(t, private.Act, "act claim must be absent when actor==subject")
+}


### PR DESCRIPTION
When the actor and subject resolve to the same issuer+subject, the actor is stripped before the delegation policy check and the exchange proceeds as a plain M2M mint (no `act` claim). This is equivalent to not sending an actor token at all.

Without this, a client that always attaches its own identity as `X-Actor-Token` (e.g. a static `headersFrom` in a Kubernetes `RemoteMCPServer`) would hard-fail the `actorDelegationAllowed` check on M2M calls where no user token is being forwarded — even though the intent is pure M2M.