### PR TITLE
docs: rename example in-cluster hostname to muster.agent-platform.svc

### DIFF
--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -96,7 +96,7 @@ type JWKSClientOptions struct {
 	// resolve to private IP addresses. All other hosts remain subject to the
 	// normal SSRF/DNS-rebinding guard. Prefer this over AllowPrivateIP when
 	// the private endpoint is a known in-cluster service (e.g.
-	// muster.agentic-platform.svc.cluster.local). Ignored when AllowPrivateIP
+	// muster.agent-platform.svc.cluster.local). Ignored when AllowPrivateIP
 	// is true.
 	AllowPrivateIPHosts []string
 

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -163,7 +163,7 @@ type TrustedIssuer struct {
 	// permitted to resolve to a private IP. All other hosts retain SSRF
 	// protection. Use this instead of AllowPrivateIPJWKS when the private
 	// endpoint is a known in-cluster service (e.g.
-	// muster.agentic-platform.svc.cluster.local). Ignored when
+	// muster.agent-platform.svc.cluster.local). Ignored when
 	// AllowPrivateIPJWKS is true.
 	AllowPrivateIPJWKSHosts []string
 

--- a/server/subject_validator_test.go
+++ b/server/subject_validator_test.go
@@ -578,7 +578,7 @@ func TestNewOIDCValidator_AllowPrivateIPJWKSHosts_CreatesIssuerClient(t *testing
 	withHosts, err := NewOIDCValidator([]TrustedIssuer{{
 		Issuer:                  testIssuer,
 		JwksURL:                 "https://example.com/jwks",
-		AllowPrivateIPJWKSHosts: []string{"muster.agentic-platform.svc.cluster.local"},
+		AllowPrivateIPJWKSHosts: []string{"muster.agent-platform.svc.cluster.local"},
 	}})
 	require.NoError(t, err)
 	require.NotNil(t, withHosts.issuerClients[testIssuer])
@@ -593,7 +593,7 @@ func TestNewOIDCValidator_AllowPrivateIPJWKSHosts_CreatesIssuerClient(t *testing
 		{
 			Issuer:                  testIssuer,
 			JwksURL:                 "https://example.com/jwks",
-			AllowPrivateIPJWKSHosts: []string{"muster.agentic-platform.svc.cluster.local"},
+			AllowPrivateIPJWKSHosts: []string{"muster.agent-platform.svc.cluster.local"},
 		},
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

Phase 4 of the agent-platform rename (giantswarm/giantswarm#36869): the `AllowPrivateIP*Hosts` doc comments and the subject-validator tests still use the old `muster.agentic-platform.svc.cluster.local` example hostname.

## Change

The example hostname becomes `muster.agent-platform.svc.cluster.local` in `providers/oidc/jwt.go`, `server/subject_validator.go`, and the tests. Comments and test fixtures only, no behavior change; historical CHANGELOG entries are left as-is.