### PR TITLE
fix(sso): honor process-installed CA for forwarded-ID-token JWKS validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- SSO forwarded-ID-token JWKS validation now honors a CA bundle the host process installs on `http.DefaultTransport` when `AllowPrivateIPJWKS` is set. Previously `Server.getJWKSClient()` built a JWKS client that verified against the system certificate pool alone, so an internal-CA Dex forwarding SSO ID tokens was rejected with `x509: certificate signed by unknown authority` even when the host process had installed that CA — the trusted-issuer permissive client (`NewOIDCValidator`) already worked this way, the forwarded-token path did not. The SSRF-safe client used when `AllowPrivateIPJWKS` is unset is unchanged and still verifies against the system pool. See https://github.com/giantswarm/giantswarm/issues/37059.
+
 ### Changed
+
+- `ValidateToken` now logs a forwarded-ID-token validation failure at `WARN` (was `DEBUG`) when the token carried a trusted audience — i.e. it was meant to be an SSO-forwarded ID token — but signature/JWKS validation then failed (e.g. a JWKS TLS/CA error). This surfaces real SSO misconfigurations without enabling debug logging. Tokens that simply don't carry a trusted audience are not SSO tokens and remain silent. No token material is logged (only an 8-character suffix for correlation).
 
 - The resource-server `ValidateToken` middleware now assigns a session ID to every validated token, not only those backed by stored refresh-token-family metadata. A token with a family still uses its `FamilyID`; any other validated token (forwarded ID token, trusted-issuer, self-issued exchange-minted JWT) falls back to `SessionIDForBearer`. Self-issued exchange-minted JWTs previously reached downstream handlers with no session, so resource servers could not session-scope an on-behalf-of bearer re-presented at the front door; they now carry one.
 

--- a/server/sso.go
+++ b/server/sso.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
 	"github.com/giantswarm/mcp-oauth/providers"
@@ -134,10 +135,25 @@ func (s *Server) findMatchingTrustedAudience(tokenAudiences []string) string {
 //   - When true: Private IPs are allowed for internal IdP deployments
 func (s *Server) getJWKSClient() *oidc.JWKSClient {
 	s.jwksClientOnce.Do(func() {
-		s.jwksClient = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+		opts := oidc.JWKSClientOptions{
 			Logger:         s.Logger,
 			AllowPrivateIP: s.Config.AllowPrivateIPJWKS,
-		})
+		}
+		if s.Config.AllowPrivateIPJWKS {
+			// AllowPrivateIPJWKS targets a controlled in-cluster endpoint
+			// (e.g. an internal Dex forwarding SSO ID tokens), which commonly
+			// presents a certificate from an internal CA. Back the client with
+			// http.DefaultTransport so a CA bundle the host process installs
+			// there (e.g. via an extra-CA file) is honored; a freshly built
+			// transport would verify against the system pool alone and reject
+			// it with "x509: certificate signed by unknown authority". This
+			// mirrors NewOIDCValidator's permissive trusted-issuer client.
+			opts.HTTPClient = &http.Client{
+				Transport: http.DefaultTransport,
+				Timeout:   oidc.DefaultHTTPTimeout,
+			}
+		}
+		s.jwksClient = oidc.NewJWKSClientWithOptions(opts)
 	})
 	return s.jwksClient
 }

--- a/server/sso_catrust_test.go
+++ b/server/sso_catrust_test.go
@@ -1,0 +1,117 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/mcp-oauth/providers/mock"
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
+	"github.com/giantswarm/mcp-oauth/storage/memory"
+)
+
+// TestGetJWKSClient_PermissiveClientTrustsProcessCABundle verifies that the SSO
+// forwarded-ID-token JWKS client honors a CA the host process installs on
+// http.DefaultTransport when AllowPrivateIPJWKS is set — the same mechanism
+// NewOIDCValidator's permissive trusted-issuer client uses.
+//
+// Before this fix the SSO path built an SSRF-safe client that verified against the
+// system pool alone, so an internal-CA Dex (the case AllowPrivateIPJWKS exists for)
+// was rejected with "x509: certificate signed by unknown authority" even when the
+// host process had installed that CA on http.DefaultTransport.
+//
+// Note: this exercises the real srv.getJWKSClient() construction, unlike
+// newForwardedTokenHarness which injects a client that trusts the test server.
+func TestGetJWKSClient_PermissiveClientTrustsProcessCABundle(t *testing.T) {
+	const (
+		issuer   = "https://auth.internal.example"
+		audience = "forwarded-audience"
+		keyID    = "ca-trust-key"
+	)
+
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	jwks := jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       privateKey.Public(),
+		KeyID:     keyID,
+		Algorithm: "RS256",
+		Use:       "sig",
+	}}}
+	jwksServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	}))
+	t.Cleanup(jwksServer.Close)
+
+	// newServer builds a Server that uses the REAL getJWKSClient() (no injected
+	// client). getJWKSClient captures the current http.DefaultTransport, so the CA
+	// trust is decided at construction time.
+	newServer := func() *Server {
+		mockProvider := mock.NewProvider()
+		mockProvider.JWKSURIFunc = func(context.Context) (string, error) { return jwksServer.URL, nil }
+		mockProvider.IssuerURLFunc = func() string { return issuer }
+		store := memory.New()
+		t.Cleanup(func() { store.Stop() })
+		return &Server{
+			Config: &Config{
+				Issuer:             issuer,
+				TrustedAudiences:   []string{audience},
+				AllowPrivateIPJWKS: true,
+			},
+			Logger:          slog.Default(),
+			provider:        mockProvider,
+			tokenStore:      store,
+			Instrumentation: testInstrumentation(t),
+			Auditor:         testAuditor(),
+		}
+	}
+
+	token := signTestRS256Token(t, privateKey, keyID, oidc.IDTokenClaims{
+		Claims: josejwt.Claims{
+			Subject:  "user-subject-123",
+			Issuer:   issuer,
+			Audience: josejwt.Audience{audience},
+			IssuedAt: josejwt.NewNumericDate(time.Now()),
+			Expiry:   josejwt.NewNumericDate(time.Now().Add(time.Hour)),
+		},
+		Email: "user@internal.example",
+	})
+	ctx := context.Background()
+
+	// Control: the JWKS server's self-signed CA is not in the process trust store,
+	// so the permissive SSO JWKS client cannot verify it. The audience matches, so
+	// this returns a validation error (not the benign "not an SSO token" nil, nil).
+	userInfo, err := newServer().validateForwardedIDToken(ctx, token)
+	require.Error(t, err)
+	require.Nil(t, userInfo)
+
+	// Install the server's CA on http.DefaultTransport, mirroring a host process
+	// (e.g. mcp-kubernetes) that injects an extra CA file at startup.
+	pool := x509.NewCertPool()
+	pool.AddCert(jwksServer.Certificate())
+	original := http.DefaultTransport
+	cloned := original.(*http.Transport).Clone()
+	cloned.TLSClientConfig = &tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12}
+	http.DefaultTransport = cloned
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	// A server constructed after the CA is installed builds its JWKS client on the
+	// updated DefaultTransport → the forwarded ID token now validates.
+	userInfo, err = newServer().validateForwardedIDToken(ctx, token)
+	require.NoError(t, err)
+	require.NotNil(t, userInfo)
+	require.Equal(t, "user-subject-123", userInfo.ID)
+}

--- a/server/sso_catrust_test.go
+++ b/server/sso_catrust_test.go
@@ -34,6 +34,9 @@ import (
 //
 // Note: this exercises the real srv.getJWKSClient() construction, unlike
 // newForwardedTokenHarness which injects a client that trusts the test server.
+//
+// NOT parallel-safe: it mutates the global http.DefaultTransport (restored via
+// t.Cleanup). Do not add t.Parallel() to this test.
 func TestGetJWKSClient_PermissiveClientTrustsProcessCABundle(t *testing.T) {
 	const (
 		issuer   = "https://auth.internal.example"

--- a/server/validate.go
+++ b/server/validate.go
@@ -241,7 +241,14 @@ func (s *Server) ValidateToken(ctx context.Context, accessToken string) (*provid
 	if len(s.Config.TrustedAudiences) > 0 && oidc.IsJWT(accessToken) {
 		userInfo, err := s.validateForwardedIDToken(ctx, accessToken)
 		if err != nil {
-			s.Logger.Debug("Forwarded ID token validation failed, falling back to userinfo",
+			// A non-nil error here means the token carried a trusted audience
+			// (it was meant to be an SSO-forwarded ID token) but validation
+			// then failed — e.g. a JWKS fetch/TLS error or a bad signature.
+			// That is a real misconfiguration, not the benign "not an SSO
+			// token" case (which returns nil, nil and is silent), so surface
+			// it at WARN. No token material is logged (only an 8-char suffix
+			// for correlation).
+			s.Logger.Warn("Forwarded ID token validation failed, falling back to userinfo",
 				"error", err.Error(),
 				"token_suffix", helpers.TokenSuffix(accessToken, 8))
 		} else if userInfo != nil {


### PR DESCRIPTION
## What
The SSO forwarded-ID-token validation path could not trust a private/internal Dex CA. On management clusters where `mcp-kubernetes` runs strict `--downstream-oauth` SSO forwarding against an internal-CA Dex, every forwarded `id_token` was rejected and muster→Kubernetes tool calls failed with `authentication required: please log in to access this resource`.

## Root cause
`Server.getJWKSClient()` built the JWKS client for forwarded-ID-token validation with only `AllowPrivateIP`, using the default system trust pool. When the Dex endpoint presents a certificate from an internal CA (the case `AllowPrivateIPJWKS` exists for), the JWKS fetch failed with `x509: certificate signed by unknown authority`. The trusted-issuer permissive client (`NewOIDCValidator`) already backs itself with `http.DefaultTransport` so a process-installed CA is honored; the forwarded-token path did not. Because the failure fell back to userinfo and was only logged at DEBUG, it was effectively invisible in production.

## Change
- `getJWKSClient()`: when `AllowPrivateIPJWKS` is set, back the JWKS client with `http.DefaultTransport`, mirroring `NewOIDCValidator`'s permissive client, so a CA bundle the host process installs there (e.g. mcp-kubernetes' `--dex-ca-file`) is honored. The SSRF-safe client used when `AllowPrivateIPJWKS` is unset is unchanged.
- `ValidateToken`: log the aud-matched-but-validation-failed case at `WARN` (was DEBUG) so real SSO misconfigurations (JWKS TLS/CA errors) are visible without enabling debug. Not-an-SSO-token cases stay silent. No token material logged (8-char suffix only).
- New test `TestGetJWKSClient_PermissiveClientTrustsProcessCABundle` exercises the real `getJWKSClient()` against a TLS JWKS endpoint trusted only via `http.DefaultTransport`.

## Downstream
`mcp-kubernetes` will install its `DEX_CA_FILE` CA on `http.DefaultTransport` at startup (companion PR) so this path trusts the internal Dex CA.

Refs giantswarm/giantswarm#37059

https://claude.ai/code/session_01UBsCu5zwKLQkH3bpauxL3a
