### PR TITLE
fix: address golangci-lint 2.13.1 findings and bump the pre-commit pin

### DIFF
--- a/.github/workflows/pre_commit_go.yaml
+++ b/.github/workflows/pre_commit_go.yaml
@@ -19,15 +19,15 @@ jobs:
     - name: Set up Go environment
       uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
       with:
-        go-version: "1.26"
+        go-version: "1.27"
     - name: Install goimports
       run: |
-        go install golang.org/x/tools/cmd/goimports@v0.42.0
+        go install golang.org/x/tools/cmd/goimports@v0.48.0
     - name: Install golangci-lint
       uses: giantswarm/install-binary-action@c37eb401e5092993fc76d545030b1d1769e61237 # v3.0.0
       with:
         binary: golangci-lint
-        version: "2.9.0"
+        version: "2.13.1"
         download_url: "https://github.com/golangci/golangci-lint/releases/download/v${version}/${binary}-${version}-linux-amd64.tar.gz"
     - name: Execute pre-commit hooks
       uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,6 +30,17 @@ linters:
           - gocyclo
           - gocognit
           - dupl
+      # Test fixtures repeat protocol strings by design; constants would only
+      # obscure what each case asserts (mirrors giantswarm/klaus-operator).
+      - path: _test\.go
+        linters:
+          - goconst
+      # Test fixtures legitimately hardcode credential-shaped values (G101)
+      # and marshal token-shaped structs for mock provider responses (G117).
+      - path: _test\.go
+        linters:
+          - gosec
+        text: "G101|G117"
       - path: ^examples/
         linters:
           - gocyclo

--- a/handler/authorize.go
+++ b/handler/authorize.go
@@ -223,7 +223,7 @@ func (h *Handler) serveCustomInterstitialTemplate(w http.ResponseWriter, templat
 	// Parse the custom template
 	tmpl, err := template.New("custom-interstitial").Parse(templateStr)
 	if err != nil {
-		h.logger.Error("Failed to parse custom interstitial template", "error", err)
+		h.logger.Error("Failed to parse custom interstitial template", paramError, err)
 		// Fall back to default template on parse error
 		h.serveDefaultInterstitial(w, redirectURL, appName, nil)
 		return
@@ -236,7 +236,7 @@ func (h *Handler) serveCustomInterstitialTemplate(w http.ResponseWriter, templat
 	// This prevents partial writes to the response if template execution fails
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, data); err != nil {
-		h.logger.Error("Failed to execute custom interstitial template", "error", err)
+		h.logger.Error("Failed to execute custom interstitial template", paramError, err)
 		// Fall back to default template on execution error
 		h.serveDefaultInterstitial(w, redirectURL, appName, nil)
 		return
@@ -264,7 +264,7 @@ func (h *Handler) serveDefaultInterstitial(w http.ResponseWriter, redirectURL, a
 	// This prevents partial writes to the response if template execution fails
 	var buf bytes.Buffer
 	if err := successInterstitialTmpl.Execute(&buf, data); err != nil {
-		h.logger.Error("Failed to execute success interstitial template", "error", err)
+		h.logger.Error("Failed to execute success interstitial template", paramError, err)
 		// Fallback to plain text on error (should be rare with pre-parsed template)
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.WriteHeader(http.StatusOK)
@@ -364,7 +364,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	// returned is the redirect target.
 	canonicalRedirectURI, err := h.server.ValidateRedirectURIForAuthorization(r.Context(), clientID, redirectURI)
 	if err != nil {
-		h.logger.Info("Authorization request rejected: invalid client or redirect_uri", "client_id", clientID, "error", err)
+		h.logger.Info("Authorization request rejected: invalid client or redirect_uri", "client_id", clientID, paramError, err)
 		h.recordHTTPMetrics(r.Context(), endpointAuthorize, http.MethodGet, http.StatusBadRequest, startTime)
 		instrumentation.SetSpanError(span, "invalid client or redirect_uri")
 		h.writeError(w, constants.ErrorCodeInvalidRequest, err.Error(), http.StatusBadRequest)
@@ -417,7 +417,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 
 	authURL, err := h.server.StartAuthorizationFlow(r.Context(), clientID, canonicalRedirectURI, scope, resource, codeChallenge, codeChallengeMethod, state, authOpts)
 	if err != nil {
-		h.logger.Error("Failed to start authorization flow", "error", err)
+		h.logger.Error("Failed to start authorization flow", paramError, err)
 		instrumentation.RecordError(span, err)
 		h.respondAuthorizationError(w, r, span, startTime, authorizationError{
 			redirectURI: canonicalRedirectURI,
@@ -437,7 +437,7 @@ func (h *Handler) ServeAuthorization(w http.ResponseWriter, r *http.Request) {
 	// defense in depth against a misconfigured provider returning a non-HTTP URL.
 	parsedAuthURL, err := url.Parse(authURL)
 	if err != nil || (parsedAuthURL.Scheme != oauth.SchemeHTTPS && parsedAuthURL.Scheme != oauth.SchemeHTTP) {
-		h.logger.Error("Provider returned invalid authorization URL", "error", err)
+		h.logger.Error("Provider returned invalid authorization URL", paramError, err)
 		h.respondAuthorizationError(w, r, span, startTime, authorizationError{
 			redirectURI: canonicalRedirectURI,
 			state:       state,
@@ -481,12 +481,12 @@ func (h *Handler) ServeCallback(w http.ResponseWriter, r *http.Request) {
 	// Parse callback parameters
 	state := r.URL.Query().Get("state")
 	code := r.URL.Query().Get("code")
-	errorParam := r.URL.Query().Get("error")
+	errorParam := r.URL.Query().Get(paramError)
 
 	// Check for provider errors
 	if errorParam != "" {
-		errorDesc := r.URL.Query().Get("error_description")
-		h.logger.Warn("Provider returned error", "ip", clientIP, "error", errorParam, "description", errorDesc)
+		errorDesc := r.URL.Query().Get(paramErrorDescription)
+		h.logger.Warn("Provider returned error", "ip", clientIP, paramError, errorParam, "description", errorDesc)
 		h.recordHTTPMetrics(r.Context(), endpointCallback, http.MethodGet, http.StatusBadRequest, startTime)
 		h.recordCallbackProcessed(r.Context(), "", false)
 		instrumentation.SetSpanError(span, errorParam)
@@ -530,7 +530,7 @@ func (h *Handler) ServeCallback(w http.ResponseWriter, r *http.Request) {
 	// Server also validates state length for defense in depth
 	authCode, clientState, err := h.server.HandleProviderCallback(r.Context(), state, code)
 	if err != nil {
-		h.logger.Error("Failed to handle callback", "ip", clientIP, "error", err)
+		h.logger.Error("Failed to handle callback", "ip", clientIP, paramError, err)
 		h.recordHTTPMetrics(r.Context(), endpointCallback, http.MethodGet, http.StatusInternalServerError, startTime)
 		h.recordCallbackProcessed(r.Context(), "", false)
 		instrumentation.RecordError(span, err)
@@ -552,7 +552,7 @@ func (h *Handler) ServeCallback(w http.ResponseWriter, r *http.Request) {
 	// build the response URL through url.Values rather than string concatenation.
 	parsedRedirect, err := url.Parse(authCode.RedirectURI)
 	if err != nil {
-		h.logger.Error("Stored redirect URI failed to parse", "ip", clientIP, "error", err, "client_id", authCode.ClientID)
+		h.logger.Error("Stored redirect URI failed to parse", "ip", clientIP, paramError, err, "client_id", authCode.ClientID)
 		h.failRequest(w, r, span, endpointCallback, http.MethodGet, http.StatusInternalServerError, constants.ErrorCodeServerError, "Authorization failed", startTime)
 		return
 	}
@@ -617,8 +617,8 @@ func (h *Handler) respondAuthorizationError(w http.ResponseWriter, r *http.Reque
 
 	redirect := *e.redirectURI
 	q := redirect.Query()
-	q.Set("error", e.code)
-	q.Set("error_description", e.description)
+	q.Set(paramError, e.code)
+	q.Set(paramErrorDescription, e.description)
 	if e.state != "" {
 		q.Set("state", e.state)
 	}

--- a/handler/constants.go
+++ b/handler/constants.go
@@ -1,0 +1,22 @@
+package handler
+
+// OAuth 2.1 grant type identifiers (RFC 6749 Section 4.1 and Section 6).
+const (
+	grantTypeAuthorizationCode = "authorization_code"
+	grantTypeRefreshToken      = "refresh_token"
+)
+
+// OAuth error response fields (RFC 6749 Section 5.2). Also used as
+// structured-logging keys so log lines mirror the wire format.
+const (
+	paramError            = "error"
+	paramErrorDescription = "error_description"
+)
+
+// OIDC claim and client registration metadata field names (OpenID Connect
+// Core 1.0, RFC 7591).
+const (
+	claimSub          = "sub"
+	fieldClientType   = "client_type"
+	fieldRedirectURIs = "redirect_uris"
+)

--- a/handler/discovery.go
+++ b/handler/discovery.go
@@ -208,7 +208,7 @@ func (h *Handler) registerMetadataSubPath(mux *http.ServeMux, resourcePath strin
 	if err := h.validateMetadataPath(resourcePath); err != nil {
 		h.logger.Warn("Rejecting invalid metadata path registration",
 			"path", resourcePath,
-			"error", err,
+			paramError, err,
 			"security_event", "invalid_metadata_path")
 		return
 	}
@@ -329,7 +329,7 @@ func (h *Handler) extractIssuerPath() string {
 	if err != nil {
 		h.logger.Warn("Failed to parse issuer URL for path extraction",
 			"issuer", h.server.Config.Issuer,
-			"error", err)
+			paramError, err)
 		return ""
 	}
 
@@ -387,13 +387,13 @@ func (h *Handler) buildAuthServerMetadata() map[string]any {
 		"authorization_endpoint":                h.server.Config.AuthorizationEndpoint(),
 		"token_endpoint":                        h.server.Config.TokenEndpoint(),
 		"response_types_supported":              oauth.DefaultResponseTypes,
-		"grant_types_supported":                 []string{"authorization_code", "refresh_token", server.GrantTypeTokenExchange},
+		"grant_types_supported":                 []string{grantTypeAuthorizationCode, grantTypeRefreshToken, server.GrantTypeTokenExchange},
 		"code_challenge_methods_supported":      []string{constants.PKCEMethodS256},
 		"token_endpoint_auth_methods_supported": oauth.SupportedTokenAuthMethods,
 		// RFC 9207: advertise that authorization responses include the `iss` parameter
 		// so clients can verify the response came from the expected authorization server.
 		"authorization_response_iss_parameter_supported": true,
-		"claims_supported":                      []string{"sub", "aud", "iss", "exp", "iat", "nonce"},
+		"claims_supported":                      []string{claimSub, "aud", "iss", "exp", "iat", "nonce"},
 		"subject_types_supported":               []string{"public"},
 		"id_token_signing_alg_values_supported": h.idTokenSigningAlgs(),
 	}
@@ -511,7 +511,7 @@ func (h *Handler) ServeJWKS(w http.ResponseWriter, r *http.Request) {
 	jwks, err := h.server.PublicJWKS()
 	if err != nil {
 		h.logger.Error("Failed to build JWKS for discovery endpoint",
-			"error", err,
+			paramError, err,
 			"ip", clientIP)
 		h.recordHTTPMetrics(r.Context(), endpointJWKS, http.MethodGet, http.StatusInternalServerError, startTime)
 		http.Error(w, "JWKS unavailable", http.StatusInternalServerError)

--- a/handler/dpop_middleware.go
+++ b/handler/dpop_middleware.go
@@ -157,9 +157,9 @@ func writeDPoPError(w http.ResponseWriter, logger *slog.Logger, wwwAuth, dpopNon
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(map[string]string{
-		"error":             code,
-		"error_description": description,
+		paramError:            code,
+		paramErrorDescription: description,
 	}); err != nil {
-		logger.Warn("failed to write JSON response", "error", err, "code", code)
+		logger.Warn("failed to write JSON response", paramError, err, "code", code)
 	}
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -262,14 +262,14 @@ func (h *Handler) writeError(w http.ResponseWriter, code, description string, st
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	h.writeJSON(w, map[string]string{
-		"error":             code,
-		"error_description": description,
+		paramError:            code,
+		paramErrorDescription: description,
 	})
 }
 
 func (h *Handler) writeJSON(w http.ResponseWriter, v any) {
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		h.logger.Warn("failed to write JSON response", "error", err)
+		h.logger.Warn("failed to write JSON response", paramError, err)
 	}
 }
 

--- a/handler/handler_refresh_token_test.go
+++ b/handler/handler_refresh_token_test.go
@@ -433,7 +433,7 @@ func formWith(kv ...string) url.Values {
 		panic("formWith: odd number of arguments")
 	}
 	form := url.Values{}
-	for i := 0; i < len(kv); i += 2 {
+	for i := 0; i+1 < len(kv); i += 2 {
 		form.Set(kv[i], kv[i+1])
 	}
 	return form

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -37,7 +37,7 @@ func (h *Handler) ValidateToken(next http.Handler) http.Handler {
 
 		userInfo, err := h.server.ValidateToken(r.Context(), accessToken)
 		if err != nil {
-			h.logger.Warn("Token validation failed", "ip", clientIP, paramError, err)
+			h.logger.Warn("Token validation failed", "ip", clientIP, "error", err)
 			h.writeUnauthorizedError(w, r, constants.ErrorCodeInvalidToken, "Token validation failed")
 			return
 		}

--- a/handler/middleware.go
+++ b/handler/middleware.go
@@ -37,7 +37,7 @@ func (h *Handler) ValidateToken(next http.Handler) http.Handler {
 
 		userInfo, err := h.server.ValidateToken(r.Context(), accessToken)
 		if err != nil {
-			h.logger.Warn("Token validation failed", "ip", clientIP, "error", err)
+			h.logger.Warn("Token validation failed", "ip", clientIP, paramError, err)
 			h.writeUnauthorizedError(w, r, constants.ErrorCodeInvalidToken, "Token validation failed")
 			return
 		}
@@ -212,8 +212,8 @@ func (h *Handler) writeUnauthorizedError(w http.ResponseWriter, r *http.Request,
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusUnauthorized)
 	h.writeJSON(w, map[string]string{
-		"error":             code,
-		"error_description": description,
+		paramError:            code,
+		paramErrorDescription: description,
 	})
 }
 
@@ -247,8 +247,8 @@ func (h *Handler) writeInsufficientScopeError(w http.ResponseWriter, requiredSco
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusForbidden)
 	h.writeJSON(w, map[string]string{
-		"error":             constants.ErrorCodeInsufficientScope,
-		"error_description": description,
+		paramError:            constants.ErrorCodeInsufficientScope,
+		paramErrorDescription: description,
 	})
 }
 
@@ -374,7 +374,7 @@ func (h *Handler) getTokenMetadata(accessToken string) *storage.TokenMetadata {
 
 	metadata, err := metadataStore.GetTokenMetadata(accessToken)
 	if err != nil {
-		h.logger.Warn("Failed to retrieve token metadata", "error", err)
+		h.logger.Warn("Failed to retrieve token metadata", paramError, err)
 		return nil
 	}
 

--- a/handler/register.go
+++ b/handler/register.go
@@ -114,7 +114,7 @@ func (h *Handler) authorizeClientRegistration(w http.ResponseWriter, r *http.Req
 
 	allowed, scheme, err := h.server.CanRegisterWithTrustedScheme(req.RedirectURIs)
 	if err != nil {
-		h.logger.Warn("Client registration rejected: invalid redirect URI", "client_ip", clientIP, "error", err)
+		h.logger.Warn("Client registration rejected: invalid redirect URI", "client_ip", clientIP, paramError, err)
 		h.writeError(w, constants.ErrorCodeInvalidRequest, fmt.Sprintf("Invalid redirect URI: %v", err), http.StatusBadRequest)
 		return result, false
 	}
@@ -152,7 +152,7 @@ func (h *Handler) validatePublicClientRegistration(ctx context.Context, w http.R
 	if !h.server.Config.AllowPublicClientRegistration && !auth.viaTrustedAllowlist {
 		h.logger.Warn("Public client registration rejected (not allowed by configuration)",
 			"token_endpoint_auth_method", req.TokenEndpointAuthMethod,
-			"client_type", req.ClientType, "ip", clientIP)
+			fieldClientType, req.ClientType, "ip", clientIP)
 		h.recordHTTPMetrics(ctx, endpointRegister, http.MethodPost, http.StatusBadRequest, startTime)
 		if span != nil {
 			instrumentation.SetSpanAttributes(
@@ -169,7 +169,7 @@ func (h *Handler) validatePublicClientRegistration(ctx context.Context, w http.R
 	}
 
 	h.logger.Debug("Public client registration authorized",
-		"token_endpoint_auth_method", req.TokenEndpointAuthMethod, "client_type", req.ClientType,
+		"token_endpoint_auth_method", req.TokenEndpointAuthMethod, fieldClientType, req.ClientType,
 		"ip", clientIP, "via_trusted_allowlist", auth.viaTrustedAllowlist, "auth_gate", auth.gate)
 	return true
 }
@@ -250,7 +250,7 @@ func (h *Handler) parseAndValidateRegistrationRequest(w http.ResponseWriter, r *
 	// Validate client_name to prevent potential stored XSS and log injection (defense-in-depth)
 	if err := helpers.ValidateClientName(req.ClientName); err != nil {
 		h.logger.Warn("Invalid client_name in registration request",
-			"client_name_length", len(req.ClientName), "error", err, "ip", clientIP)
+			"client_name_length", len(req.ClientName), paramError, err, "ip", clientIP)
 		h.writeError(w, constants.ErrorCodeInvalidRequest, err.Error(), http.StatusBadRequest)
 		return nil, err
 	}
@@ -301,7 +301,7 @@ func (h *Handler) recordTrustedAllowlistSpan(span trace.Span, auth registrationA
 // handleRegistrationError handles client registration errors.
 func (h *Handler) handleRegistrationError(ctx context.Context, w http.ResponseWriter, err error, clientIP string, startTime time.Time, span trace.Span) {
 	if errors.Is(err, storage.ErrClientIPLimitExceeded) {
-		h.logger.Warn("Client registration limit exceeded", "ip", clientIP, "error", err)
+		h.logger.Warn("Client registration limit exceeded", "ip", clientIP, paramError, err)
 		h.recordHTTPMetrics(ctx, endpointRegister, http.MethodPost, http.StatusTooManyRequests, startTime)
 		instrumentation.RecordError(span, err)
 		instrumentation.SetSpanError(span, "registration limit exceeded")
@@ -309,7 +309,7 @@ func (h *Handler) handleRegistrationError(ctx context.Context, w http.ResponseWr
 		return
 	}
 
-	h.logger.Error("Failed to register client", "ip", clientIP, "error", err)
+	h.logger.Error("Failed to register client", "ip", clientIP, paramError, err)
 	h.recordHTTPMetrics(ctx, endpointRegister, http.MethodPost, http.StatusInternalServerError, startTime)
 	instrumentation.RecordError(span, err)
 	instrumentation.SetSpanError(span, "registration failed")
@@ -324,9 +324,9 @@ func (h *Handler) auditTrustedAllowlistRegistration(ctx context.Context, auth re
 	}
 
 	details := map[string]any{
-		"client_type":   client.ClientType,
-		"client_ip":     clientIP,
-		"redirect_uris": client.RedirectURIs,
+		fieldClientType:   client.ClientType,
+		"client_ip":       clientIP,
+		fieldRedirectURIs: client.RedirectURIs,
 	}
 
 	var eventType string
@@ -375,8 +375,8 @@ func (h *Handler) writeRegistrationResponse(w http.ResponseWriter, client *stora
 		"client_id":                  client.ClientID,
 		"client_id_issued_at":        client.CreatedAt.Unix(),
 		"client_name":                client.ClientName,
-		"client_type":                client.ClientType,
-		"redirect_uris":              client.RedirectURIs,
+		fieldClientType:              client.ClientType,
+		fieldRedirectURIs:            client.RedirectURIs,
 		"token_endpoint_auth_method": client.TokenEndpointAuthMethod,
 		"grant_types":                client.GrantTypes,
 		"response_types":             client.ResponseTypes,

--- a/handler/register_management.go
+++ b/handler/register_management.go
@@ -77,7 +77,7 @@ func (h *Handler) authenticateManagementRequest(w http.ResponseWriter, r *http.R
 			h.writeError(w, constants.ErrorCodeInvalidToken, "client not found", http.StatusNotFound)
 			return nil, false
 		}
-		h.logger.Error("Client management: failed to retrieve client", "ip", clientIP, "client_id", clientID, "error", err)
+		h.logger.Error("Client management: failed to retrieve client", "ip", clientIP, "client_id", clientID, paramError, err)
 		h.writeError(w, constants.ErrorCodeServerError, "failed to retrieve client", http.StatusInternalServerError)
 		return nil, false
 	}
@@ -108,8 +108,8 @@ func (h *Handler) buildClientResponseBody(client *storage.Client) map[string]any
 		"client_id":                  client.ClientID,
 		"client_id_issued_at":        client.CreatedAt.Unix(),
 		"client_name":                client.ClientName,
-		"client_type":                client.ClientType,
-		"redirect_uris":              client.RedirectURIs,
+		fieldClientType:              client.ClientType,
+		fieldRedirectURIs:            client.RedirectURIs,
 		"token_endpoint_auth_method": client.TokenEndpointAuthMethod,
 		"grant_types":                client.GrantTypes,
 		"response_types":             client.ResponseTypes,
@@ -157,7 +157,7 @@ func (h *Handler) handleClientManagementPut(w http.ResponseWriter, r *http.Reque
 
 	newToken, newHash, err := server.GenerateRegistrationAccessToken()
 	if err != nil {
-		h.logger.Error("Client management: failed to rotate registration token", "ip", clientIP, "client_id", existing.ClientID, "error", err)
+		h.logger.Error("Client management: failed to rotate registration token", "ip", clientIP, "client_id", existing.ClientID, paramError, err)
 		h.writeError(w, constants.ErrorCodeServerError, "failed to rotate registration token", http.StatusInternalServerError)
 		return
 	}
@@ -180,7 +180,7 @@ func (h *Handler) handleClientManagementPut(w http.ResponseWriter, r *http.Reque
 	updated.RegistrationAccessTokenHash = newHash
 
 	if err := h.server.SaveClient(r.Context(), &updated); err != nil {
-		h.logger.Error("Client management: failed to update client", "ip", clientIP, "client_id", existing.ClientID, "error", err)
+		h.logger.Error("Client management: failed to update client", "ip", clientIP, "client_id", existing.ClientID, paramError, err)
 		h.recordHTTPMetrics(r.Context(), endpointClientManagement, http.MethodPut, http.StatusInternalServerError, startTime)
 		h.writeError(w, constants.ErrorCodeServerError, "failed to update client", http.StatusInternalServerError)
 		return
@@ -202,7 +202,7 @@ func (h *Handler) handleClientManagementDelete(w http.ResponseWriter, r *http.Re
 			h.writeError(w, constants.ErrorCodeInvalidRequest, "client not found", http.StatusNotFound)
 			return
 		}
-		h.logger.Error("Client management: failed to delete client", "ip", clientIP, "client_id", client.ClientID, "error", err)
+		h.logger.Error("Client management: failed to delete client", "ip", clientIP, "client_id", client.ClientID, paramError, err)
 		h.recordHTTPMetrics(r.Context(), endpointClientManagement, http.MethodDelete, http.StatusInternalServerError, startTime)
 		h.writeError(w, constants.ErrorCodeServerError, "failed to delete client", http.StatusInternalServerError)
 		return

--- a/handler/revoke.go
+++ b/handler/revoke.go
@@ -108,7 +108,7 @@ func (h *Handler) ServeTokenRevocation(w http.ResponseWriter, r *http.Request) {
 
 	// Revoke token
 	if err := h.server.RevokeToken(r.Context(), token, clientID, clientIP); err != nil {
-		h.logger.Error("Failed to revoke token", "client_id", clientID, "ip", clientIP, "error", err)
+		h.logger.Error("Failed to revoke token", "client_id", clientID, "ip", clientIP, paramError, err)
 		instrumentation.RecordError(span, err)
 		// Per RFC 7009, don't fail the request even if revocation failed
 	}

--- a/handler/token.go
+++ b/handler/token.go
@@ -57,9 +57,9 @@ func (h *Handler) ServeToken(w http.ResponseWriter, r *http.Request) {
 	grantType := r.Form.Get("grant_type")
 
 	switch grantType {
-	case "authorization_code":
+	case grantTypeAuthorizationCode:
 		h.handleAuthorizationCodeGrant(w, r, clientIP)
-	case "refresh_token":
+	case grantTypeRefreshToken:
 		h.handleRefreshTokenGrant(w, r, clientIP)
 	case server.GrantTypeTokenExchange:
 		h.handleTokenExchangeGrant(w, r, clientIP)
@@ -77,7 +77,7 @@ func (h *Handler) ServeToken(w http.ResponseWriter, r *http.Request) {
 // grant_type=<random> would otherwise mint a fresh series per probe).
 func (h *Handler) recordTokenFailure(ctx context.Context, grantType, errorCode string) {
 	switch grantType {
-	case "authorization_code", "refresh_token", "client_credentials", "password", server.GrantTypeTokenExchange:
+	case grantTypeAuthorizationCode, grantTypeRefreshToken, "client_credentials", "password", server.GrantTypeTokenExchange:
 	default:
 		grantType = "unknown"
 	}
@@ -98,7 +98,7 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 	codeVerifier := r.Form.Get("code_verifier")
 
 	if code == "" {
-		h.recordTokenFailure(r.Context(), "authorization_code", constants.ErrorCodeInvalidRequest)
+		h.recordTokenFailure(r.Context(), grantTypeAuthorizationCode, constants.ErrorCodeInvalidRequest)
 		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 		instrumentation.SetSpanError(span, "code missing")
 		h.writeError(w, constants.ErrorCodeInvalidRequest, "Required parameter 'code' missing", http.StatusBadRequest)
@@ -115,11 +115,11 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 		// 401 (unauthorized) in dashboards.
 		var oauthErr *oauth.Error
 		if errors.As(err, &oauthErr) {
-			h.recordTokenFailure(r.Context(), "authorization_code", oauthErr.Code)
+			h.recordTokenFailure(r.Context(), grantTypeAuthorizationCode, oauthErr.Code)
 			h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, oauthErr.Status, startTime)
 			h.writeError(w, oauthErr.Code, oauthErr.Description, oauthErr.Status)
 		} else {
-			h.recordTokenFailure(r.Context(), "authorization_code", constants.ErrorCodeInvalidClient)
+			h.recordTokenFailure(r.Context(), grantTypeAuthorizationCode, constants.ErrorCodeInvalidClient)
 			h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusUnauthorized, startTime)
 			h.writeError(w, constants.ErrorCodeInvalidClient, "Client authentication failed", http.StatusUnauthorized)
 		}
@@ -143,13 +143,13 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 		span,
 		attribute.String(instrumentation.AttrClientID, client.ClientID),
 		attribute.String(instrumentation.AttrClientType, client.ClientType),
-		attribute.String(instrumentation.AttrGrantType, "authorization_code"),
+		attribute.String(instrumentation.AttrGrantType, grantTypeAuthorizationCode),
 	)
 
 	dpopJKT, err := h.extractDPoPJKT(r)
 	if err != nil {
-		h.logger.Warn("Invalid DPoP proof on code exchange", "client_id", client.ClientID, "ip", clientIP, "error", err)
-		h.recordTokenFailure(r.Context(), "authorization_code", constants.ErrorCodeInvalidDPoPProof)
+		h.logger.Warn("Invalid DPoP proof on code exchange", "client_id", client.ClientID, "ip", clientIP, paramError, err)
+		h.recordTokenFailure(r.Context(), grantTypeAuthorizationCode, constants.ErrorCodeInvalidDPoPProof)
 		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 		instrumentation.RecordError(span, err)
 		instrumentation.SetSpanError(span, "invalid dpop proof")
@@ -160,8 +160,8 @@ func (h *Handler) handleAuthorizationCodeGrant(w http.ResponseWriter, r *http.Re
 	// Exchange authorization code for tokens
 	tokenResponse, scope, err := h.server.ExchangeAuthorizationCode(r.Context(), code, client.ClientID, redirectURI, resource, codeVerifier, dpopJKT)
 	if err != nil {
-		h.logger.Error("Failed to exchange authorization code", "client_id", client.ClientID, "ip", clientIP, "error", err)
-		h.recordTokenFailure(r.Context(), "authorization_code", constants.ErrorCodeInvalidGrant)
+		h.logger.Error("Failed to exchange authorization code", "client_id", client.ClientID, "ip", clientIP, paramError, err)
+		h.recordTokenFailure(r.Context(), grantTypeAuthorizationCode, constants.ErrorCodeInvalidGrant)
 		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 		instrumentation.RecordError(span, err)
 		instrumentation.SetSpanError(span, "code exchange failed")
@@ -194,11 +194,11 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	defer endSpan()
 
 	// Read from already-parsed form (ParseForm called by ServeToken)
-	refreshToken := r.Form.Get("refresh_token")
+	refreshToken := r.Form.Get(grantTypeRefreshToken)
 	clientID := r.Form.Get("client_id")
 
 	if refreshToken == "" {
-		h.recordTokenFailure(r.Context(), "refresh_token", constants.ErrorCodeInvalidRequest)
+		h.recordTokenFailure(r.Context(), grantTypeRefreshToken, constants.ErrorCodeInvalidRequest)
 		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 		instrumentation.SetSpanError(span, "refresh_token missing")
 		h.writeError(w, constants.ErrorCodeInvalidRequest, "refresh_token is required", http.StatusBadRequest)
@@ -216,7 +216,7 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	instrumentation.SetSpanAttributes(
 		span,
 		attribute.String(instrumentation.AttrClientID, clientID),
-		attribute.String(instrumentation.AttrGrantType, "refresh_token"),
+		attribute.String(instrumentation.AttrGrantType, grantTypeRefreshToken),
 	)
 	if clientAuthenticated {
 		instrumentation.SetSpanAttributes(span, attribute.Bool("oauth.client_authenticated", true))
@@ -233,8 +233,8 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 	// Refresh token
 	tokenResponse, err := h.server.RefreshAccessToken(r.Context(), refreshToken, clientID)
 	if err != nil {
-		h.logger.Error("Failed to refresh token", "client_id", clientID, "ip", clientIP, "error", err)
-		h.recordTokenFailure(r.Context(), "refresh_token", constants.ErrorCodeInvalidGrant)
+		h.logger.Error("Failed to refresh token", "client_id", clientID, "ip", clientIP, paramError, err)
+		h.recordTokenFailure(r.Context(), grantTypeRefreshToken, constants.ErrorCodeInvalidGrant)
 		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 		instrumentation.RecordError(span, err)
 		instrumentation.SetSpanError(span, "token refresh failed")
@@ -262,7 +262,7 @@ func (h *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Request
 func (h *Handler) authenticateRefreshTokenClient(ctx context.Context, w http.ResponseWriter, r *http.Request, clientID, clientIP string, startTime time.Time, span trace.Span) (string, bool, error) {
 	basicClientID, basicClientSecret := h.parseBasicAuth(r)
 
-	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, clientID, clientIP, endpointToken, "refresh_token", span, startTime) {
+	if h.rejectBasicFormClientIDMismatch(w, r, basicClientID, clientID, clientIP, endpointToken, grantTypeRefreshToken, span, startTime) {
 		return "", false, fmt.Errorf("client_id mismatch between Basic Authorization header and form parameter")
 	}
 
@@ -270,7 +270,7 @@ func (h *Handler) authenticateRefreshTokenClient(ctx context.Context, w http.Res
 	if basicClientID != "" {
 		clientID = basicClientID
 		if err := h.server.ValidateClientCredentials(ctx, clientID, basicClientSecret); err != nil {
-			h.logger.Warn("Client authentication failed", "client_id", clientID, "ip", clientIP, "error", err)
+			h.logger.Warn("Client authentication failed", "client_id", clientID, "ip", clientIP, paramError, err)
 			if h.server.Auditor != nil {
 				h.server.Auditor.LogAuthFailure(ctx, "", clientID, clientIP, "refresh_client_authentication_failed")
 			}
@@ -316,12 +316,12 @@ func (h *Handler) authenticateRefreshTokenClient(ctx context.Context, w http.Res
 				Type:     security.EventAuthFailure,
 				ClientID: clientID,
 				Details: map[string]any{
-					"severity":     "high",
-					"client_type":  "confidential",
-					"auth_missing": true,
-					"endpoint":     "refresh_token",
-					"ip":           clientIP,
-					"oauth_spec":   "OAuth 2.1 Section 6",
+					"severity":      "high",
+					fieldClientType: "confidential",
+					"auth_missing":  true,
+					"endpoint":      grantTypeRefreshToken,
+					"ip":            clientIP,
+					"oauth_spec":    "OAuth 2.1 Section 6",
 				},
 			})
 		}
@@ -456,7 +456,7 @@ func (h *Handler) writeTokenResponse(w http.ResponseWriter, token *oauth2.Token,
 	}
 
 	if token.RefreshToken != "" {
-		response["refresh_token"] = token.RefreshToken
+		response[grantTypeRefreshToken] = token.RefreshToken
 	}
 
 	if scope != "" {

--- a/handler/token_exchange.go
+++ b/handler/token_exchange.go
@@ -206,7 +206,7 @@ func (h *Handler) handleBrokeredTokenExchangeError(
 			"no validator registered for "+unsupported.Role()+"_token_type "+unsupported.TokenType(), http.StatusBadRequest)
 	default:
 		h.logger.Debug("brokered token exchange failed",
-			"client_id", clientID, "audience", audience, "ip", clientIP, "error", err)
+			"client_id", clientID, "audience", audience, "ip", clientIP, paramError, err)
 		h.recordTokenFailure(r.Context(), server.GrantTypeTokenExchange, constants.ErrorCodeInvalidGrant)
 		h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 		instrumentation.SetSpanError(span, "brokered exchange failed")
@@ -259,7 +259,7 @@ func (h *Handler) handleTokenExchangeError(
 			http.StatusBadRequest)
 		return
 	}
-	h.logger.Debug("token exchange failed", "ip", clientIP, "error", err)
+	h.logger.Debug("token exchange failed", "ip", clientIP, paramError, err)
 	h.recordHTTPMetrics(r.Context(), endpointToken, http.MethodPost, http.StatusBadRequest, startTime)
 	instrumentation.SetSpanError(span, "token exchange failed")
 	h.writeError(w, constants.ErrorCodeInvalidGrant, "subject token invalid or rejected", http.StatusBadRequest)

--- a/handler/userinfo.go
+++ b/handler/userinfo.go
@@ -18,8 +18,8 @@ import (
 // underlying field is non-empty. The returned `emitted` slice names the scope
 // groups that contributed at least one claim — used for the audit record.
 func buildUserInfoClaims(userInfo *providers.UserInfo, scopeSet map[string]struct{}) (map[string]any, []string) {
-	emitted := []string{"sub"}
-	claims := map[string]any{"sub": userInfo.ID}
+	emitted := []string{claimSub}
+	claims := map[string]any{claimSub: userInfo.ID}
 	if _, ok := scopeSet["profile"]; ok {
 		addProfileClaims(claims, userInfo)
 		emitted = append(emitted, "profile")
@@ -116,7 +116,7 @@ func (h *Handler) ServeUserInfo(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(claims); err != nil {
-		h.logger.Warn("failed to write JSON response", "error", err)
+		h.logger.Warn("failed to write JSON response", paramError, err)
 		h.recordHTTPMetrics(r.Context(), endpointUserInfo, r.Method, http.StatusInternalServerError, startTime)
 		return
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -85,13 +85,24 @@ func GenerateTestUserInfo() *storage.UserInfo {
 	}
 }
 
+// Shared test fixture values.
+const (
+	testClientID    = "test-client-id"
+	testRedirectURI = "https://example.com/callback"
+
+	// testClientBcryptHash is the bcrypt hash of the well-known fixture
+	// plaintext "secret". It is not a credential — the plaintext is public
+	// and only accepted by test stores seeded with this fixture.
+	testClientBcryptHash = "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy"
+)
+
 // GenerateTestClient creates a test OAuth client
 func GenerateTestClient() *storage.Client {
 	return &storage.Client{
-		ClientID:                "test-client-id",
-		ClientSecretHash:        "$2a$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy", // hash of "secret"
+		ClientID:                testClientID,
+		ClientSecretHash:        testClientBcryptHash,
 		ClientType:              "confidential",
-		RedirectURIs:            []string{"https://example.com/callback"},
+		RedirectURIs:            []string{testRedirectURI},
 		TokenEndpointAuthMethod: "client_secret_basic",
 		GrantTypes:              []string{"authorization_code", "refresh_token"},
 		ResponseTypes:           []string{"code"},
@@ -105,8 +116,8 @@ func GenerateTestClient() *storage.Client {
 func GenerateTestAuthorizationState() *storage.AuthorizationState {
 	return &storage.AuthorizationState{
 		StateID:             GenerateRandomString(32),
-		ClientID:            "test-client-id",
-		RedirectURI:         "https://example.com/callback",
+		ClientID:            testClientID,
+		RedirectURI:         testRedirectURI,
 		Scope:               "openid email profile",
 		CodeChallenge:       "test-code-challenge",
 		CodeChallengeMethod: "S256",
@@ -120,8 +131,8 @@ func GenerateTestAuthorizationState() *storage.AuthorizationState {
 func GenerateTestAuthorizationCode() *storage.AuthorizationCode {
 	return &storage.AuthorizationCode{
 		Code:                GenerateRandomString(32),
-		ClientID:            "test-client-id",
-		RedirectURI:         "https://example.com/callback",
+		ClientID:            testClientID,
+		RedirectURI:         testRedirectURI,
 		Scope:               "openid email profile",
 		CodeChallenge:       "test-code-challenge",
 		CodeChallengeMethod: "S256",

--- a/security/audit.go
+++ b/security/audit.go
@@ -10,6 +10,10 @@ import (
 	"github.com/giantswarm/mcp-oauth/internal/helpers"
 )
 
+// logKeyReason is the structured-logging key carrying the human-readable
+// cause of an audited security event.
+const logKeyReason = "reason"
+
 // Auditor handles security event logging with PII protection.
 type Auditor struct {
 	logger    *slog.Logger
@@ -148,7 +152,7 @@ func (a *Auditor) LogAuthFailure(ctx context.Context, userID, clientID, ipAddres
 		ClientID:  clientID,
 		IPAddress: ipAddress,
 		Details: map[string]any{
-			"reason": reason,
+			logKeyReason: reason,
 		},
 	})
 }
@@ -193,7 +197,7 @@ func (a *Auditor) LogInvalidPKCE(ctx context.Context, clientID, ipAddress, reaso
 		ClientID:  clientID,
 		IPAddress: ipAddress,
 		Details: map[string]any{
-			"reason": reason,
+			logKeyReason: reason,
 		},
 	})
 }
@@ -231,8 +235,8 @@ func (a *Auditor) LogInvalidRedirect(ctx context.Context, clientID, ipAddress, u
 		ClientID:  clientID,
 		IPAddress: ipAddress,
 		Details: map[string]any{
-			"uri":    uri,
-			"reason": reason,
+			"uri":        uri,
+			logKeyReason: reason,
 		},
 	})
 }

--- a/security/ratelimit_test.go
+++ b/security/ratelimit_test.go
@@ -3,6 +3,7 @@ package security
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -542,7 +543,7 @@ func TestRateLimiter_ConcurrentWithEviction(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		go func(base int) {
 			for j := 0; j < requestsPerGoroutine; j++ {
-				identifier := "id-" + string(rune('0'+base*requestsPerGoroutine+j))
+				identifier := "id-" + strconv.Itoa(base*requestsPerGoroutine+j)
 				rl.Allow(identifier)
 			}
 			done <- true

--- a/server/access_token.go
+++ b/server/access_token.go
@@ -180,8 +180,8 @@ const rfc9068TokenType = "at+jwt"
 // Issue sets explicitly. Allowing Extra to override them would let callers
 // extend token lifetime (exp), forge issuers (iss), or substitute subjects (sub).
 var jwtReservedClaims = map[string]struct{}{
-	"iss": {}, "sub": {}, "aud": {},
-	"exp": {}, "nbf": {}, "iat": {}, "jti": {},
+	claimIss: {}, claimSub: {}, "aud": {},
+	"exp": {}, "nbf": {}, "iat": {}, claimJTI: {},
 }
 
 // rfc9068Claims is the on-the-wire claim shape for an RFC 9068 access token.

--- a/server/authcode.go
+++ b/server/authcode.go
@@ -25,8 +25,8 @@ import (
 // This helper reduces code duplication and ensures consistent error handling.
 func (s *Server) logAuthCodeValidationFailure(ctx context.Context, reason, clientID, userID, codePrefix string) error {
 	s.Logger.Debug("Authorization code validation failed",
-		"reason", reason,
-		"client_id", clientID,
+		logKeyReason, reason,
+		paramClientID, clientID,
 		"user_id", userID,
 		"code_prefix", codePrefix)
 
@@ -117,12 +117,12 @@ func (s *Server) handleCodeReuseDetection(ctx context.Context, authCode *storage
 	// Rate limit logging to prevent DoS via log flooding
 	if s.SecurityEventRateLimiter == nil || s.SecurityEventRateLimiter.Allow(authCode.UserID+":"+clientID) {
 		s.Logger.Error("Authorization code reuse detected - revoking all tokens",
-			"user_id", authCode.UserID, "client_id", clientID, "oauth_spec", "OAuth 2.1 Section 4.1.2")
+			"user_id", authCode.UserID, paramClientID, clientID, logKeyOAuthSpec, oauthSpecSection412)
 	}
 
 	// Revoke all tokens for this user+client (OAuth 2.1 requirement)
 	if err := s.RevokeAllTokensForUserClient(ctx, authCode.UserID, clientID); err != nil {
-		s.Logger.Error("Failed to revoke tokens after code reuse detection", "error", err)
+		s.Logger.Error("Failed to revoke tokens after code reuse detection", logKeyError, err)
 	}
 
 	if s.Auditor != nil {
@@ -131,7 +131,7 @@ func (s *Server) handleCodeReuseDetection(ctx context.Context, authCode *storage
 			UserID:   authCode.UserID,
 			ClientID: clientID,
 			Details: map[string]any{
-				"severity": "critical", "action": "all_tokens_revoked", "oauth_spec": "OAuth 2.1 Section 4.1.2",
+				logKeySeverity: severityCritical, logKeyAction: "all_tokens_revoked", logKeyOAuthSpec: oauthSpecSection412,
 			},
 		})
 		s.Auditor.LogAuthFailure(ctx, authCode.UserID, clientID, "", "authorization_code_reuse")
@@ -150,8 +150,8 @@ func (s *Server) validatePublicClientPKCE(ctx context.Context, client *storage.C
 
 	if !s.Config.AllowPublicClientsWithoutPKCE {
 		s.Logger.Error("Public client attempted token exchange without PKCE",
-			"client_id", client.ClientID, "user_id", authCode.UserID,
-			"client_type", client.ClientType, "oauth_spec", OAuthSpecVersion)
+			paramClientID, client.ClientID, "user_id", authCode.UserID,
+			"client_type", client.ClientType, logKeyOAuthSpec, OAuthSpecVersion)
 
 		if s.Auditor != nil {
 			s.Auditor.LogEvent(ctx, security.Event{
@@ -159,7 +159,7 @@ func (s *Server) validatePublicClientPKCE(ctx context.Context, client *storage.C
 				UserID:   authCode.UserID,
 				ClientID: client.ClientID,
 				Details: map[string]any{
-					"severity": "high", "client_type": client.ClientType, "oauth_spec": OAuthSpecVersion,
+					logKeySeverity: severityHigh, "client_type": client.ClientType, logKeyOAuthSpec: OAuthSpecVersion,
 				},
 			})
 			s.Auditor.LogAuthFailure(ctx, authCode.UserID, client.ClientID, "", "pkce_required_for_public_client")
@@ -169,7 +169,7 @@ func (s *Server) validatePublicClientPKCE(ctx context.Context, client *storage.C
 
 	// Warn about insecure configuration
 	s.Logger.Warn("INSECURE: Public client token exchange without PKCE allowed by configuration",
-		"client_id", client.ClientID, "user_id", authCode.UserID, "security_risk", "authorization_code_theft")
+		paramClientID, client.ClientID, "user_id", authCode.UserID, "security_risk", "authorization_code_theft")
 
 	if s.Auditor != nil {
 		s.Auditor.LogEvent(ctx, security.Event{
@@ -177,7 +177,7 @@ func (s *Server) validatePublicClientPKCE(ctx context.Context, client *storage.C
 			UserID:   authCode.UserID,
 			ClientID: client.ClientID,
 			Details: map[string]any{
-				"severity": "warning", "client_type": client.ClientType, "config": "AllowPublicClientsWithoutPKCE=true",
+				logKeySeverity: "warning", "client_type": client.ClientType, "config": "AllowPublicClientsWithoutPKCE=true",
 			},
 		})
 	}
@@ -209,7 +209,7 @@ func (s *Server) validatePKCEWithAudit(ctx context.Context, authCode *storage.Au
 				Type:     security.EventPKCEValidationFailed,
 				UserID:   authCode.UserID,
 				ClientID: clientID,
-				Details:  map[string]any{"reason": err.Error()},
+				Details:  map[string]any{logKeyReason: err.Error()},
 			})
 			s.Auditor.LogAuthFailure(ctx, authCode.UserID, clientID, "", fmt.Sprintf("pkce_validation_failed: %v", err))
 		}
@@ -259,7 +259,7 @@ func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID string, re
 	trackingState := clientState
 	if trackingState == "" {
 		trackingState = generateRandomToken()
-		s.Logger.Debug("Generated server-side state for client without state parameter", "client_id", clientID)
+		s.Logger.Debug("Generated server-side state for client without state parameter", paramClientID, clientID)
 	}
 
 	// Validate PKCE parameters
@@ -286,7 +286,7 @@ func (s *Server) StartAuthorizationFlow(ctx context.Context, clientID string, re
 	if err := s.ValidateRedirectURIAtAuthorizationTime(ctx, redirectURIStr); err != nil {
 		s.logAuthFailure(ctx, "", clientID, "redirect_uri_security_violation")
 		s.Logger.Warn("Redirect URI failed authorization-time security validation",
-			"client_id", clientID, "redirect_uri", sanitizeURIForLogging(redirectURIStr), "error", err.Error())
+			paramClientID, clientID, "redirect_uri", sanitizeURIForLogging(redirectURIStr), logKeyError, err.Error())
 		return "", fmt.Errorf("%s: redirect URI failed security validation", ErrorCodeInvalidRequest)
 	}
 
@@ -367,8 +367,8 @@ func (s *Server) resolveAuthorizationNonce(clientID, scope string, authOpts *pro
 	if !helpers.HasScope(scope, "openid") {
 		if authOpts != nil && authOpts.Nonce != "" {
 			s.Logger.Debug("Dropping client-supplied nonce on non-OIDC flow",
-				"client_id", clientID,
-				"scope", scope)
+				paramClientID, clientID,
+				paramScope, scope)
 			amended := *authOpts
 			amended.Nonce = ""
 			return "", &amended
@@ -379,7 +379,7 @@ func (s *Server) resolveAuthorizationNonce(clientID, scope string, authOpts *pro
 	if authOpts != nil && authOpts.Nonce != "" {
 		if len(authOpts.Nonce) < minClientNonceLength {
 			s.Logger.Warn("Client-supplied nonce below minimum length; replacing with server-generated value",
-				"client_id", clientID,
+				paramClientID, clientID,
 				"client_nonce_length", len(authOpts.Nonce),
 				"min_required", minClientNonceLength)
 			minted := generateRandomToken()
@@ -468,7 +468,7 @@ func (s *Server) logInvalidProviderCallback(ctx context.Context, reason string) 
 	if s.Auditor != nil {
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type:    security.EventInvalidProviderCallback,
-			Details: map[string]any{"reason": reason},
+			Details: map[string]any{logKeyReason: reason},
 		})
 	}
 }
@@ -479,7 +479,7 @@ func (s *Server) logProviderStateMismatch(ctx context.Context, clientID string) 
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type:     security.EventProviderStateMismatch,
 			ClientID: clientID,
-			Details:  map[string]any{"severity": "critical"},
+			Details:  map[string]any{logKeySeverity: severityCritical},
 		})
 	}
 }
@@ -562,8 +562,8 @@ func (s *Server) logProviderNonceMismatch(ctx context.Context, clientID, reason 
 		Type:     security.EventProviderNonceMismatch,
 		ClientID: clientID,
 		Details: map[string]any{
-			"severity": "high",
-			"reason":   reason,
+			logKeySeverity: severityHigh,
+			logKeyReason:   reason,
 		},
 	})
 }
@@ -576,10 +576,10 @@ func (s *Server) exchangeCodeWithProvider(ctx context.Context, code, providerVer
 			s.Auditor.LogEvent(ctx, security.Event{
 				Type: security.EventProviderCodeExchangeFailed,
 				Details: map[string]any{
-					"provider":     s.provider.Name(),
-					"error":        err.Error(),
+					logKeyProvider: s.provider.Name(),
+					logKeyError:    err.Error(),
 					"pkce_enabled": providerVerifier != "",
-					"client_id":    authState.ClientID,
+					paramClientID:  authState.ClientID,
 					"state_id":     helpers.SafeTruncate(providerState, 16),
 				},
 			})
@@ -661,7 +661,7 @@ func (s *Server) saveUserInfoAndToken(ctx context.Context, userInfo *providers.U
 		return nil
 	}
 	if err := s.tokenStore.SaveUserInfo(ctx, userInfo.Email, storedInfo); err != nil {
-		s.Logger.Warn("Failed to save user info by email", "error", err)
+		s.Logger.Warn("Failed to save user info by email", logKeyError, err)
 		s.auditProviderTokenStorageFailed(ctx, userInfo, "save_user_info_by_email", err.Error())
 	}
 	// Email-keyed provider-token copies exist only in the legacy layout; the
@@ -669,7 +669,7 @@ func (s *Server) saveUserInfoAndToken(ctx context.Context, userInfo *providers.U
 	// keeping a second copy that write-backs would miss.
 	if _, unified := s.userProviderTokenStore(); !unified {
 		if err := s.tokenStore.SaveToken(ctx, userInfo.Email, s.extendTokenExpiryForStorage(providerToken)); err != nil {
-			s.Logger.Warn("Failed to save provider token by email", "error", err)
+			s.Logger.Warn("Failed to save provider token by email", logKeyError, err)
 			s.auditProviderTokenStorageFailed(ctx, userInfo, "save_token_by_email", err.Error())
 		}
 	}
@@ -739,7 +739,7 @@ func (s *Server) mergedLoginProviderToken(ctx context.Context, upts storage.User
 	if err != nil {
 		if !storage.IsNotFoundError(err) && !storage.IsExpiredError(err) {
 			s.Logger.Warn("Failed to read shared provider token for login merge, saving login token as-is",
-				"user_id", userID, "error", err)
+				"user_id", userID, logKeyError, err)
 		}
 		return providerToken
 	}
@@ -779,14 +779,14 @@ func (s *Server) acquireProviderRefreshLockForLogin(ctx context.Context, userID 
 		lockValue, acquired, err := locker.AcquireProviderRefreshLock(waitCtx, userID, providerRefreshLockTTL)
 		if err != nil {
 			s.Logger.Warn("Provider refresh lock acquire failed during login token save, proceeding without lock",
-				"user_id", userID, "error", err)
+				"user_id", userID, logKeyError, err)
 			return noop, false
 		}
 		if acquired {
 			return func() {
 				if releaseErr := locker.ReleaseProviderRefreshLock(context.WithoutCancel(ctx), userID, lockValue); releaseErr != nil {
 					s.Logger.Warn("Failed to release provider refresh lock after login token save",
-						"user_id", userID, "error", releaseErr)
+						"user_id", userID, logKeyError, releaseErr)
 				}
 			}, true
 		}
@@ -819,9 +819,9 @@ func (s *Server) auditProviderTokenStorageFailed(ctx context.Context, userInfo *
 		Type:   security.EventProviderTokenStorageFailed,
 		UserID: userID,
 		Details: map[string]any{
-			"reason":   reason,
-			"severity": "high",
-			"detail":   detail,
+			logKeyReason:   reason,
+			logKeySeverity: severityHigh,
+			"detail":       detail,
 		},
 	})
 }
@@ -908,7 +908,7 @@ func (s *Server) logAuthorizationCodeIssued(ctx context.Context, userID, clientI
 			UserID:   userID,
 			ClientID: clientID,
 			Details: map[string]any{
-				"scope":                 scope,
+				paramScope:              scope,
 				"client_state_returned": true,
 			},
 		})
@@ -1022,13 +1022,13 @@ func (s *Server) validateScopesAndPKCE(ctx context.Context, authCode *storage.Au
 // logScopeValidationFailure logs a scope validation failure event.
 func (s *Server) logScopeValidationFailure(ctx context.Context, authCode *storage.AuthorizationCode, clientID, code string, err error) {
 	s.Logger.Debug("Client scope validation failed during token exchange",
-		"reason", err.Error(), "client_id", clientID, "user_id", authCode.UserID,
+		logKeyReason, err.Error(), paramClientID, clientID, "user_id", authCode.UserID,
 		"requested_scope", authCode.Scope, "code_prefix", helpers.SafeTruncate(code, 8))
 
 	if s.Auditor != nil {
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventScopeEscalationAttempt, UserID: authCode.UserID, ClientID: clientID,
-			Details: map[string]any{"severity": "high", "requested_scope": authCode.Scope},
+			Details: map[string]any{logKeySeverity: severityHigh, "requested_scope": authCode.Scope},
 		})
 		s.Auditor.LogAuthFailure(ctx, authCode.UserID, clientID, "", fmt.Sprintf("scope_validation_failed: %v", err))
 	}
@@ -1063,7 +1063,7 @@ func (s *Server) generateAndStoreTokens(ctx context.Context, authCode *storage.A
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		Expiry:       expiry,
-		TokenType:    "Bearer",
+		TokenType:    tokenTypeBearer,
 	}
 
 	// OIDC Compliance: Forward id_token from upstream provider to client
@@ -1084,17 +1084,17 @@ func (s *Server) generateAndStoreTokens(ctx context.Context, authCode *storage.A
 	// write-back would clobber the fresh credential with a stale one.
 	if upts, unified := s.userProviderTokenStore(); unified {
 		if err := upts.SaveProviderTokenRef(ctx, accessToken, authCode.UserID, refreshExpiry); err != nil {
-			s.Logger.Warn("Failed to save access token provider reference", "error", err)
+			s.Logger.Warn("Failed to save access token provider reference", logKeyError, err)
 		}
 		if err := upts.SaveProviderTokenRef(ctx, refreshToken, authCode.UserID, refreshExpiry); err != nil {
-			s.Logger.Warn("Failed to save refresh token provider reference", "error", err)
+			s.Logger.Warn("Failed to save refresh token provider reference", logKeyError, err)
 		}
 	} else {
 		if err := s.tokenStore.SaveToken(ctx, accessToken, authCode.ProviderToken); err != nil {
-			s.Logger.Warn("Failed to save access token mapping", "error", err)
+			s.Logger.Warn("Failed to save access token mapping", logKeyError, err)
 		}
 		if err := s.tokenStore.SaveToken(ctx, refreshToken, authCode.ProviderToken); err != nil {
-			s.Logger.Warn("Failed to save refresh token", "error", err)
+			s.Logger.Warn("Failed to save refresh token", logKeyError, err)
 		}
 	}
 
@@ -1174,7 +1174,7 @@ func (s *Server) fillUserInfoClaims(ctx context.Context, userID string, c *Acces
 	info, err := s.tokenStore.GetUserInfo(ctx, userID)
 	if err != nil {
 		s.Logger.Debug("UserInfo lookup failed during JWT access token issuance — email/groups claims omitted",
-			"error", err,
+			logKeyError, err,
 			"user_id", userID)
 		return
 	}
@@ -1197,15 +1197,15 @@ func (s *Server) trackRefreshTokenFamily(ctx context.Context, refreshToken, user
 			familyID = generateRandomToken()
 		}
 		if err := familyStore.SaveRefreshTokenWithFamily(ctx, refreshToken, userID, clientID, familyID, 0, refreshTokenExpiry); err != nil {
-			s.Logger.Warn("Failed to track refresh token with family", "error", err)
+			s.Logger.Warn("Failed to track refresh token with family", logKeyError, err)
 		} else {
-			s.Logger.Debug("Created new refresh token family", "user_id", userID, "family_id", helpers.SafeTruncate(familyID, 8))
+			s.Logger.Debug("Created new refresh token family", "user_id", userID, logKeyFamilyID, helpers.SafeTruncate(familyID, 8))
 		}
 		return
 	}
 
 	if err := s.tokenStore.SaveRefreshToken(ctx, refreshToken, userID, refreshTokenExpiry); err != nil {
-		s.Logger.Warn("Failed to track refresh token", "error", err)
+		s.Logger.Warn("Failed to track refresh token", logKeyError, err)
 	}
 }
 
@@ -1229,7 +1229,7 @@ func (s *Server) logAuthorizationFlowStarted(ctx context.Context, clientID, redi
 
 	details := map[string]any{
 		"redirect_uri":          redirectURI,
-		"scope":                 scope,
+		paramScope:              scope,
 		"code_challenge_method": codeChallengeMethod,
 	}
 

--- a/server/cimd.go
+++ b/server/cimd.go
@@ -207,7 +207,7 @@ func (s *Server) fetchClientMetadata(ctx context.Context, clientID string) (*Cli
 
 	if allowPrivateIP {
 		s.Logger.Debug("CIMD fetch with private IP allowance enabled",
-			"client_id", clientID,
+			paramClientID, clientID,
 			"config", "AllowPrivateIPClientMetadata=true")
 	}
 
@@ -215,8 +215,8 @@ func (s *Server) fetchClientMetadata(ctx context.Context, clientID string) (*Cli
 	if err != nil {
 		s.recordCIMDFetchMetric(ctx, "blocked", fetchStart)
 		s.logMetadataFetchEvent(ctx, "client_metadata_fetch_blocked", clientID, map[string]any{
-			"reason": err.Error(),
-			"ssrf":   "protected",
+			logKeyReason: err.Error(),
+			"ssrf":       "protected",
 		})
 		return nil, 0, fmt.Errorf("metadata URL validation failed: %w", err)
 	}
@@ -236,7 +236,7 @@ func (s *Server) fetchClientMetadata(ctx context.Context, clientID string) (*Cli
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, sanitizedURL, nil)
 	if err != nil {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		return nil, 0, fmt.Errorf("failed to create metadata request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
@@ -244,15 +244,15 @@ func (s *Server) fetchClientMetadata(ctx context.Context, clientID string) (*Cli
 
 	resp, err := client.Do(req)
 	if err != nil {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		s.logMetadataFetchEvent(ctx, "client_metadata_fetch_failed", clientID, map[string]any{
-			"error": err.Error(),
+			logKeyError: err.Error(),
 		})
 		return nil, 0, fmt.Errorf("failed to fetch metadata from %s: %w", clientID, err)
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
-			s.Logger.Warn("Failed to close response body", "error", closeErr)
+			s.Logger.Warn("Failed to close response body", logKeyError, closeErr)
 		}
 	}()
 
@@ -267,7 +267,7 @@ func (s *Server) fetchClientMetadata(ctx context.Context, clientID string) (*Cli
 // processMetadataResponse validates, parses, and processes a CIMD HTTP response.
 func (s *Server) processMetadataResponse(ctx context.Context, resp *http.Response, clientID string, fetchStart time.Time) (*ClientMetadata, time.Duration, error) {
 	if resp.StatusCode != http.StatusOK {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		s.logMetadataFetchEvent(ctx, "client_metadata_fetch_failed", clientID, map[string]any{
 			"status_code": resp.StatusCode,
 			"status":      resp.Status,
@@ -276,25 +276,25 @@ func (s *Server) processMetadataResponse(ctx context.Context, resp *http.Respons
 	}
 
 	if err := validateResponseContentType(resp); err != nil {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		return nil, 0, err
 	}
 
 	const maxMetadataSize int64 = 1 * 1024 * 1024 // 1MB
 	bodyBytes, err := readAndValidateResponseBody(resp, maxMetadataSize)
 	if err != nil {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		return nil, 0, err
 	}
 
 	var metadata ClientMetadata
 	if err := json.Unmarshal(bodyBytes, &metadata); err != nil {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		return nil, 0, fmt.Errorf("failed to parse metadata JSON: %w", err)
 	}
 
 	if err := s.validateFetchedClientMetadata(ctx, &metadata, clientID); err != nil {
-		s.recordCIMDFetchMetric(ctx, "error", fetchStart)
+		s.recordCIMDFetchMetric(ctx, logKeyError, fetchStart)
 		return nil, 0, err
 	}
 
@@ -311,7 +311,7 @@ func (s *Server) processMetadataResponse(ctx context.Context, resp *http.Respons
 	s.recordCIMDFetchMetric(ctx, "success", fetchStart)
 
 	s.Logger.Debug("Fetched client metadata from URL",
-		"client_id", clientID,
+		paramClientID, clientID,
 		"client_name", metadata.ClientName,
 		"redirect_uris", len(metadata.RedirectURIs),
 		"size_bytes", len(bodyBytes),
@@ -332,7 +332,7 @@ func parseSuggestedTTL(resp *http.Response, clientID string, logger *slog.Logger
 	}
 	ttl := time.Duration(maxAge) * time.Second
 	logger.Debug("Parsed Cache-Control max-age",
-		"client_id", clientID,
+		paramClientID, clientID,
 		"max_age_seconds", maxAge,
 		"suggested_ttl", ttl)
 	return ttl
@@ -402,7 +402,7 @@ func (s *Server) validateFetchedClientMetadata(ctx context.Context, metadata *Cl
 		s.logMetadataFetchEvent(ctx, "client_metadata_id_mismatch", expectedClientID, map[string]any{
 			"document_client_id": metadata.ClientID,
 			"url_client_id":      expectedClientID,
-			"severity":           "high",
+			logKeySeverity:       severityHigh,
 		})
 		return fmt.Errorf("client_id mismatch: document contains %q but was fetched from %q (security violation)",
 			metadata.ClientID, expectedClientID)
@@ -416,7 +416,7 @@ func (s *Server) validateFetchedClientMetadata(ctx context.Context, metadata *Cl
 	// Validate client_name to prevent stored XSS and log injection (defense-in-depth)
 	if err := helpers.ValidateClientName(metadata.ClientName); err != nil {
 		s.Logger.Warn("Invalid client_name in fetched metadata",
-			"client_id", expectedClientID, "error", err)
+			paramClientID, expectedClientID, logKeyError, err)
 		return fmt.Errorf("invalid client metadata: %w", err)
 	}
 
@@ -480,7 +480,7 @@ func (s *Server) calculateFetchTimeout(ctx context.Context) time.Duration {
 			s.Logger.Debug("Using context deadline for metadata fetch",
 				"original_timeout", s.Config.ClientMetadataFetchTimeout,
 				"adjusted_timeout", timeUntilDeadline,
-				"reason", "context deadline")
+				logKeyReason, "context deadline")
 			return timeUntilDeadline
 		}
 	}

--- a/server/cimd_cache.go
+++ b/server/cimd_cache.go
@@ -319,7 +319,7 @@ func (s *Server) tryGetCachedClient(ctx context.Context, clientID string) (*stor
 
 	s.recordCIMDCacheMetric(ctx, "hit")
 	s.logMetadataFetchEvent(ctx, "client_metadata_cache_hit", clientID, map[string]any{"source": "cache"})
-	s.Logger.Debug("Using cached client metadata", "client_id", clientID)
+	s.Logger.Debug("Using cached client metadata", paramClientID, clientID)
 	return cachedClient, true
 }
 
@@ -335,7 +335,7 @@ func (s *Server) checkNegativeCache(ctx context.Context, clientID string) error 
 	s.logMetadataFetchEvent(ctx, "client_metadata_negative_cache_hit", clientID, map[string]any{
 		"source": "negative_cache", "cached_error": errorMsg,
 	})
-	s.Logger.Debug("Client ID in negative cache", "client_id", clientID, "cached_error", errorMsg)
+	s.Logger.Debug("Client ID in negative cache", paramClientID, clientID, "cached_error", errorMsg)
 	return fmt.Errorf("client metadata previously failed validation: %s (cached)", errorMsg)
 }
 
@@ -353,7 +353,7 @@ func (s *Server) checkMetadataFetchRateLimit(ctx context.Context, clientID strin
 
 	if !s.metadataFetchRateLimiter.Allow(domain) {
 		s.logMetadataFetchEvent(ctx, "client_metadata_rate_limited", clientID, map[string]any{
-			"domain": domain, "reason": "rate_limit_exceeded",
+			"domain": domain, logKeyReason: "rate_limit_exceeded",
 		})
 		return fmt.Errorf("rate limit exceeded for metadata fetches from domain: %s", domain)
 	}
@@ -416,7 +416,7 @@ func (s *Server) fetchClientWithSingleflight(ctx context.Context, clientID strin
 	// Double-check cache (another goroutine might have filled it while we waited)
 	if cachedClient, ok := s.metadataCache.Get(clientID); ok {
 		s.recordCIMDCacheMetric(ctx, "hit")
-		s.Logger.Debug("Using cached client metadata (singleflight)", "client_id", clientID)
+		s.Logger.Debug("Using cached client metadata (singleflight)", paramClientID, clientID)
 		return cachedClient, nil
 	}
 
@@ -427,7 +427,7 @@ func (s *Server) fetchClientWithSingleflight(ctx context.Context, clientID strin
 	}
 
 	s.recordCIMDCacheMetric(ctx, "miss")
-	s.Logger.Debug("Fetching client metadata from URL", "client_id", clientID)
+	s.Logger.Debug("Fetching client metadata from URL", paramClientID, clientID)
 
 	metadata, suggestedTTL, fetchErr := s.fetchClientMetadata(ctx, clientID)
 	if fetchErr != nil {
@@ -450,7 +450,7 @@ func (s *Server) handleMetadataFetchFailure(ctx context.Context, clientID string
 		Type:     "client_metadata_fetch_failed_cached",
 		ClientID: clientID,
 		Details: map[string]any{
-			"error":          fetchErr.Error(),
+			logKeyError:      fetchErr.Error(),
 			"negative_cache": "stored",
 			"cache_purpose":  "prevent_rapid_retry",
 		},
@@ -473,7 +473,7 @@ func (s *Server) cacheAndReturnClient(clientID string, metadata *ClientMetadata,
 // determineCacheTTL determines the TTL to use for caching.
 func (s *Server) determineCacheTTL(clientID string, suggestedTTL time.Duration) time.Duration {
 	if suggestedTTL > 0 {
-		s.Logger.Debug("Using Cache-Control TTL", "client_id", clientID, "ttl", suggestedTTL)
+		s.Logger.Debug("Using Cache-Control TTL", paramClientID, clientID, "ttl", suggestedTTL)
 		return suggestedTTL
 	}
 

--- a/server/client.go
+++ b/server/client.go
@@ -170,7 +170,7 @@ func (s *Server) EnsureConfidentialClient(ctx context.Context, clientID, clientS
 		return false, fmt.Errorf("failed to save client %q: %w", clientID, err)
 	}
 
-	s.Logger.Info("Seeded confidential OAuth client", "client_id", clientID)
+	s.Logger.Info("Seeded confidential OAuth client", paramClientID, clientID)
 	return true, nil
 }
 
@@ -181,13 +181,13 @@ func (s *Server) validateRedirectURIsWithAudit(ctx context.Context, redirectURIs
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventClientRegistrationRejected,
 			Details: map[string]any{
-				"reason":    "redirect_uri_validation_failed",
-				"category":  category,
-				"client_ip": clientIP,
+				logKeyReason: "redirect_uri_validation_failed",
+				"category":   category,
+				"client_ip":  clientIP,
 			},
 		})
 		s.Logger.Warn("Client registration rejected: redirect URI validation failed",
-			"error", err.Error(),
+			logKeyError, err.Error(),
 			"client_ip", clientIP)
 		return fmt.Errorf("invalid_redirect_uri: %w", err)
 	}
@@ -243,14 +243,14 @@ func GenerateRegistrationAccessToken() (plaintext, hash string, err error) {
 func (s *Server) trackClientIPAndLog(ctx context.Context, client *storage.Client, _ /* clientSecret - not logged for security */, clientIP string) {
 	if tracker, ok := s.clientStore.(storage.ClientIPTracker); ok {
 		if err := tracker.TrackClientIP(context.WithoutCancel(ctx), client.ClientID, clientIP); err != nil {
-			s.Logger.Warn("failed to track client IP", "client_id", client.ClientID, "ip", clientIP, "error", err)
+			s.Logger.Warn("failed to track client IP", paramClientID, client.ClientID, "ip", clientIP, logKeyError, err)
 		}
 	}
 
 	s.Auditor.LogClientRegistered(ctx, client.ClientID, client.ClientType, clientIP)
 
 	s.Logger.Debug("Registered new OAuth client",
-		"client_id", client.ClientID,
+		paramClientID, client.ClientID,
 		"client_name", client.ClientName,
 		"client_type", client.ClientType,
 		"token_endpoint_auth_method", client.TokenEndpointAuthMethod,

--- a/server/config_trusted_redirect_uris.go
+++ b/server/config_trusted_redirect_uris.go
@@ -25,7 +25,7 @@ func validateTrustedPublicRegistrationRedirectURIs(config *Config, logger *slog.
 		canonical, err := normalizeTrustedRedirectURI(raw)
 		if err != nil {
 			logger.Error("Removing invalid TrustedPublicRegistrationRedirectURIs entry",
-				"index", i, "uri", raw, "reason", err.Error())
+				"index", i, "uri", raw, logKeyReason, err.Error())
 			continue
 		}
 		if set[canonical] {

--- a/server/config_validation.go
+++ b/server/config_validation.go
@@ -154,7 +154,7 @@ func validateProviderRevocationConfig(config *Config, logger *slog.Logger) {
 		logger.Warn("CONFIGURATION WARNING: Invalid ProviderRevocationTimeout corrected",
 			"provided_value", origTimeout,
 			"corrected_to", config.ProviderRevocationTimeout,
-			"reason", "timeout must be at least 1 second")
+			logKeyReason, "timeout must be at least 1 second")
 		hasInvalidValues = true
 	}
 
@@ -163,7 +163,7 @@ func validateProviderRevocationConfig(config *Config, logger *slog.Logger) {
 		logger.Warn("CONFIGURATION WARNING: Invalid ProviderRevocationMaxRetries corrected",
 			"provided_value", origRetries,
 			"corrected_to", config.ProviderRevocationMaxRetries,
-			"reason", "retries cannot be negative")
+			logKeyReason, "retries cannot be negative")
 		hasInvalidValues = true
 	}
 
@@ -172,7 +172,7 @@ func validateProviderRevocationConfig(config *Config, logger *slog.Logger) {
 		logger.Warn("CONFIGURATION WARNING: Invalid ProviderRevocationFailureThreshold corrected",
 			"provided_value", origThreshold,
 			"corrected_to", config.ProviderRevocationFailureThreshold,
-			"reason", "threshold must be between 0.0 and 1.0")
+			logKeyReason, "threshold must be between 0.0 and 1.0")
 		hasInvalidValues = true
 	}
 
@@ -285,8 +285,8 @@ func validateScopesForPath(path string, scopes []string, logger *slog.Logger) {
 		if err := validateScopeFormat(scope); err != nil {
 			logger.Warn("Invalid scope format in EndpointScopeRequirements",
 				"path", path,
-				"scope", scope,
-				"error", err,
+				paramScope, scope,
+				logKeyError, err,
 				"rfc", "RFC 6749 Section 3.3")
 		}
 	}
@@ -324,8 +324,8 @@ func validateScopesForPathMethod(path, method string, scopes []string, logger *s
 			logger.Warn("Invalid scope format in EndpointMethodScopeRequirements",
 				"path", path,
 				"method", method,
-				"scope", scope,
-				"error", err,
+				paramScope, scope,
+				logKeyError, err,
 				"rfc", "RFC 6749 Section 3.3")
 		}
 	}
@@ -386,7 +386,7 @@ func validateResourceMetadataByPath(config *Config, logger *slog.Logger) {
 // validateResourceMetadataPathConfig validates a single resource metadata path configuration.
 func validateResourceMetadataPathConfig(pathKey string, pathConfig ProtectedResourceConfig, logger *slog.Logger) {
 	if err := helpers.ValidateMetadataPath(pathKey); err != nil {
-		logger.Warn("Invalid path in ResourceMetadataByPath", "path", pathKey, "error", err)
+		logger.Warn("Invalid path in ResourceMetadataByPath", "path", pathKey, logKeyError, err)
 	}
 
 	validatePathScopes(pathKey, pathConfig.ScopesSupported, logger)
@@ -398,7 +398,7 @@ func validateResourceMetadataPathConfig(pathKey string, pathConfig ProtectedReso
 func validatePathScopes(pathKey string, scopes []string, logger *slog.Logger) {
 	for _, scope := range scopes {
 		if err := validateScopeFormat(scope); err != nil {
-			logger.Warn("Invalid scope format", "path", pathKey, "scope", scope, "error", err)
+			logger.Warn("Invalid scope format", "path", pathKey, paramScope, scope, logKeyError, err)
 		}
 	}
 }
@@ -486,7 +486,7 @@ func validateAudience(audience string, index int, seen map[string]bool, logger *
 
 	if seen[audience] {
 		logger.Warn("Duplicate audience in TrustedAudiences - removing",
-			"audience", audience, "index", index)
+			paramAudience, audience, "index", index)
 		return "", false
 	}
 
@@ -507,7 +507,7 @@ func isValidAudienceFormat(audience string, index int, logger *slog.Logger) bool
 	u, err := url.Parse(audience)
 	if err != nil || u.Host == "" {
 		logger.Warn("Invalid URL format in TrustedAudiences",
-			"audience", audience, "index", index, "error", err)
+			paramAudience, audience, "index", index, logKeyError, err)
 		return false
 	}
 	return true
@@ -582,7 +582,7 @@ func validateMaxRequestBodySizeConfig(config *Config, logger *slog.Logger) {
 		logger.Warn("CONFIGURATION WARNING: Invalid MaxRequestBodySize corrected",
 			"provided_value", config.MaxRequestBodySize,
 			"corrected_to", 1<<20,
-			"reason", "negative value would reject all requests")
+			logKeyReason, "negative value would reject all requests")
 		config.MaxRequestBodySize = 1 << 20
 	}
 }

--- a/server/config_validation_security.go
+++ b/server/config_validation_security.go
@@ -155,7 +155,7 @@ func validateChallengeScopeCharacters(scopes []string, logger *slog.Logger) {
 		if strings.Contains(scope, `"`) {
 			logger.Warn("CONFIGURATION WARNING: Invalid character in DefaultChallengeScopes",
 				"index", i,
-				"scope", scope,
+				paramScope, scope,
 				"invalid_char", `"`,
 				"risk", "Scope contains double-quote character",
 				"recommendation", "Use alphanumeric characters, hyphens, underscores, colons, and slashes only")
@@ -163,7 +163,7 @@ func validateChallengeScopeCharacters(scopes []string, logger *slog.Logger) {
 		if strings.Contains(scope, ",") {
 			logger.Warn("CONFIGURATION WARNING: Invalid character in DefaultChallengeScopes",
 				"index", i,
-				"scope", scope,
+				paramScope, scope,
 				"invalid_char", ",",
 				"risk", "Scope contains comma character",
 				"recommendation", "Use alphanumeric characters, hyphens, underscores, colons, and slashes only")
@@ -171,7 +171,7 @@ func validateChallengeScopeCharacters(scopes []string, logger *slog.Logger) {
 		if strings.Contains(scope, `\`) {
 			logger.Warn("CONFIGURATION WARNING: Invalid character in DefaultChallengeScopes",
 				"index", i,
-				"scope", scope,
+				paramScope, scope,
 				"invalid_char", `\`,
 				"risk", "Scope contains backslash character",
 				"recommendation", "Use alphanumeric characters, hyphens, underscores, colons, and slashes only")

--- a/server/constants.go
+++ b/server/constants.go
@@ -1,0 +1,47 @@
+package server
+
+// Structured-logging and audit-detail keys used across the server package.
+const (
+	logKeyReason           = "reason"
+	logKeyError            = "error"
+	logKeySeverity         = "severity"
+	logKeyAction           = "action"
+	logKeyOAuthSpec        = "oauth_spec"
+	logKeyValidationMethod = "validation_method"
+	logKeySessionID        = "session_id"
+	logKeyProvider         = "provider"
+	logKeyFamilyID         = "family_id"
+	logKeyExchange         = "exchange"
+)
+
+// Audit severity levels attached to security events.
+const (
+	severityHigh     = "high"
+	severityCritical = "critical"
+)
+
+// exchangeBrokered marks audit events emitted by the brokered token-exchange
+// path (details key "exchange").
+const exchangeBrokered = "brokered"
+
+// OAuth protocol parameters, JWT/OIDC claims, and token introspection fields
+// (RFC 6749, RFC 7519, RFC 7662).
+const (
+	paramGrantType = "grant_type"
+	paramClientID  = "client_id"
+	paramScope     = "scope"
+	paramAudience  = "audience"
+
+	claimSub   = "sub"
+	claimIss   = "iss"
+	claimJTI   = "jti"
+	claimEmail = "email"
+
+	fieldActive     = "active"
+	fieldTokenType  = "token_type"
+	tokenTypeBearer = "Bearer"
+)
+
+// oauthSpecSection412 cites the OAuth 2.1 section that mandates revoking all
+// tokens derived from a reused authorization code; attached to audit events.
+const oauthSpecSection412 = "OAuth 2.1 Section 4.1.2"

--- a/server/introspect.go
+++ b/server/introspect.go
@@ -52,7 +52,7 @@ func (s *Server) IntrospectToken(ctx context.Context, accessToken, requestingCli
 // the requester is not authorized to introspect or that fails validation.
 // Constructed fresh per call so a caller mutating it cannot affect another.
 func inactiveIntrospectionResponse() map[string]any {
-	return map[string]any{"active": false}
+	return map[string]any{fieldActive: false}
 }
 
 // introspectSelfIssuedJWT projects the verified claim set into the RFC 7662
@@ -77,7 +77,7 @@ func (s *Server) introspectSelfIssuedJWT(ctx context.Context, accessToken, reque
 		return inactiveIntrospectionResponse()
 	}
 
-	verifiedBoundClient, _ := claims["client_id"].(string)
+	verifiedBoundClient, _ := claims[paramClientID].(string)
 	if verifiedBoundClient != unverifiedBoundClient &&
 		!s.introspectionRequesterAllowed(ctx, requestingClient, verifiedBoundClient) {
 		return inactiveIntrospectionResponse()
@@ -97,7 +97,7 @@ func unverifiedClientIDClaim(accessToken string) string {
 	if err != nil {
 		return ""
 	}
-	v, _ := claims["client_id"].(string)
+	v, _ := claims[paramClientID].(string)
 	return v
 }
 
@@ -106,25 +106,25 @@ func unverifiedClientIDClaim(accessToken string) string {
 // verbatim so that application-defined claims (e.g. allowed_backends, muster_sid)
 // added to the JWT body reach the introspection caller without server changes.
 var jwtStandardClaims = map[string]struct{}{
-	"active": {}, "token_type": {}, "client_id": {},
-	"sub": {}, "iss": {}, "aud": {}, "scope": {},
-	"email": {}, "email_verified": {}, "name": {},
-	"exp": {}, "iat": {}, "nbf": {}, "jti": {},
+	fieldActive: {}, fieldTokenType: {}, paramClientID: {},
+	claimSub: {}, claimIss: {}, "aud": {}, paramScope: {},
+	claimEmail: {}, "email_verified": {}, "name": {},
+	"exp": {}, "iat": {}, "nbf": {}, claimJTI: {},
 	"cnf": {}, "at_hash": {}, "nonce": {},
 }
 
 func introspectionResponseFromJWTClaims(claims map[string]any, tokenBoundClient string) map[string]any {
 	response := map[string]any{
-		"active":     true,
-		"token_type": "Bearer",
+		fieldActive:    true,
+		fieldTokenType: tokenTypeBearer,
 	}
 	if tokenBoundClient != "" {
-		response["client_id"] = tokenBoundClient
+		response[paramClientID] = tokenBoundClient
 	}
-	copyClaimString(response, claims, "sub")
-	copyClaimString(response, claims, "iss")
-	copyClaimString(response, claims, "scope")
-	copyClaimString(response, claims, "email")
+	copyClaimString(response, claims, claimSub)
+	copyClaimString(response, claims, claimIss)
+	copyClaimString(response, claims, paramScope)
+	copyClaimString(response, claims, claimEmail)
 	copyClaimString(response, claims, "name")
 	copyClaimBool(response, claims, "email_verified")
 	copyClaimUnixTime(response, claims, "exp")
@@ -191,21 +191,21 @@ func (s *Server) introspectOpaqueToken(ctx context.Context, accessToken, request
 
 func (s *Server) introspectionResponseFromOpaqueToken(_ context.Context, _ string, tokenMetadata *storage.TokenMetadata, userInfo *providers.UserInfo) map[string]any {
 	response := map[string]any{
-		"active":     true,
-		"token_type": "Bearer",
-		"client_id":  tokenMetadata.ClientID,
-		"sub":        userInfo.ID,
-		"iss":        s.Config.Issuer,
+		fieldActive:    true,
+		fieldTokenType: tokenTypeBearer,
+		paramClientID:  tokenMetadata.ClientID,
+		claimSub:       userInfo.ID,
+		claimIss:       s.Config.Issuer,
 	}
 	if userInfo.Email != "" {
-		response["email"] = userInfo.Email
+		response[claimEmail] = userInfo.Email
 		response["email_verified"] = userInfo.EmailVerified
 	}
 	if userInfo.Name != "" {
 		response["name"] = userInfo.Name
 	}
 	if scope := helpers.JoinScopes(tokenMetadata.Scopes); scope != "" {
-		response["scope"] = scope
+		response[paramScope] = scope
 	}
 	if tokenMetadata.Audience != "" {
 		response["aud"] = tokenMetadata.Audience
@@ -250,8 +250,8 @@ func (s *Server) logIntrospectionRequesterDenied(ctx context.Context, requesting
 		Type:     security.EventIntrospectionRequesterDenied,
 		ClientID: requestingClient,
 		Details: map[string]any{
-			"severity":           "medium",
-			"reason":             reason,
+			logKeySeverity:       "medium",
+			logKeyReason:         reason,
 			"token_bound_client": tokenBoundClient,
 		},
 	})

--- a/server/jwt.go
+++ b/server/jwt.go
@@ -41,7 +41,7 @@ func (s *Server) looksLikeSelfIssuedJWT(tokenString string) bool {
 	if err != nil {
 		return false
 	}
-	iss, _ := claims["iss"].(string)
+	iss, _ := claims[claimIss].(string)
 	return iss != "" && iss == s.Config.Issuer
 }
 
@@ -88,7 +88,7 @@ func (s *Server) validateSelfIssuedJWT(ctx context.Context, tokenString string) 
 	if err := s.checkJWTAudience(ctx, claims, tokenString); err != nil {
 		return nil, nil, err
 	}
-	jti, _ := claims["jti"].(string)
+	jti, _ := claims[claimJTI].(string)
 	if err := s.checkJWTRevocation(ctx, jti, tokenString); err != nil {
 		return nil, nil, err
 	}
@@ -144,7 +144,7 @@ func (s *Server) checkJWTHeaderAndIssuer(header jose.Header, claims map[string]a
 	if typ != rfc9068TokenType {
 		return fmt.Errorf("%w: typ header is %q (expected %q)", errBearerNotSelfIssuedJWT, typ, rfc9068TokenType)
 	}
-	iss, _ := claims["iss"].(string)
+	iss, _ := claims[claimIss].(string)
 	if iss != s.Config.Issuer {
 		return fmt.Errorf("%w: iss claim is %q (expected %q)", errBearerNotSelfIssuedJWT, iss, s.Config.Issuer)
 	}
@@ -195,7 +195,7 @@ func (s *Server) checkJWTRevocation(ctx context.Context, jti, tokenString string
 	revoked, err := s.revokedTokenStore.IsJTIRevoked(ctx, jti)
 	if err != nil {
 		s.Logger.Warn("Failed to check JWT revocation list",
-			"error", err,
+			logKeyError, err,
 			"token_suffix", helpers.TokenSuffix(tokenString, 8))
 		return fmt.Errorf("revocation check failed: %w", err)
 	}
@@ -223,7 +223,7 @@ func (s *Server) checkJWTRevocation(ctx context.Context, jti, tokenString string
 // re-enable a revoked family. ErrRefreshTokenFamilyNotFound is the only
 // "not present" signal and is treated as legit absence.
 func (s *Server) checkJWTFamily(ctx context.Context, claims map[string]any, tokenString string) error {
-	familyID, _ := claims["family_id"].(string)
+	familyID, _ := claims[logKeyFamilyID].(string)
 	if familyID == "" {
 		return nil
 	}
@@ -237,8 +237,8 @@ func (s *Server) checkJWTFamily(ctx context.Context, claims map[string]any, toke
 	}
 	if err != nil {
 		s.Logger.Warn("Failed to check JWT family revocation",
-			"error", err,
-			"family_id", familyID,
+			logKeyError, err,
+			logKeyFamilyID, familyID,
 			"token_suffix", helpers.TokenSuffix(tokenString, 8))
 		return fmt.Errorf("family revocation check failed: %w", err)
 	}
@@ -282,10 +282,10 @@ func userInfoFromJWTClaims(claims map[string]any) *providers.UserInfo {
 	info := &providers.UserInfo{
 		TokenSource: providers.TokenSourceJWT,
 	}
-	if v, ok := claims["sub"].(string); ok {
+	if v, ok := claims[claimSub].(string); ok {
 		info.ID = v
 	}
-	if v, ok := claims["email"].(string); ok {
+	if v, ok := claims[claimEmail].(string); ok {
 		info.Email = v
 	}
 	if v, ok := claims["email_verified"].(bool); ok {
@@ -314,15 +314,15 @@ func userInfoFromJWTClaims(claims map[string]any) *providers.UserInfo {
 func (s *Server) logSelfIssuedJWTAccepted(ctx context.Context, tokenString string, userInfo *providers.UserInfo, jti string) {
 	s.Logger.Debug("Self-issued JWT access token validated",
 		"user_id", userInfo.ID,
-		"jti", jti,
+		claimJTI, jti,
 		"token_suffix", helpers.TokenSuffix(tokenString, 8))
 
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type:   security.EventSelfIssuedJWTAccepted,
 		UserID: userInfo.ID,
 		Details: map[string]any{
-			"validation_method": "self_issued_jwt",
-			"jti":               jti,
+			logKeyValidationMethod: "self_issued_jwt",
+			claimJTI:               jti,
 		},
 	})
 }
@@ -351,11 +351,11 @@ func (s *Server) revokeSelfIssuedJWT(ctx context.Context, tokenString, clientID,
 		// Bearer was peeked as self-issued but failed verification —
 		// suspicious (forged or expired). Treat as success per RFC 7009.
 		s.Logger.Debug("Self-issued JWT revocation: signature/parse failed",
-			"error", err,
+			logKeyError, err,
 			"token_suffix", helpers.TokenSuffix(tokenString, 8))
 		return true
 	}
-	jti, _ := claims["jti"].(string)
+	jti, _ := claims[claimJTI].(string)
 	expVal, _ := claims["exp"].(float64)
 	if jti == "" || expVal == 0 {
 		s.Logger.Debug("Self-issued JWT missing jti or exp during revocation",
@@ -366,26 +366,26 @@ func (s *Server) revokeSelfIssuedJWT(ctx context.Context, tokenString, clientID,
 
 	if err := s.revokedTokenStore.RevokeJTI(ctx, jti, expiresAt); err != nil {
 		s.Logger.Warn("Failed to write revoked JWT jti to denylist",
-			"error", err,
-			"jti", jti,
+			logKeyError, err,
+			claimJTI, jti,
 			"token_suffix", helpers.TokenSuffix(tokenString, 8))
 		return true
 	}
 
-	userID, _ := claims["sub"].(string)
+	userID, _ := claims[claimSub].(string)
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type:     security.EventSelfIssuedJWTRevoked,
 		UserID:   userID,
 		ClientID: clientID,
 		Details: map[string]any{
-			"jti":        jti,
+			claimJTI:     jti,
 			"expires_at": expiresAt.Unix(),
 			"ip":         clientIP,
 		},
 	})
 	s.Logger.Debug("Self-issued JWT access token revoked",
-		"jti", jti,
-		"client_id", clientID,
+		claimJTI, jti,
+		paramClientID, clientID,
 		"ip", clientIP,
 		"expires_at", expiresAt)
 	return true
@@ -396,7 +396,7 @@ func (s *Server) revokeSelfIssuedJWT(ctx context.Context, tokenString, clientID,
 // token_revoked, family_revoked, missing_aud) so dashboards can pivot on it.
 func (s *Server) logSelfIssuedJWTAuthFailure(ctx context.Context, reason, tokenString string) {
 	s.Logger.Debug("Self-issued JWT access token rejected",
-		"reason", reason,
+		logKeyReason, reason,
 		"token_suffix", helpers.TokenSuffix(tokenString, 8))
 	s.Auditor.LogAuthFailure(ctx, "", "", "", reason)
 }

--- a/server/options.go
+++ b/server/options.go
@@ -137,7 +137,7 @@ func WithTrustedIssuers(issuers []TrustedIssuer) Option {
 		}
 		v, err := NewOIDCValidator(issuers)
 		if err != nil {
-			s.Logger.Error("failed to initialise trusted issuer validator", "error", err)
+			s.Logger.Error("failed to initialise trusted issuer validator", logKeyError, err)
 			return
 		}
 		if s.subjectValidators == nil {

--- a/server/provider_refresh.go
+++ b/server/provider_refresh.go
@@ -235,7 +235,7 @@ func (s *Server) coordinateProviderRefresh(ctx context.Context, upts storage.Use
 func (s *Server) refreshSharedProviderTokenLocked(ctx context.Context, upts storage.UserProviderTokenStore, locker storage.ProviderRefreshLockStore, userID, lockValue string, observed *oauth2.Token) (*oauth2.Token, error) {
 	defer func() {
 		if err := locker.ReleaseProviderRefreshLock(context.WithoutCancel(ctx), userID, lockValue); err != nil {
-			s.Logger.Warn("Failed to release provider refresh lock", "user_id", userID, "error", err)
+			s.Logger.Warn("Failed to release provider refresh lock", "user_id", userID, logKeyError, err)
 		}
 	}()
 	return s.refreshSharedProviderToken(ctx, upts, userID, observed)

--- a/server/redirect_uri_security.go
+++ b/server/redirect_uri_security.go
@@ -286,8 +286,8 @@ func (s *Server) validateHostnameWithDNS(ctx context.Context, hostname, rawURI s
 			// Strict mode: fail-closed - block registration on DNS failure
 			s.Logger.Warn("DNS resolution failed during redirect URI validation (strict mode - blocking)",
 				"hostname", hostname,
-				"error", err,
-				"action", "blocking_registration",
+				logKeyError, err,
+				logKeyAction, "blocking_registration",
 				"mode", "strict")
 			return newRedirectURISecurityError(
 				RedirectURIErrorCategoryDNSFailure,
@@ -300,8 +300,8 @@ func (s *Server) validateHostnameWithDNS(ctx context.Context, hostname, rawURI s
 		// This prevents false positives for legitimate hostnames with temporary DNS issues
 		s.Logger.Warn("DNS resolution failed during redirect URI validation (allowing registration)",
 			"hostname", hostname,
-			"error", err,
-			"action", "allowing_registration",
+			logKeyError, err,
+			logKeyAction, "allowing_registration",
 			"mode", "permissive",
 			"recommendation", "Enable DNSValidationStrict=true for fail-closed behavior")
 		return nil

--- a/server/redirect_uri_security_test.go
+++ b/server/redirect_uri_security_test.go
@@ -2,8 +2,10 @@ package server
 
 import (
 	"context"
+	"encoding/binary"
 	"io"
 	"log/slog"
+	"math"
 	"net"
 	"net/url"
 	"os"
@@ -820,12 +822,12 @@ func (d *testDNSDialer) serveConn(conn net.Conn) {
 		return
 	}
 	resp := d.buildResponse(buf)
-	if len(resp) == 0 {
+	respLen := len(resp)
+	if respLen == 0 || respLen > math.MaxUint16 {
 		return
 	}
-	out := make([]byte, 2+len(resp))
-	out[0] = byte(len(resp) >> 8)
-	out[1] = byte(len(resp))
+	out := make([]byte, 2+respLen)
+	binary.BigEndian.PutUint16(out[:2], uint16(respLen))
 	copy(out[2:], resp)
 	_, _ = conn.Write(out)
 }

--- a/server/refresh.go
+++ b/server/refresh.go
@@ -29,10 +29,10 @@ func (s *Server) handleRefreshTokenReuseDetection(ctx context.Context, refreshTo
 		// Attempted use of token from previously revoked family
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventRevokedTokenFamilyReuseAttempt, UserID: family.UserID, ClientID: clientID,
-			Details: map[string]any{"severity": "critical", "family_id": family.FamilyID},
+			Details: map[string]any{logKeySeverity: severityCritical, logKeyFamilyID: family.FamilyID},
 		})
 		s.Logger.Error("Attempted use of revoked token family",
-			"user_id", family.UserID, "family_id", helpers.SafeTruncate(family.FamilyID, 8))
+			"user_id", family.UserID, logKeyFamilyID, helpers.SafeTruncate(family.FamilyID, 8))
 		return errInvalidGrant
 	}
 
@@ -41,24 +41,24 @@ func (s *Server) handleRefreshTokenReuseDetection(ctx context.Context, refreshTo
 
 	if s.SecurityEventRateLimiter == nil || s.SecurityEventRateLimiter.Allow(family.UserID+":"+clientID) {
 		s.Logger.Error("Refresh token reuse detected - token was rotated but still being used",
-			"user_id", family.UserID, "client_id", clientID, "family_id", helpers.SafeTruncate(family.FamilyID, 8))
+			"user_id", family.UserID, paramClientID, clientID, logKeyFamilyID, helpers.SafeTruncate(family.FamilyID, 8))
 	}
 
 	// Revoke entire token family
 	if err := familyStore.RevokeRefreshTokenFamily(ctx, family.FamilyID); err != nil {
-		s.Logger.Error("Failed to revoke token family", "error", err)
+		s.Logger.Error("Failed to revoke token family", logKeyError, err)
 	}
 
 	// Revoke all tokens for this user+client
 	if err := s.RevokeAllTokensForUserClient(ctx, family.UserID, family.ClientID); err != nil {
-		s.Logger.Error("Failed to revoke user tokens", "error", err)
+		s.Logger.Error("Failed to revoke user tokens", logKeyError, err)
 	}
 
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type: security.EventRefreshTokenReuseDetected, UserID: family.UserID, ClientID: clientID,
 		Details: map[string]any{
-			"severity": "critical", "family_id": family.FamilyID, "generation": family.Generation,
-			"action": "family_and_tokens_revoked",
+			logKeySeverity: severityCritical, logKeyFamilyID: family.FamilyID, "generation": family.Generation,
+			logKeyAction: "family_and_tokens_revoked",
 		},
 	})
 	s.Auditor.LogTokenReuse(ctx, family.UserID, clientID)
@@ -97,20 +97,20 @@ func (s *Server) handleRefreshTokenReuseDetection(ctx context.Context, refreshTo
 func (s *Server) handleSharedProviderTokenError(ctx context.Context, err error, refreshToken, userID, clientID string) error {
 	if !storage.IsNotFoundError(err) && !storage.IsExpiredError(err) {
 		s.Logger.Warn("Transient error reading shared provider token during refresh",
-			"error", err.Error(), "user_id", userID, "client_id", clientID,
+			logKeyError, err.Error(), "user_id", userID, paramClientID, clientID,
 			"token_suffix", helpers.TokenSuffix(refreshToken, 8))
 		return fmt.Errorf("read shared provider token: %w", err)
 	}
 
 	s.Logger.Warn("Shared provider token missing for valid refresh token - re-login required",
-		"user_id", userID, "client_id", clientID, "reason", err.Error(),
+		"user_id", userID, paramClientID, clientID, logKeyReason, err.Error(),
 		"token_suffix", helpers.TokenSuffix(refreshToken, 8))
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type: security.EventAuthFailure, UserID: userID, ClientID: clientID,
 		Details: map[string]any{
-			"severity": "warning",
-			"reason":   "shared_provider_token_missing",
-			"action":   "re_login_required",
+			logKeySeverity: "warning",
+			logKeyReason:   "shared_provider_token_missing",
+			logKeyAction:   "re_login_required",
 		},
 	})
 	s.Auditor.LogAuthFailure(ctx, userID, clientID, "", "shared_provider_token_missing")
@@ -143,17 +143,17 @@ func (s *Server) handleRefreshTokenError(ctx context.Context, err error, refresh
 	// the shared-entry and metadata reads on this path).
 	if !isNotFoundOrExpired {
 		s.Logger.Warn("Transient error during refresh token validation",
-			"error", err.Error(), "client_id", clientID, "token_suffix", helpers.TokenSuffix(refreshToken, 8))
+			logKeyError, err.Error(), paramClientID, clientID, "token_suffix", helpers.TokenSuffix(refreshToken, 8))
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventAuthFailure, ClientID: clientID,
-			Details: map[string]any{"reason": "transient_storage_error"},
+			Details: map[string]any{logKeyReason: "transient_storage_error"},
 		})
 		return fmt.Errorf("validate refresh token: %w", err)
 	}
 
 	// Regular invalid token error
 	s.Logger.Debug("Refresh token validation failed",
-		"reason", err.Error(), "client_id", clientID, "token_suffix", helpers.TokenSuffix(refreshToken, 8))
+		logKeyReason, err.Error(), paramClientID, clientID, "token_suffix", helpers.TokenSuffix(refreshToken, 8))
 	s.Auditor.LogAuthFailure(ctx, "", clientID, "", "invalid_refresh_token")
 	return errInvalidGrant
 }
@@ -197,11 +197,11 @@ func (s *Server) rotateRefreshToken(ctx context.Context, oldRefreshToken, userID
 	refreshTokenExpiry := s.refreshTokenExpiry(time.Now())
 	if supportsFamilies && familyID != "" {
 		if err := familyStore.SaveRefreshTokenWithFamily(ctx, newRefreshToken, userID, clientID, familyID, generation, refreshTokenExpiry); err != nil {
-			s.Logger.Warn("Failed to save refresh token with family", "error", err)
+			s.Logger.Warn("Failed to save refresh token with family", logKeyError, err)
 		}
 	} else {
 		if err := s.tokenStore.SaveRefreshToken(ctx, newRefreshToken, userID, refreshTokenExpiry); err != nil {
-			s.Logger.Warn("Failed to track new refresh token", "error", err)
+			s.Logger.Warn("Failed to track new refresh token", logKeyError, err)
 		}
 	}
 
@@ -263,18 +263,18 @@ func (s *Server) refreshProviderTokenForGrant(ctx context.Context, userID string
 func (s *Server) storeRefreshedProviderToken(ctx context.Context, userID, newAccessToken, newRefreshToken string, newProviderToken *oauth2.Token, refreshExpiry time.Time) {
 	if upts, unified := s.userProviderTokenStore(); unified {
 		if err := upts.SaveProviderTokenRef(ctx, newAccessToken, userID, refreshExpiry); err != nil {
-			s.Logger.Warn("Failed to save access token provider reference", "error", err)
+			s.Logger.Warn("Failed to save access token provider reference", logKeyError, err)
 		}
 		if err := upts.SaveProviderTokenRef(ctx, newRefreshToken, userID, refreshExpiry); err != nil {
-			s.Logger.Warn("Failed to save refresh token provider reference", "error", err)
+			s.Logger.Warn("Failed to save refresh token provider reference", logKeyError, err)
 		}
 		return
 	}
 	if err := s.tokenStore.SaveToken(ctx, newAccessToken, newProviderToken); err != nil {
-		s.Logger.Warn("Failed to save new access token", "error", err)
+		s.Logger.Warn("Failed to save new access token", logKeyError, err)
 	}
 	if err := s.tokenStore.SaveToken(ctx, newRefreshToken, newProviderToken); err != nil {
-		s.Logger.Warn("Failed to save new refresh token", "error", err)
+		s.Logger.Warn("Failed to save new refresh token", logKeyError, err)
 	}
 }
 
@@ -379,7 +379,7 @@ func (s *Server) RefreshAccessToken(ctx context.Context, refreshToken, clientID 
 			// atomically inside the consume, which failed transiently as a
 			// whole.
 			s.Logger.Warn("Transient error reading refresh token metadata",
-				"error", metaErr.Error(), "client_id", clientID,
+				logKeyError, metaErr.Error(), paramClientID, clientID,
 				"token_suffix", helpers.TokenSuffix(refreshToken, 8))
 			return nil, fmt.Errorf("read refresh token metadata: %w", metaErr)
 		}
@@ -450,7 +450,7 @@ func (s *Server) RefreshAccessToken(ctx context.Context, refreshToken, clientID 
 		AccessToken:  newAccessToken,
 		RefreshToken: newRefreshToken,
 		Expiry:       expiry,
-		TokenType:    "Bearer",
+		TokenType:    tokenTypeBearer,
 	}
 
 	// Per OpenID Connect Core 1.0 §12.2, the refreshed id_token (when present) is
@@ -498,17 +498,17 @@ func (s *Server) handleLegacyRefreshToken(ctx context.Context, requestingClientI
 	s.Logger.Warn("Refresh token rejected - missing client binding",
 		"user_id", userID,
 		"requesting_client_id", requestingClientID,
-		"reason", "OAuth 2.1 Section 6 requires client binding")
+		logKeyReason, "OAuth 2.1 Section 6 requires client binding")
 
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type:     security.EventRefreshTokenMissingClientBinding,
 		UserID:   userID,
 		ClientID: requestingClientID,
 		Details: map[string]any{
-			"severity":      "high",
-			"action":        "rejected",
+			logKeySeverity:  severityHigh,
+			logKeyAction:    "rejected",
 			"security_risk": "cross_client_token_theft_prevented",
-			"oauth_spec":    "OAuth 2.1 Section 6",
+			logKeyOAuthSpec: "OAuth 2.1 Section 6",
 		},
 	})
 	s.Auditor.LogAuthFailure(ctx, userID, requestingClientID, "", "refresh_token_missing_client_binding")
@@ -543,7 +543,7 @@ func (s *Server) validateRefreshTokenClientBinding(ctx context.Context, storedCl
 				"stored_client_id", storedClientID,
 				"requesting_client_id", requestingClientID,
 				"security_event", "cross_client_token_theft_attempt",
-				"oauth_spec", "OAuth 2.1 Section 6")
+				logKeyOAuthSpec, "OAuth 2.1 Section 6")
 		}
 
 		s.Auditor.LogEvent(ctx, security.Event{
@@ -551,11 +551,11 @@ func (s *Server) validateRefreshTokenClientBinding(ctx context.Context, storedCl
 			UserID:   userID,
 			ClientID: requestingClientID,
 			Details: map[string]any{
-				"severity":             "critical",
+				logKeySeverity:         severityCritical,
 				"stored_client_id":     storedClientID,
 				"requesting_client_id": requestingClientID,
 				"attack_indicator":     "cross_client_token_theft_attempt",
-				"oauth_spec":           "OAuth 2.1 Section 6",
+				logKeyOAuthSpec:        "OAuth 2.1 Section 6",
 			},
 		})
 		s.Auditor.LogAuthFailure(ctx, userID, requestingClientID, "", "refresh_token_client_binding_mismatch")
@@ -566,7 +566,7 @@ func (s *Server) validateRefreshTokenClientBinding(ctx context.Context, storedCl
 
 	s.Logger.Debug("Refresh token client binding validated",
 		"user_id", userID,
-		"client_id", storedClientID)
+		paramClientID, storedClientID)
 
 	return nil
 }

--- a/server/revoke.go
+++ b/server/revoke.go
@@ -63,7 +63,7 @@ func (s *Server) RevokeToken(ctx context.Context, token, clientID, clientIP stri
 	// — are what the refresh grant gates on.
 	if providerToken, err := s.resolveProviderToken(ctx, token); err == nil && providerToken.AccessToken != "" {
 		if err := s.provider.RevokeToken(ctx, providerToken.AccessToken); err != nil {
-			s.Logger.Warn("Failed to revoke token at provider", "error", err)
+			s.Logger.Warn("Failed to revoke token at provider", logKeyError, err)
 			// Continue with local deletion even if provider revocation fails
 		}
 	}
@@ -83,13 +83,13 @@ func (s *Server) RevokeToken(ctx context.Context, token, clientID, clientIP stri
 	// and only this one was deleted).
 	if upts, unified := s.userProviderTokenStore(); unified {
 		if err := upts.DeleteProviderTokenRef(ctx, token); err != nil {
-			s.Logger.Warn("Failed to delete provider token reference", "error", err)
+			s.Logger.Warn("Failed to delete provider token reference", logKeyError, err)
 		}
 		if err := s.tokenStore.DeleteRefreshToken(ctx, token); err != nil {
-			s.Logger.Warn("Failed to delete refresh token record", "error", err)
+			s.Logger.Warn("Failed to delete refresh token record", logKeyError, err)
 		}
 	} else if err := s.tokenStore.DeleteToken(ctx, token); err != nil {
-		s.Logger.Warn("Failed to delete token locally", "error", err)
+		s.Logger.Warn("Failed to delete token locally", logKeyError, err)
 	}
 	s.unregisterTokenPairIfPresent(token)
 
@@ -101,7 +101,7 @@ func (s *Server) RevokeToken(ctx context.Context, token, clientID, clientIP stri
 		// for invalid TOKENS, not for storage outages (the HTTP handler owns
 		// the transport response and logs this error).
 		s.Logger.Error("Failed to look up refresh token family during revocation",
-			"client_id", clientID, "ip", clientIP, "error", famErr)
+			paramClientID, clientID, "ip", clientIP, logKeyError, famErr)
 		return fmt.Errorf("token revocation incomplete: refresh token family lookup failed: %w", famErr)
 	}
 
@@ -109,7 +109,7 @@ func (s *Server) RevokeToken(ctx context.Context, token, clientID, clientIP stri
 
 	s.Auditor.LogTokenRevoked(ctx, "", clientID, clientIP, "access_or_refresh")
 
-	s.Logger.Debug("Token revoked", "client_id", clientID, "ip", clientIP)
+	s.Logger.Debug("Token revoked", paramClientID, clientID, "ip", clientIP)
 	return nil
 }
 
@@ -142,11 +142,11 @@ func (s *Server) revokeTokenFamilyIfNeeded(ctx context.Context, family *storage.
 		return
 	}
 	if err := familyStore.RevokeRefreshTokenFamily(ctx, family.FamilyID); err != nil {
-		s.Logger.Warn("Failed to revoke refresh token family", "family_id", family.FamilyID, "error", err)
+		s.Logger.Warn("Failed to revoke refresh token family", logKeyFamilyID, family.FamilyID, logKeyError, err)
 		return
 	}
 	s.Logger.Debug("Revoked refresh token family on explicit revocation",
-		"family_id", family.FamilyID, "client_id", clientID, "ip", clientIP)
+		logKeyFamilyID, family.FamilyID, paramClientID, clientID, "ip", clientIP)
 
 	if s.sessionRevocationHandler != nil {
 		s.sessionRevocationHandler(ctx, family.UserID, family.FamilyID)
@@ -157,9 +157,9 @@ func (s *Server) revokeTokenFamilyIfNeeded(ctx context.Context, family *storage.
 		UserID:   family.UserID,
 		ClientID: clientID,
 		Details: map[string]any{
-			"family_id": family.FamilyID,
-			"reason":    "explicit_revocation",
-			"ip":        clientIP,
+			logKeyFamilyID: family.FamilyID,
+			logKeyReason:   "explicit_revocation",
+			"ip":           clientIP,
 		},
 	})
 }
@@ -185,11 +185,11 @@ func (s *Server) revokeTokenFamilyIfNeeded(ctx context.Context, family *storage.
 // handleRevocationNotSupported handles the case when storage doesn't support revocation
 func (s *Server) handleRevocationNotSupported(ctx context.Context, userID, clientID string) error {
 	s.Logger.Error("CRITICAL: Token storage does not support TokenRevocationStore - OAuth 2.1 NOT compliant",
-		"user_id", userID, "client_id", clientID)
+		"user_id", userID, paramClientID, clientID)
 
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type: security.EventTokenRevocationNotSupported, UserID: userID, ClientID: clientID,
-		Details: map[string]any{"severity": "critical", "message": "Storage backend does not support bulk token revocation - OAuth 2.1 compliance FAILED"},
+		Details: map[string]any{logKeySeverity: severityCritical, "message": "Storage backend does not support bulk token revocation - OAuth 2.1 compliance FAILED"},
 	})
 
 	return fmt.Errorf("storage backend must implement TokenRevocationStore for OAuth 2.1 compliance")
@@ -265,7 +265,7 @@ func (s *Server) revokeTokensAtProvider(ctx context.Context, tokens []string, us
 		providerToken, err := s.resolveProviderToken(ctx, tokenID)
 		if err != nil {
 			s.Logger.Warn("Could not get provider token for revocation",
-				"token_id", helpers.SafeTruncate(tokenID, 8), "error", err)
+				"token_id", helpers.SafeTruncate(tokenID, 8), logKeyError, err)
 			continue
 		}
 
@@ -287,10 +287,10 @@ func (s *Server) revokeTokensAtProvider(ctx context.Context, tokens []string, us
 	if unified && sharedEntryDead {
 		if err := upts.DeleteUserProviderToken(ctx, userID); err != nil {
 			s.Logger.Warn("Failed to delete dead shared provider entry after upstream revocation",
-				"user_id", userID, "client_id", clientID, "error", err)
+				"user_id", userID, paramClientID, clientID, logKeyError, err)
 		} else {
 			s.Logger.Debug("Deleted dead shared provider entry after upstream refresh token revocation",
-				"user_id", userID, "client_id", clientID)
+				"user_id", userID, paramClientID, clientID)
 		}
 	}
 
@@ -301,7 +301,7 @@ func (s *Server) revokeTokensAtProvider(ctx context.Context, tokens []string, us
 func (s *Server) checkProviderRevocationFailure(ctx context.Context, userID, clientID string, totalTokens, revokedCount, failedCount int, failureRate float64) error {
 	if totalTokens > 0 && failureRate > s.Config.ProviderRevocationFailureThreshold {
 		s.Logger.Error("CRITICAL: Provider revocation failure rate exceeds threshold",
-			"user_id", userID, "client_id", clientID,
+			"user_id", userID, paramClientID, clientID,
 			"failure_rate", fmt.Sprintf("%.2f%%", failureRate*100),
 			"threshold", fmt.Sprintf("%.2f%%", s.Config.ProviderRevocationFailureThreshold*100),
 			"failed_count", failedCount, "total_count", totalTokens)
@@ -309,8 +309,8 @@ func (s *Server) checkProviderRevocationFailure(ctx context.Context, userID, cli
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventProviderRevocationThresholdExceeded, UserID: userID, ClientID: clientID,
 			Details: map[string]any{
-				"severity": "critical", "failure_rate": failureRate, "threshold": s.Config.ProviderRevocationFailureThreshold,
-				"failed_count": failedCount, "total_count": totalTokens, "oauth_spec": "OAuth 2.1 Section 4.1.2",
+				logKeySeverity: severityCritical, "failure_rate": failureRate, "threshold": s.Config.ProviderRevocationFailureThreshold,
+				"failed_count": failedCount, "total_count": totalTokens, logKeyOAuthSpec: oauthSpecSection412,
 			},
 		})
 
@@ -320,11 +320,11 @@ func (s *Server) checkProviderRevocationFailure(ctx context.Context, userID, cli
 
 	if revokedCount == 0 && totalTokens > 0 {
 		s.Logger.Error("CRITICAL: All provider revocations failed - tokens still valid at provider!",
-			"user_id", userID, "client_id", clientID, "token_count", totalTokens)
+			"user_id", userID, paramClientID, clientID, "token_count", totalTokens)
 
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventProviderRevocationCompleteFailure, UserID: userID, ClientID: clientID,
-			Details: map[string]any{"severity": "critical", "token_count": totalTokens, "oauth_spec": "OAuth 2.1 Section 4.1.2"},
+			Details: map[string]any{logKeySeverity: severityCritical, "token_count": totalTokens, logKeyOAuthSpec: oauthSpecSection412},
 		})
 
 		return fmt.Errorf("all provider revocations failed (0/%d succeeded)", totalTokens)
@@ -356,7 +356,7 @@ func (s *Server) RevokeAllTokensForUserClient(ctx context.Context, userID, clien
 	}
 
 	s.Logger.Debug("Provider revocation complete",
-		"user_id", userID, "client_id", clientID, "revoked_at_provider", revokedAtProvider,
+		"user_id", userID, paramClientID, clientID, "revoked_at_provider", revokedAtProvider,
 		"failed_at_provider", failedAtProvider, "total_tokens", totalTokensToRevoke,
 		"failure_rate", fmt.Sprintf("%.2f%%", failureRate*100))
 
@@ -369,8 +369,8 @@ func (s *Server) RevokeAllTokensForUserClient(ctx context.Context, userID, clien
 	if err != nil {
 		s.Logger.Error("Failed to revoke tokens locally",
 			"user_id", userID,
-			"client_id", clientID,
-			"error", err)
+			paramClientID, clientID,
+			logKeyError, err)
 		return fmt.Errorf("failed to revoke tokens locally: %w", err)
 	}
 
@@ -381,21 +381,21 @@ func (s *Server) RevokeAllTokensForUserClient(ctx context.Context, userID, clien
 	// Log the revocation
 	s.Logger.Warn("Revoked all tokens for user+client due to security event",
 		"user_id", userID,
-		"client_id", clientID,
+		paramClientID, clientID,
 		"tokens_revoked_locally", revokedCount,
 		"tokens_revoked_at_provider", revokedAtProvider,
-		"reason", "reuse_detection")
+		logKeyReason, "reuse_detection")
 
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type:     security.EventAllTokensRevoked,
 		UserID:   userID,
 		ClientID: clientID,
 		Details: map[string]any{
-			"severity":                "critical",
+			logKeySeverity:            severityCritical,
 			"tokens_revoked_local":    revokedCount,
 			"tokens_revoked_provider": revokedAtProvider,
-			"reason":                  "authorization_code_reuse_detected",
-			"oauth_spec":              "OAuth 2.1 Section 4.1.2",
+			logKeyReason:              "authorization_code_reuse_detected",
+			logKeyOAuthSpec:           oauthSpecSection412,
 		},
 	})
 
@@ -422,11 +422,11 @@ func (s *Server) revokeTokenWithRetry(ctx context.Context, token, tokenType, use
 			// Success - log if this wasn't the first attempt
 			if attempt > 0 {
 				s.Logger.Debug("Provider token revocation succeeded after retry",
-					"token_type", tokenType,
+					fieldTokenType, tokenType,
 					"attempt", attempt+1,
 					"max_retries", maxRetries,
 					"user_id", userID,
-					"client_id", clientID)
+					paramClientID, clientID)
 			}
 			return nil
 		}
@@ -440,11 +440,11 @@ func (s *Server) revokeTokenWithRetry(ctx context.Context, token, tokenType, use
 
 			// Don't log transient failures at high severity - only on final failure
 			s.Logger.Debug("Provider token revocation failed, retrying",
-				"token_type", tokenType,
+				fieldTokenType, tokenType,
 				"attempt", attempt+1,
 				"max_retries", maxRetries,
 				"backoff_ms", backoffDuration.Milliseconds(),
-				"error", err)
+				logKeyError, err)
 
 			// Wait before retry (check for context cancellation)
 			select {
@@ -458,10 +458,10 @@ func (s *Server) revokeTokenWithRetry(ctx context.Context, token, tokenType, use
 
 	// All attempts failed
 	s.Logger.Warn("Provider token revocation failed after all retries",
-		"token_type", tokenType,
+		fieldTokenType, tokenType,
 		"attempts", maxRetries+1,
 		"user_id", userID,
-		"client_id", clientID,
+		paramClientID, clientID,
 		"final_error", lastErr)
 
 	return fmt.Errorf("provider revocation failed after %d attempts: %w", maxRetries+1, lastErr)

--- a/server/scope.go
+++ b/server/scope.go
@@ -33,7 +33,7 @@ func (s *Server) resolveScopes(ctx context.Context, requestedScope string, clien
 			Type:     security.EventScopeDefaultsApplied,
 			ClientID: client.ClientID,
 			Details: map[string]any{
-				"provider":          s.provider.Name(),
+				logKeyProvider:      s.provider.Name(),
 				"provider_defaults": defaultScopes,
 				"resolved_scopes":   resolvedScopes,
 				"client_restricted": false,
@@ -47,7 +47,7 @@ func (s *Server) resolveScopes(ctx context.Context, requestedScope string, clien
 			Type:     security.EventScopeDefaultsApplied,
 			ClientID: client.ClientID,
 			Details: map[string]any{
-				"provider":           s.provider.Name(),
+				logKeyProvider:       s.provider.Name(),
 				"provider_defaults":  defaultScopes,
 				"client_allowed":     client.Scopes,
 				"resolved_scopes":    resolvedScopes,

--- a/server/server.go
+++ b/server/server.go
@@ -339,8 +339,8 @@ func (s *Server) validateProviderDefaultScopes(logger *slog.Logger) {
 	for _, scope := range providerDefaults {
 		if !supportedSet[scope] {
 			logger.Warn("Provider default scope not in server supported scopes - clients relying on defaults may encounter errors",
-				"scope", scope,
-				"provider", s.provider.Name(),
+				paramScope, scope,
+				logKeyProvider, s.provider.Name(),
 				"supported_scopes", s.Config.SupportedScopes)
 		}
 	}
@@ -360,7 +360,7 @@ func (s *Server) logMandatoryAudienceScopes(logger *slog.Logger, providerDefault
 	if len(audienceScopes) > 0 {
 		logger.Debug("Mandatory cross-client audience scopes configured - these will be merged into ALL authorization requests",
 			"audience_scopes", audienceScopes,
-			"provider", s.provider.Name(),
+			logKeyProvider, s.provider.Name(),
 			"count", len(audienceScopes))
 	}
 }
@@ -421,7 +421,7 @@ func (s *Server) saveTokenMetadata(ctx context.Context, tokenID string, metadata
 		return
 	}
 	if err := store.SaveTokenMetadata(ctx, tokenID, metadata); err != nil {
-		s.Logger.Warn("Failed to save token metadata", "error", err)
+		s.Logger.Warn("Failed to save token metadata", logKeyError, err)
 	}
 }
 
@@ -606,7 +606,7 @@ func (s *Server) Shutdown(ctx context.Context) error {
 			// Shutdown completed successfully
 		case <-ctx.Done():
 			shutdownErr = fmt.Errorf("shutdown cancelled: %w", ctx.Err())
-			s.Logger.Warn("Shutdown timed out or was cancelled", "error", shutdownErr)
+			s.Logger.Warn("Shutdown timed out or was cancelled", logKeyError, shutdownErr)
 		}
 	})
 
@@ -660,7 +660,7 @@ func (s *Server) stopMetadataCacheCleanup() {
 func (s *Server) shutdownInstrumentation(ctx context.Context) {
 	s.Logger.Debug("Shutting down instrumentation...")
 	if err := s.Instrumentation.Shutdown(ctx); err != nil {
-		s.Logger.Warn("Failed to shutdown instrumentation", "error", err)
+		s.Logger.Warn("Failed to shutdown instrumentation", logKeyError, err)
 	}
 }
 

--- a/server/sso.go
+++ b/server/sso.go
@@ -60,7 +60,7 @@ func (s *Server) validateAndParseForwardedIDToken(ctx context.Context, tokenStri
 	jwksProvider, ok := s.provider.(providers.JWKSProvider)
 	if !ok {
 		s.Logger.Warn("Provider does not support JWKS validation, cannot validate forwarded ID token",
-			"provider", s.provider.Name())
+			logKeyProvider, s.provider.Name())
 		return nil, "", fmt.Errorf("provider %s does not support JWKS validation", s.provider.Name())
 	}
 
@@ -178,17 +178,17 @@ func (s *Server) idTokenClaimsToUserInfo(claims *oidc.IDTokenClaims) *providers.
 func (s *Server) logForwardedIDTokenAccepted(ctx context.Context, tokenString, matchedAudience, validatedIssuer string, userInfo *providers.UserInfo) {
 	s.Logger.Debug("Forwarded ID token accepted via TrustedAudiences (SSO)",
 		"user_id", userInfo.ID,
-		"email", userInfo.Email,
+		claimEmail, userInfo.Email,
 		"matched_audience", matchedAudience,
 		"issuer_validated", validatedIssuer != "",
 		"token_suffix", helpers.TokenSuffix(tokenString, 8))
 
 	details := map[string]any{
-		"matched_audience":    matchedAudience,
-		"email":               userInfo.Email,
-		"validation_method":   "jwks",
-		"sso_token_forwarded": true,
-		"issuer_validated":    validatedIssuer != "",
+		"matched_audience":     matchedAudience,
+		claimEmail:             userInfo.Email,
+		logKeyValidationMethod: "jwks",
+		"sso_token_forwarded":  true,
+		"issuer_validated":     validatedIssuer != "",
 	}
 	if validatedIssuer != "" {
 		details["validated_issuer"] = validatedIssuer

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -270,7 +270,7 @@ func (v *OIDCValidator) Validate(ctx context.Context, tokenString string, defaul
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrIssuerNotTrusted, err)
 	}
-	iss, _ := rawClaims["iss"].(string)
+	iss, _ := rawClaims[claimIss].(string)
 	if iss == "" {
 		return nil, fmt.Errorf("%w: missing iss claim", ErrIssuerNotTrusted)
 	}

--- a/server/token_exchange.go
+++ b/server/token_exchange.go
@@ -125,8 +125,8 @@ func (s *Server) SelfIssuedExchange(ctx context.Context, req SelfIssuedExchangeR
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventAuthFailure,
 			Details: map[string]any{
-				"reason":     "token_exchange_jwt_mode_required",
-				"grant_type": GrantTypeTokenExchange,
+				logKeyReason:   "token_exchange_jwt_mode_required",
+				paramGrantType: GrantTypeTokenExchange,
 			},
 		})
 		return nil, fmt.Errorf("token exchange requires JWT access token mode (set AccessTokenFormat=jwt)")
@@ -178,12 +178,12 @@ func (s *Server) SelfIssuedExchange(ctx context.Context, req SelfIssuedExchangeR
 
 	jti := generateRandomToken()
 	auditDetails := map[string]any{
-		"grant_type":         GrantTypeTokenExchange,
+		paramGrantType:       GrantTypeTokenExchange,
 		"subject_token_type": req.Subject.Type,
-		"audience":           audience,
-		"scope":              grantedScope,
-		"jti":                jti,
-		"session_id":         sessionID,
+		paramAudience:        audience,
+		paramScope:           grantedScope,
+		claimJTI:             jti,
+		logKeySessionID:      sessionID,
 	}
 	if act != nil {
 		auditDetails["actor_iss"] = act.Iss
@@ -206,8 +206,8 @@ func (s *Server) SelfIssuedExchange(ctx context.Context, req SelfIssuedExchangeR
 		Extra:         options.Extra,
 	})
 	if err != nil {
-		auditDetails["reason"] = "access_token_issue_failed"
-		auditDetails["error"] = err.Error()
+		auditDetails[logKeyReason] = "access_token_issue_failed"
+		auditDetails[logKeyError] = err.Error()
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type:    security.EventAuthFailure,
 			UserID:  identity.Subject,
@@ -217,7 +217,7 @@ func (s *Server) SelfIssuedExchange(ctx context.Context, req SelfIssuedExchangeR
 	}
 
 	s.Logger.Debug("token exchange: issued token",
-		"sub", identity.Subject, "aud", audience, "scope", grantedScope, "exp", expiresAt,
+		claimSub, identity.Subject, "aud", audience, paramScope, grantedScope, "exp", expiresAt,
 		"delegated", act != nil)
 
 	s.Auditor.LogEvent(ctx, security.Event{
@@ -306,9 +306,9 @@ func (s *Server) checkSelfRenewal(ctx context.Context, identity, actor *SubjectI
 		Type:   security.EventAuthFailure,
 		UserID: identity.Subject,
 		Details: map[string]any{
-			"reason":     "token_exchange_self_renewal_denied",
-			"grant_type": GrantTypeTokenExchange,
-			"session_id": sessionID,
+			logKeyReason:    "token_exchange_self_renewal_denied",
+			paramGrantType:  GrantTypeTokenExchange,
+			logKeySessionID: sessionID,
 		},
 	})
 	return ErrSelfRenewalDenied
@@ -326,9 +326,9 @@ func (s *Server) checkSubjectKeyBinding(ctx context.Context, identity *SubjectId
 		Type:   security.EventAuthFailure,
 		UserID: identity.Subject,
 		Details: map[string]any{
-			"reason":     "token_exchange_subject_key_mismatch",
-			"grant_type": GrantTypeTokenExchange,
-			"session_id": sessionID,
+			logKeyReason:    "token_exchange_subject_key_mismatch",
+			paramGrantType:  GrantTypeTokenExchange,
+			logKeySessionID: sessionID,
 		},
 	})
 	return ErrSubjectKeyMismatch
@@ -347,10 +347,10 @@ func (s *Server) checkAllowedResource(ctx context.Context, audience, sessionID s
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type: security.EventAuthFailure,
 		Details: map[string]any{
-			"reason":     "token_exchange_resource_not_allowed",
-			"grant_type": GrantTypeTokenExchange,
-			"audience":   audience,
-			"session_id": sessionID,
+			logKeyReason:    "token_exchange_resource_not_allowed",
+			paramGrantType:  GrantTypeTokenExchange,
+			paramAudience:   audience,
+			logKeySessionID: sessionID,
 		},
 	})
 	return fmt.Errorf("%w: resource %q", ErrInvalidTarget, audience)
@@ -369,9 +369,9 @@ func (s *Server) checkSubjectEmailVerified(ctx context.Context, identity *Subjec
 		Type:   security.EventAuthFailure,
 		UserID: identity.Subject,
 		Details: map[string]any{
-			"reason":     "token_exchange_unverified_subject_email",
-			"grant_type": GrantTypeTokenExchange,
-			"session_id": sessionID,
+			logKeyReason:    "token_exchange_unverified_subject_email",
+			paramGrantType:  GrantTypeTokenExchange,
+			logKeySessionID: sessionID,
 		},
 	})
 	return ErrUnverifiedSubjectEmail
@@ -388,9 +388,9 @@ func (s *Server) exchangeSessionRateLimited(ctx context.Context, sessionID strin
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type: security.EventAuthFailure,
 		Details: map[string]any{
-			"reason":     "token_exchange_rate_limited",
-			"grant_type": GrantTypeTokenExchange,
-			"session_id": sessionID,
+			logKeyReason:    "token_exchange_rate_limited",
+			paramGrantType:  GrantTypeTokenExchange,
+			logKeySessionID: sessionID,
 		},
 	})
 	return true
@@ -512,9 +512,9 @@ func (s *Server) validateExchangeToken(ctx context.Context, token TypedToken, ro
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventAuthFailure,
 			Details: auditDetails(map[string]any{
-				"reason":     unsupportedReason,
-				"grant_type": GrantTypeTokenExchange,
-				typeKey:      token.Type,
+				logKeyReason:   unsupportedReason,
+				paramGrantType: GrantTypeTokenExchange,
+				typeKey:        token.Type,
 			}),
 		})
 		return nil, &TokenExchangeUnsupportedTypeError{tokenType: token.Type, role: role}
@@ -525,9 +525,9 @@ func (s *Server) validateExchangeToken(ctx context.Context, token TypedToken, ro
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventAuthFailure,
 			Details: auditDetails(map[string]any{
-				"reason":     unsupportedReason,
-				"grant_type": GrantTypeTokenExchange,
-				typeKey:      token.Type,
+				logKeyReason:   unsupportedReason,
+				paramGrantType: GrantTypeTokenExchange,
+				typeKey:        token.Type,
 			}),
 		})
 		return nil, &TokenExchangeUnsupportedTypeError{tokenType: token.Type, role: role}
@@ -536,14 +536,14 @@ func (s *Server) validateExchangeToken(ctx context.Context, token TypedToken, ro
 	identity, err := v.Validate(ctx, token.Token, defaultAudiences)
 	if err != nil {
 		s.Logger.Debug("token exchange: "+role+" token validation failed",
-			typeKey, token.Type, "error", err)
+			typeKey, token.Type, logKeyError, err)
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventAuthFailure,
 			Details: auditDetails(map[string]any{
-				"reason":     validationFailedReason,
-				"grant_type": GrantTypeTokenExchange,
-				typeKey:      token.Type,
-				"error":      err.Error(),
+				logKeyReason:   validationFailedReason,
+				paramGrantType: GrantTypeTokenExchange,
+				typeKey:        token.Type,
+				logKeyError:    err.Error(),
 			}),
 		})
 		return nil, fmt.Errorf("%s token validation: %w", role, err)

--- a/server/token_exchange_broker.go
+++ b/server/token_exchange_broker.go
@@ -137,10 +137,10 @@ func (s *Server) BrokeredExchange(ctx context.Context, req BrokeredExchangeReque
 	}
 
 	auditCtx := map[string]any{
-		"exchange":   "brokered",
-		"client_id":  req.ClientID,
-		"audience":   req.Audience,
-		"session_id": sessionID,
+		logKeyExchange:  exchangeBrokered,
+		paramClientID:   req.ClientID,
+		paramAudience:   req.Audience,
+		logKeySessionID: sessionID,
 	}
 
 	identity, err := s.validateExchangeSubjectToken(ctx, req.Subject, nil, auditCtx)
@@ -186,10 +186,10 @@ func (s *Server) dispatchDownstreamExchange(
 	})
 	if err != nil {
 		s.Logger.Debug("brokered token exchange: downstream exchange failed",
-			"client_id", clientID, "audience", audience, "error", err)
+			paramClientID, clientID, paramAudience, audience, logKeyError, err)
 		s.auditExchangeFailure(ctx, clientID, audience, sessionID, "token_exchange_downstream_failed", map[string]any{
-			"sub":   identity.Subject,
-			"error": err.Error(),
+			claimSub:    identity.Subject,
+			logKeyError: err.Error(),
 		})
 		if errors.Is(err, ErrInvalidTarget) {
 			return nil, err
@@ -198,7 +198,7 @@ func (s *Server) dispatchDownstreamExchange(
 	}
 	if result == nil || result.AccessToken == "" {
 		s.auditExchangeFailure(ctx, clientID, audience, sessionID, "token_exchange_downstream_empty_token", map[string]any{
-			"sub": identity.Subject,
+			claimSub: identity.Subject,
 		})
 		return nil, fmt.Errorf("downstream exchange returned no token")
 	}
@@ -209,18 +209,18 @@ func (s *Server) dispatchDownstreamExchange(
 	}
 
 	s.Logger.Debug("brokered token exchange: issued downstream token",
-		"client_id", clientID, "sub", identity.Subject, "subject_iss", identity.Issuer,
-		"audience", audience, "scope", result.Scope, "exp", result.ExpiresAt,
-		"session_id", sessionID)
+		paramClientID, clientID, claimSub, identity.Subject, "subject_iss", identity.Issuer,
+		paramAudience, audience, paramScope, result.Scope, "exp", result.ExpiresAt,
+		logKeySessionID, sessionID)
 
 	successDetails := map[string]any{
-		"grant_type":         GrantTypeTokenExchange,
-		"exchange":           "brokered",
+		paramGrantType:       GrantTypeTokenExchange,
+		logKeyExchange:       exchangeBrokered,
 		"subject_token_type": subject.Type,
-		"audience":           audience,
-		"scope":              result.Scope,
+		paramAudience:        audience,
+		paramScope:           result.Scope,
 		"subject_iss":        identity.Issuer,
-		"session_id":         sessionID,
+		logKeySessionID:      sessionID,
 	}
 	if actorIdentity != nil {
 		successDetails["actor_iss"] = actorIdentity.Issuer
@@ -259,11 +259,11 @@ func (s *Server) exchangeRateLimited(ctx context.Context, clientID, audience, se
 // rejection paths. extra is merged over the base details.
 func (s *Server) auditExchangeFailure(ctx context.Context, clientID, audience, sessionID, reason string, extra map[string]any) {
 	details := map[string]any{
-		"reason":     reason,
-		"grant_type": GrantTypeTokenExchange,
-		"exchange":   "brokered",
-		"audience":   audience,
-		"session_id": sessionID,
+		logKeyReason:    reason,
+		paramGrantType:  GrantTypeTokenExchange,
+		logKeyExchange:  exchangeBrokered,
+		paramAudience:   audience,
+		logKeySessionID: sessionID,
 	}
 	maps.Copy(details, extra)
 	s.Auditor.LogEvent(ctx, security.Event{

--- a/server/validate.go
+++ b/server/validate.go
@@ -78,20 +78,20 @@ func (s *Server) updateProviderTokenMappings(ctx context.Context, accessToken st
 	if upts, unified := s.userProviderTokenStore(); unified {
 		userID, err := upts.GetProviderTokenRef(ctx, accessToken)
 		if err != nil {
-			s.Logger.Warn("Failed to resolve access token to user for provider token write-back", "error", err)
+			s.Logger.Warn("Failed to resolve access token to user for provider token write-back", logKeyError, err)
 			return
 		}
 		if saveErr := upts.SaveUserProviderToken(ctx, userID, newProviderToken); saveErr != nil {
-			s.Logger.Warn("Failed to save refreshed shared provider token", "error", saveErr)
+			s.Logger.Warn("Failed to save refreshed shared provider token", logKeyError, saveErr)
 		}
 		return
 	}
 	if saveErr := s.tokenStore.SaveToken(ctx, accessToken, newProviderToken); saveErr != nil {
-		s.Logger.Warn("Failed to save refreshed provider token for access key", "error", saveErr)
+		s.Logger.Warn("Failed to save refreshed provider token for access key", logKeyError, saveErr)
 	}
 	if pairedRT, ok := s.tokenPairs.Load(accessToken); ok {
 		if saveErr := s.tokenStore.SaveToken(ctx, pairedRT.(string), newProviderToken); saveErr != nil {
-			s.Logger.Warn("Failed to save refreshed provider token for refresh key", "error", saveErr)
+			s.Logger.Warn("Failed to save refreshed provider token for refresh key", logKeyError, saveErr)
 		}
 	}
 }
@@ -145,7 +145,7 @@ func (s *Server) fireTokenRefreshHandler(ctx context.Context, accessToken string
 			familyID = meta.FamilyID
 		} else if err != nil {
 			s.Logger.Debug("Failed to retrieve token metadata for refresh handler",
-				"error", err,
+				logKeyError, err,
 				"token_suffix", helpers.TokenSuffix(accessToken, 8))
 		}
 	}
@@ -198,14 +198,14 @@ func (s *Server) attemptProactiveRefresh(ctx context.Context, accessToken string
 	if err != nil {
 		// Refresh failed - log warning but continue with validation (graceful degradation)
 		s.Logger.Warn("Proactive token refresh failed, falling back to validation",
-			"error", err,
+			logKeyError, err,
 			"token_suffix", helpers.TokenSuffix(accessToken, 8),
 			"time_until_expiry", timeUntilExpiry)
 
 		s.Auditor.LogEvent(ctx, security.Event{
 			Type: security.EventProactiveRefreshFailed,
 			Details: map[string]any{
-				"error":             err.Error(),
+				logKeyError:         err.Error(),
 				"time_until_expiry": timeUntilExpiry.String(),
 				"fallback":          "validation",
 			},
@@ -307,7 +307,7 @@ func (s *Server) ValidateToken(ctx context.Context, accessToken string) (*provid
 			// it at WARN. No token material is logged (only an 8-char suffix
 			// for correlation).
 			s.Logger.Warn("Forwarded ID token validation failed, falling back to userinfo",
-				"error", err.Error(),
+				logKeyError, err.Error(),
 				"token_suffix", helpers.TokenSuffix(accessToken, 8))
 		} else if userInfo != nil {
 			s.Logger.Debug("Forwarded ID token validated via JWKS",
@@ -339,7 +339,7 @@ func (s *Server) ValidateToken(ctx context.Context, accessToken string) (*provid
 
 	// Store user info
 	if err := s.tokenStore.SaveUserInfo(ctx, userInfo.ID, providerUserInfoToStorage(userInfo)); err != nil {
-		s.Logger.Warn("Failed to save user info", "error", err)
+		s.Logger.Warn("Failed to save user info", logKeyError, err)
 	}
 
 	return userInfo, nil
@@ -433,7 +433,7 @@ func (s *Server) validateTokenAudience(ctx context.Context, accessToken string) 
 	// Check if audience matches this server's own resource identifier
 	if subtle.ConstantTimeCompare([]byte(normalizedAudience), []byte(normalizedExpected)) == 1 {
 		s.Logger.Debug("Token audience validation passed",
-			"audience", metadata.Audience,
+			paramAudience, metadata.Audience,
 			"token_suffix", helpers.TokenSuffix(accessToken, 8))
 		return nil
 	}
@@ -518,15 +518,15 @@ func (s *Server) logTrustedIssuerJWTAccepted(ctx context.Context, accessToken, i
 	s.Logger.Debug("Trusted-issuer JWT accepted",
 		"issuer", issuer,
 		"user_id", userInfo.ID,
-		"email", userInfo.Email,
+		claimEmail, userInfo.Email,
 		"token_suffix", helpers.TokenSuffix(accessToken, 8))
 	s.Auditor.LogEvent(ctx, security.Event{
 		Type:   security.EventForwardedIDTokenAccepted,
 		UserID: userInfo.ID,
 		Details: map[string]any{
-			"validation_method": "trusted_issuer_jwks",
-			"trusted_issuer":    issuer,
-			"email":             userInfo.Email,
+			logKeyValidationMethod: "trusted_issuer_jwks",
+			"trusted_issuer":       issuer,
+			claimEmail:             userInfo.Email,
 		},
 	})
 }
@@ -537,7 +537,7 @@ func (s *Server) logCrossClientTokenAccepted(ctx context.Context, accessToken st
 	s.Logger.Debug("Token accepted via TrustedAudiences (SSO token forwarding)",
 		"token_audience", metadata.Audience,
 		"user_id", metadata.UserID,
-		"client_id", metadata.ClientID,
+		paramClientID, metadata.ClientID,
 		"token_suffix", helpers.TokenSuffix(accessToken, 8))
 
 	s.Auditor.LogEvent(ctx, security.Event{
@@ -561,7 +561,7 @@ func (s *Server) logAudienceMismatch(ctx context.Context, accessToken string, me
 			"server_identifier", expectedAudience,
 			"token_suffix", helpers.TokenSuffix(accessToken, 8),
 			"user_id", metadata.UserID,
-			"client_id", metadata.ClientID)
+			paramClientID, metadata.ClientID)
 	}
 
 	s.Auditor.LogEvent(ctx, security.Event{
@@ -569,7 +569,7 @@ func (s *Server) logAudienceMismatch(ctx context.Context, accessToken string, me
 		UserID:   metadata.UserID,
 		ClientID: metadata.ClientID,
 		Details: map[string]any{
-			"severity":          "critical",
+			logKeySeverity:      severityCritical,
 			"token_audience":    metadata.Audience,
 			"server_identifier": expectedAudience,
 			"attack_indicator":  "token_replay_to_wrong_resource_server",

--- a/server/validation.go
+++ b/server/validation.go
@@ -627,7 +627,7 @@ func (s *Server) validateResourceConsistency(ctx context.Context, resource strin
 			s.Logger.Debug("Resource parameter mismatch",
 				"expected", authCode.Resource,
 				"provided", resource,
-				"client_id", clientID,
+				paramClientID, clientID,
 				"user_id", authCode.UserID)
 		}
 		s.Auditor.LogEvent(ctx, security.Event{
@@ -637,7 +637,7 @@ func (s *Server) validateResourceConsistency(ctx context.Context, resource strin
 			Details: map[string]any{
 				"expected_resource": authCode.Resource,
 				"provided_resource": resource,
-				"severity":          "high",
+				logKeySeverity:      severityHigh,
 			},
 		})
 		return s.logAuthCodeValidationFailure(ctx, "resource_mismatch", clientID, authCode.UserID, helpers.SafeTruncate(code, 8))

--- a/storage/valkey/provider_token.go
+++ b/storage/valkey/provider_token.go
@@ -58,7 +58,7 @@ func (s *Store) SaveUserProviderToken(ctx context.Context, userID string, token 
 	}
 
 	st := toSerializable(tokenToStore)
-	data, err := json.Marshal(st)
+	data, err := json.Marshal(st) // #nosec G117 -- serializing the OAuth token (RFC 6749 access/refresh token) for persistence is this token store's purpose; the value is encrypted at rest by encryptToken above when an encryptor is configured, and written only to Valkey, never logged
 	if err != nil {
 		return fmt.Errorf("failed to marshal token: %w", err)
 	}

--- a/storage/valkey/token.go
+++ b/storage/valkey/token.go
@@ -83,7 +83,7 @@ func (s *Store) SaveToken(ctx context.Context, userID string, token *oauth2.Toke
 	// Convert to serializable struct that explicitly includes Extra fields
 	st := toSerializable(tokenToStore)
 
-	data, err := json.Marshal(st)
+	data, err := json.Marshal(st) // #nosec G117 -- serializing the OAuth token (RFC 6749 access/refresh token) for persistence is this token store's purpose; the value is encrypted at rest by encryptToken above when an encryptor is configured, and written only to Valkey, never logged
 	if err != nil {
 		return fmt.Errorf("failed to marshal token: %w", err)
 	}


### PR DESCRIPTION
## What

Unblocks the Go 1.27 wave for this repo (giantswarm/github#5798). golangci-lint 2.9.0 is built with Go 1.26 and refuses to lint Go 1.27 code, which currently blocks #545.

The honest 2.9.0 → 2.13.1 delta here was **1022 findings** (880 goconst + 142 gosec), not just the 142 gosec reported in the issue — goconst also fires across the board on the new version. Triage outcome:

### Fixed in code (no suppressions)
- **~90 non-test goconst findings**: introduced package-local constants — new `server/constants.go` and `handler/constants.go` (log keys, severities, OAuth params/claims like `grant_type`, `sub`, `jti`, `Bearer`), plus small const additions in `security/audit.go` and `internal/testutil`. Nothing exported.
- **G101** in `internal/testutil/testutil.go`: restructured (named const with comment for the bcrypt hash of the public fixture plaintext "secret") — no `#nosec` needed.
- **G602** `handler/handler_refresh_token_test.go`: loop bound corrected so `kv[i+1]` is provably in bounds.
- **G115** `security/ratelimit_test.go`: `string(rune('0'+…))` hack replaced with `strconv.Itoa` — also fixes identifier uniqueness.
- **G115** `server/redirect_uri_security_test.go`: DNS length prefix bounds-checked against `math.MaxUint16` and written via `binary.BigEndian.PutUint16`.

### Annotated (targeted, justified — 2 sites)
- **G117** on the two `json.Marshal` calls in `storage/valkey/`: serializing the token struct for persistence **is** the token store's purpose; values are encrypted at rest via `encryptToken` when an encryptor is configured and are never logged. Per-line `#nosec G117` with that justification.

### Scoped test-fixture exclusions (.golangci.yml)
- goconst on `_test.go` — mirrors giantswarm/klaus-operator's fleet-standard config; table-driven tests repeat protocol strings by design (800 of the 880).
- gosec **G101/G117 only** on `_test.go` — fixtures hardcode credential-shaped values and marshal mock token responses (120 of the 121 G101s). No linter disabled, no blanket nolint.

### Pin bump
`.github/workflows/pre_commit_go.yaml`: golangci-lint 2.9.0 → 2.13.1, Go 1.26 → 1.27, goimports v0.42.0 → v0.48.0 — byte-matching the central template after giantswarm/github#5799, so the next align sweep is a no-op.

## Verification

- `golangci-lint run -E=gosec -E=goconst -E=govet --max-same-issues=0 --max-issues-per-linter=0 ./...` → **0 issues** with 2.13.1 (was 1022)
- `go build ./...` clean, `go test ./...` green across all 20 test packages
- Security review of the triage: no real issues found; noted (informational) that at-rest token encryption is optional by configuration.

Part of giantswarm/github#5798. Unblocks #545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)