### PR TITLE
ci: guard exported-API removals with gorelease

### DIFF
--- a/.github/workflows/api_compat.yaml
+++ b/.github/workflows/api_compat.yaml
@@ -1,0 +1,67 @@
+# API-compatibility guard (see issue #499).
+#
+# Releases are tagged automatically from conventional commits on merge to
+# main (zz_generated.auto_release.yaml): fix -> patch, feat -> minor,
+# "!" / BREAKING CHANGE -> major. Nothing in that pipeline verifies the
+# declared bump matches the actual API change, which is how v1.0.1 shipped
+# exported-API removals as a patch and broke every consumer's Renovate
+# auto-merge (#499).
+#
+# This job runs gorelease against the latest v* tag. If it detects
+# incompatible changes (removed/changed exported API), the PR title must
+# declare a breaking change in conventional-commit form ("type!:" or
+# "type(scope)!:") so the auto-release tags a major version.
+name: API compatibility
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gorelease:
+    name: gorelease vs latest tag
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go environment
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: "1.26"
+
+      # Untrusted input (PR title) is passed via env, never interpolated
+      # into the script (actions injection guidance).
+      - name: Check API compatibility against latest release
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          BASE=$(git tag -l 'v*' --sort=-v:refname | head -1)
+          if [ -z "$BASE" ]; then
+            echo "No release tag found; skipping."
+            exit 0
+          fi
+          echo "Comparing against ${BASE}"
+
+          set +e
+          OUTPUT=$(go run golang.org/x/exp/cmd/gorelease@latest -base="$BASE" 2>&1)
+          set -e
+          echo "$OUTPUT"
+
+          if ! echo "$OUTPUT" | grep -q "Incompatible changes were detected"; then
+            exit 0
+          fi
+
+          if echo "$PR_TITLE" | grep -Eq '^[a-z]+(\([^)]*\))?!:'; then
+            echo "PR title declares a breaking change; auto-release will tag a major version."
+            exit 0
+          fi
+
+          echo "::error::This PR removes or changes exported API relative to ${BASE}, but the PR title does not declare a breaking change."
+          echo "::error::Mark the PR title as breaking (e.g. 'feat!: ...' or 'refactor(server)!: ...') so auto-release tags a major version, or restore the removed API."
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,27 @@ Please follow our [Security Policy](SECURITY.md) to report vulnerabilities respo
    - No merge conflicts
    - Follows coding standards
 
+## Versioning Policy
+
+Releases are tagged automatically from conventional commits on merge to main
+(`fix:` -> patch, `feat:` -> minor, `!`/`BREAKING CHANGE` -> major). On the 1.x
+line this library follows [semantic versioning](https://semver.org/) strictly:
+
+- **Patch** releases may only contain bug fixes and internal changes. No
+  exported API may be removed or changed incompatibly.
+- **Minor** releases may add exported API. Existing API may be deprecated
+  (with a `// Deprecated:` comment) but not removed.
+- **Major** releases are required for any removal or incompatible change of
+  exported API, including struct fields, method signatures, and observable
+  wire-protocol contracts (e.g. `/oauth/token` request handling).
+
+Because consumers auto-merge patch and minor bumps via Renovate, an API
+removal in a patch release breaks their builds without review (this happened
+in v1.0.1, see #499). The `API compatibility` workflow enforces this: it runs
+[`gorelease`](https://pkg.go.dev/golang.org/x/exp/cmd/gorelease) against the
+latest tag on every PR and fails if exported API is removed without the PR
+title carrying the conventional-commit breaking marker (`type!:`).
+
 ## Coding Standards
 
 ### Go Style Guide


### PR DESCRIPTION
## Summary
- Adds an `API compatibility` workflow: on every PR, `gorelease` compares the exported API against the latest `v*` tag; incompatible changes fail the check unless the PR title declares a breaking change (`type!:`), which makes auto-release tag a major version
- Documents the 1.x versioning policy in CONTRIBUTING.md (what may ship in patch/minor/major)

Verified locally: `gorelease -base=v1.0.0` on current main correctly reports the #499 removals as incompatible and exits non-zero.

Fixes #499

Made with [Cursor](https://cursor.com)