### PR TITLE
fix(storage/valkey): clamp sub-second TTL to a 1s floor for token saves and RevokeJTI (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Valkey `calculateTTL` now clamps a positive sub-second TTL up to a one-second floor. valkey-go's `Ex()` builds `SET` with a whole-second `EX` argument, so a near-expiry save (e.g. 50ms remaining) truncated to `EX 0` and Valkey rejected it with `invalid expire time in 'set' command`; the "already expired -> 0" semantics are preserved. `RevokeJTI` bypassed `calculateTTL` with its own `time.Until(expiresAt)` and hit the identical `EX 0` truncation, silently failing to denylist a self-issued JWT revoked in the final second before its (whole-second) `exp`; it now routes through `calculateTTL` too. See https://github.com/giantswarm/mcp-oauth/issues/518.
 - SSO forwarded-ID-token JWKS validation now honors a CA bundle the host process installs on `http.DefaultTransport` when `AllowPrivateIPJWKS` is set. Previously `Server.getJWKSClient()` built a JWKS client that verified against the system certificate pool alone, so an internal-CA Dex forwarding SSO ID tokens was rejected with `x509: certificate signed by unknown authority` even when the host process had installed that CA — the trusted-issuer permissive client (`NewOIDCValidator`) already worked this way, the forwarded-token path did not. The SSRF-safe client used when `AllowPrivateIPJWKS` is unset is unchanged and still verifies against the system pool. See https://github.com/giantswarm/giantswarm/issues/37059.
 
 ### Changed

--- a/storage/valkey/revoked.go
+++ b/storage/valkey/revoked.go
@@ -14,10 +14,12 @@ func (s *Store) revokedJTIKey(jti string) string {
 }
 
 // RevokeJTI implements storage.RevokedTokenStore by writing a sentinel
-// value at revokedJTIKey(jti) with EXAT set to the JWT's expiresAt. The
-// value is intentionally minimal — presence is the signal; the JWT itself
-// already carries every other claim. RFC 7009 treats revocation of an
-// already-expired token as a no-op, so we drop those without a round-trip.
+// value at revokedJTIKey(jti) with a relative TTL derived from the JWT's
+// expiresAt via calculateTTL (clamped to a >=1s floor), so the entry
+// auto-expires at/just after the JWT's own exp. The value is intentionally
+// minimal — presence is the signal; the JWT itself already carries every
+// other claim. RFC 7009 treats revocation of an already-expired token as a
+// no-op, so we drop those without a round-trip.
 func (s *Store) RevokeJTI(ctx context.Context, jti string, expiresAt time.Time) (err error) {
 	if jti == "" {
 		return fmt.Errorf("jti cannot be empty")
@@ -29,7 +31,11 @@ func (s *Store) RevokeJTI(ctx context.Context, jti string, expiresAt time.Time) 
 	op := s.startTracedOp(ctx, "revoke_jti")
 	defer op.end(&err)
 
-	ttl := time.Until(expiresAt)
+	// calculateTTL clamps a positive sub-second TTL up to a 1s floor;
+	// without it a JWT revoked in its final second before exp would build
+	// "EX 0" (valkey-go's Ex() truncates to whole seconds) and Valkey would
+	// reject the write, silently failing to denylist the JTI.
+	ttl := calculateTTL(expiresAt)
 	if ttl <= 0 {
 		return nil
 	}

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -1036,12 +1036,21 @@ func safeTruncate(s string, n int) string {
 	return s[:n]
 }
 
-// calculateTTL calculates the TTL for a key based on expiry time
-// Returns 0 if the key has already expired
+// calculateTTL returns the TTL to apply for a key expiring at expiresAt.
+//
+// Returns 0 when the key has already expired; callers treat 0 as "expired".
+// For a still-valid expiry it never returns a positive duration below one
+// second: valkey-go's Ex() builds SET with a whole-second EX argument, so any
+// sub-second duration would truncate to "EX 0", which Valkey rejects with
+// "invalid expire time in 'set' command". Clamping to a one-second floor keeps
+// near-expiry saves valid while preserving the "expired -> 0" semantics.
 func calculateTTL(expiresAt time.Time) time.Duration {
 	ttl := time.Until(expiresAt)
 	if ttl <= 0 {
 		return 0
+	}
+	if ttl < time.Second {
+		return time.Second
 	}
 	return ttl
 }

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -368,6 +368,31 @@ func TestTokenStore_SaveToken_WithoutRefreshToken_HasTTL(t *testing.T) {
 		"token without RefreshToken should be evicted after TTL")
 }
 
+// TestTokenStore_RevokeJTI_SubSecondExpiry pins the sibling EX-0 fix: a JWT
+// revoked in its final sub-second before exp derives a sub-second TTL, which
+// valkey-go's Ex() would truncate to "EX 0" and Valkey would reject, silently
+// failing to denylist the JTI. calculateTTL's 1s floor keeps the write valid.
+func TestTokenStore_RevokeJTI_SubSecondExpiry(t *testing.T) {
+	s := testStore(t)
+	ctx := t.Context()
+
+	// Sub-second expiry: before the clamp this failed with
+	// "invalid expire time in 'set' command".
+	err := s.RevokeJTI(ctx, "jti-sub-second", time.Now().Add(200*time.Millisecond))
+	if err != nil {
+		t.Fatalf("RevokeJTI with sub-second expiry failed: %v", err)
+	}
+
+	// The JTI is denylisted while the entry lives.
+	revoked, err := s.IsJTIRevoked(ctx, "jti-sub-second")
+	if err != nil {
+		t.Fatalf("IsJTIRevoked failed: %v", err)
+	}
+	if !revoked {
+		t.Error("JTI should be revoked immediately after RevokeJTI")
+	}
+}
+
 // ============================================================
 // UserInfo Tests
 // ============================================================
@@ -1631,6 +1656,28 @@ func TestCalculateTTL(t *testing.T) {
 	ttl = calculateTTL(past)
 	if ttl != 0 {
 		t.Error("TTL should be 0 for past expiry")
+	}
+
+	// Sub-second positive expiry must clamp up to the 1s floor: valkey-go's
+	// Ex() builds a whole-second EX argument, so anything below 1s would
+	// truncate to "EX 0" and Valkey would reject the write.
+	subSecond := time.Now().Add(50 * time.Millisecond)
+	ttl = calculateTTL(subSecond)
+	if ttl != time.Second {
+		t.Errorf("TTL should clamp to 1s for sub-second expiry, got: %v", ttl)
+	}
+
+	// Just-under-1s expiry must also clamp up to the 1s floor.
+	justUnder := time.Now().Add(900 * time.Millisecond)
+	ttl = calculateTTL(justUnder)
+	if ttl != time.Second {
+		t.Errorf("TTL should clamp to 1s for just-under-1s expiry, got: %v", ttl)
+	}
+
+	// Comfortably-future expiry must return a duration above the floor.
+	ttl = calculateTTL(time.Now().Add(2 * time.Second))
+	if ttl <= time.Second {
+		t.Errorf("TTL should exceed 1s for a comfortably-future expiry, got: %v", ttl)
 	}
 }
 


### PR DESCRIPTION
## What

`storage/valkey`'s `calculateTTL` returned the raw `time.Until(expiresAt)` duration. valkey-go's `Ex()` builds the `SET` command with a whole-second `EX` argument, so any positive sub-second duration truncated to `EX 0`, which Valkey rejects with `invalid expire time in 'set' command`. Near-expiry token saves therefore failed. `calculateTTL` now clamps a positive sub-second TTL up to a one-second floor, preserving the existing "already expired -> 0" semantics.

## Sibling bug hardened in the same change

While fixing this I audited the sibling `Ex()` sites and found `RevokeJTI` (`storage/valkey/revoked.go`) hit the identical truncation: it built its TTL with its own `time.Until(expiresAt)` rather than `calculateTTL`. Because the caller derives `expiresAt` from a whole-second JWT `exp` (`time.Unix(expVal, 0)`), any revocation issued in the **final second before `exp`** produced a sub-second TTL → `EX 0` → Valkey rejected the write → the JTI was **silently not denylisted** (the caller only logs a warning and returns success per RFC 7009). `RevokeJTI` now routes through `calculateTTL` too. Exposure is self-limited to the token's own remaining sub-second lifetime, but it is the same defect class, so it is fixed here.

## Changes

- `storage/valkey/store.go`: `calculateTTL` clamps positive sub-second TTLs to a 1s floor, with a doc comment describing the whole-second-`EX` truncation hazard.
- `storage/valkey/revoked.go`: `RevokeJTI` derives its TTL via `calculateTTL`; the stale doc comment (which claimed an `EXAT` write) is corrected.
- `storage/valkey/store_test.go`:
  - `TestCalculateTTL` gains fast, infra-free assertions pinning the 1s floor (50ms → 1s, 900ms → 1s, 2s → > 1s). These run in CI even without a live Valkey, so the floor cannot regress silently.
  - `TestTokenStore_RevokeJTI_SubSecondExpiry` (live Valkey) pins the sibling fix.
- `CHANGELOG.md`: entry under `Unreleased → Fixed`.

## Why clamp (not `PX`)

Clamping is the smaller change and matches the existing "expired -> 0" contract; it fixes every call site that flows through `calculateTTL` at once. The alternative (switching SET builders to `PxMilliseconds()`) would touch every call site for sub-second precision that no caller needs.

## Testing

- `TestTokenStore_SaveToken_WithoutRefreshToken_HasTTL` (the pin from the issue), `TestTokenStore_RevokeJTI_SubSecondExpiry`, and `TestCalculateTTL` all pass against a live Valkey. Reverting either one-line clamp reproduces the `invalid expire time in 'set' command` failure, confirming the tests pin the fix.
- `go build ./...` and `go vet ./storage/valkey/` clean.
- Reviewed adversarially (independent skeptic pass), which surfaced the `RevokeJTI` sibling bug and the missing fast unit test — both folded in above.

Fixes #518
