### PR TITLE
feat(dex): resolve cross-client audience scopes per authorization request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `dex.Config.AudienceResolver`: an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it on every authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` still reaches the next login. `Scopes` alone is a construction-time snapshot: an audience added later never reached the authorization request, and the minted ID token carried only the provider's own client. Nil keeps the previous behaviour. Audiences that fail validation are skipped, one at a time, and logged once each; `FormatAudienceScopes` still rejects the whole set.
+
 ## [1.1.0] - 2026-07-16
 
 > ### ⚠️ DEPLOY NOTE — one-time re-login required; token-key flush recommended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `dex.Config.AudienceResolver`: an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it on every authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` still reaches the next login. `Scopes` alone is a construction-time snapshot: an audience added later never reached the authorization request, and the minted ID token carried only the provider's own client. Nil keeps the previous behaviour. Audiences that fail validation are skipped, one at a time, and logged once each; `FormatAudienceScopes` still rejects the whole set.
+- `dex.Config.AudienceResolver`, an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it per authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` reaches the next login. Nil keeps the previous behaviour. Duplicates are dropped, invalid audiences are skipped and logged once each, and the merged set stays within `oidc.MaxScopeCount`.
+- `oidc.MaxScopeCount` and `oidc.MaxScopeLength`, the bounds `oidc.ValidateScopes` already applied.
 
 ## [1.1.0] - 2026-07-16
 

--- a/providers/dex/audience.go
+++ b/providers/dex/audience.go
@@ -196,8 +196,9 @@ type audienceRejection struct {
 }
 
 // partitionAudienceScopes formats every valid audience as a cross-client
-// audience scope and reports the ones it skipped. Empty entries are skipped
-// without a rejection, as in FormatAudienceScopes.
+// audience scope and reports the ones it skipped. Empty entries, duplicates,
+// and audiences whose scope is already in present are skipped without a
+// rejection, as FormatAudienceScopes skips empty entries.
 //
 // It differs from FormatAudienceScopes in its failure mode: one malformed
 // audience costs only its own scope, not the whole set. A caller that resolves
@@ -205,24 +206,42 @@ type audienceRejection struct {
 // needs that, because a single bad value must not drop the audiences every
 // other consumer depends on.
 //
-// At most MaxAudienceCount scopes are returned. Audiences past that cap are
-// reported as rejected.
-func partitionAudienceScopes(audiences []string) ([]string, []audienceRejection) {
+// limit caps the returned scopes. Audiences past the limit are reported as
+// rejected, and a limit of zero or less rejects every audience. Only a scope
+// that the result actually carries counts against the limit, so a duplicate
+// cannot displace a distinct audience. Each distinct audience is reported at
+// most once.
+func partitionAudienceScopes(audiences []string, limit int, present map[string]struct{}) ([]string, []audienceRejection) {
 	if len(audiences) == 0 {
 		return nil, nil
 	}
 
-	scopes := make([]string, 0, min(len(audiences), MaxAudienceCount))
+	scopes := make([]string, 0, min(len(audiences), max(limit, 0)))
 	var rejected []audienceRejection
+	seen := make(map[string]struct{}, len(audiences))
 
 	for _, audience := range audiences {
 		if audience == "" {
 			continue
 		}
-		if len(scopes) >= MaxAudienceCount {
+
+		scope := AudienceScopePrefix + audience
+		if _, exists := seen[scope]; exists {
+			continue
+		}
+		if _, exists := present[scope]; exists {
+			continue
+		}
+		seen[scope] = struct{}{}
+
+		// The limit is checked before validation, so a caller that reports far
+		// more audiences than fit does not pay for a regex on every extra entry.
+		// An unvalidated audience therefore reaches a rejection, which is why
+		// warnRejectedAudiences truncates the value before it logs it.
+		if len(scopes) >= limit {
 			rejected = append(rejected, audienceRejection{
 				Audience: audience,
-				Reason:   fmt.Sprintf("audiences exceed maximum count of %d", MaxAudienceCount),
+				Reason:   fmt.Sprintf("no room left for more audience scopes (limit %d)", limit),
 			})
 			continue
 		}
@@ -230,7 +249,8 @@ func partitionAudienceScopes(audiences []string) ([]string, []audienceRejection)
 			rejected = append(rejected, audienceRejection{Audience: audience, Reason: err.Error()})
 			continue
 		}
-		scopes = append(scopes, AudienceScopePrefix+audience)
+
+		scopes = append(scopes, scope)
 	}
 
 	return scopes, rejected

--- a/providers/dex/audience.go
+++ b/providers/dex/audience.go
@@ -188,3 +188,50 @@ func AppendAudienceScopes(scopes string, audiences []string) (string, error) {
 	}
 	return scopes + " " + strings.Join(audienceScopes, " "), nil
 }
+
+// audienceRejection records one audience that partitionAudienceScopes skipped.
+type audienceRejection struct {
+	Audience string
+	Reason   string
+}
+
+// partitionAudienceScopes formats every valid audience as a cross-client
+// audience scope and reports the ones it skipped. Empty entries are skipped
+// without a rejection, as in FormatAudienceScopes.
+//
+// It differs from FormatAudienceScopes in its failure mode: one malformed
+// audience costs only its own scope, not the whole set. A caller that resolves
+// audiences from external state (Kubernetes resources, a service registry)
+// needs that, because a single bad value must not drop the audiences every
+// other consumer depends on.
+//
+// At most MaxAudienceCount scopes are returned. Audiences past that cap are
+// reported as rejected.
+func partitionAudienceScopes(audiences []string) ([]string, []audienceRejection) {
+	if len(audiences) == 0 {
+		return nil, nil
+	}
+
+	scopes := make([]string, 0, min(len(audiences), MaxAudienceCount))
+	var rejected []audienceRejection
+
+	for _, audience := range audiences {
+		if audience == "" {
+			continue
+		}
+		if len(scopes) >= MaxAudienceCount {
+			rejected = append(rejected, audienceRejection{
+				Audience: audience,
+				Reason:   fmt.Sprintf("audiences exceed maximum count of %d", MaxAudienceCount),
+			})
+			continue
+		}
+		if err := ValidateAudience(audience); err != nil {
+			rejected = append(rejected, audienceRejection{Audience: audience, Reason: err.Error()})
+			continue
+		}
+		scopes = append(scopes, AudienceScopePrefix+audience)
+	}
+
+	return scopes, rejected
+}

--- a/providers/dex/audience_resolver_test.go
+++ b/providers/dex/audience_resolver_test.go
@@ -2,11 +2,14 @@ package dex
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/url"
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/giantswarm/mcp-oauth/providers/oidc"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -143,23 +146,33 @@ func TestAudienceResolverSkipsInvalidAudiences(t *testing.T) {
 	assert.Equal(t, []string{"openid", k8sAudienceScope}, provider.DefaultScopes())
 }
 
+// numberedAudiences returns count distinct valid audience client IDs.
+func numberedAudiences(count int) []string {
+	audiences := make([]string, 0, count)
+	for i := range count {
+		audiences = append(audiences, fmt.Sprintf("client-%d", i))
+	}
+
+	return audiences
+}
+
 func TestPartitionAudienceScopes(t *testing.T) {
 	t.Run("no audiences", func(t *testing.T) {
-		scopes, rejected := partitionAudienceScopes(nil)
+		scopes, rejected := partitionAudienceScopes(nil, MaxAudienceCount, nil)
 
 		assert.Empty(t, scopes)
 		assert.Empty(t, rejected)
 	})
 
 	t.Run("an empty entry is skipped without a rejection", func(t *testing.T) {
-		scopes, rejected := partitionAudienceScopes([]string{"", "valid-client"})
+		scopes, rejected := partitionAudienceScopes([]string{"", "valid-client"}, MaxAudienceCount, nil)
 
 		assert.Equal(t, []string{AudienceScopePrefix + "valid-client"}, scopes)
 		assert.Empty(t, rejected)
 	})
 
 	t.Run("an invalid entry is reported with its reason", func(t *testing.T) {
-		scopes, rejected := partitionAudienceScopes([]string{"valid-client", "has space"})
+		scopes, rejected := partitionAudienceScopes([]string{"valid-client", "has space"}, MaxAudienceCount, nil)
 
 		assert.Equal(t, []string{AudienceScopePrefix + "valid-client"}, scopes)
 		require.Len(t, rejected, 1)
@@ -170,25 +183,83 @@ func TestPartitionAudienceScopes(t *testing.T) {
 	t.Run("an over-long entry is reported, not truncated into a scope", func(t *testing.T) {
 		long := strings.Repeat("a", MaxAudienceLength+1)
 
-		scopes, rejected := partitionAudienceScopes([]string{long})
+		scopes, rejected := partitionAudienceScopes([]string{long}, MaxAudienceCount, nil)
 
 		assert.Empty(t, scopes)
 		require.Len(t, rejected, 1)
 		assert.Contains(t, rejected[0].Reason, "maximum length")
 	})
 
-	t.Run("audiences past the count cap are reported", func(t *testing.T) {
-		audiences := make([]string, 0, MaxAudienceCount+2)
-		for i := range MaxAudienceCount + 2 {
-			audiences = append(audiences, "client-"+strings.Repeat("x", i%3)+string(rune('a'+i%26))+string(rune('a'+i/26)))
-		}
-
-		scopes, rejected := partitionAudienceScopes(audiences)
+	t.Run("audiences past the limit are reported", func(t *testing.T) {
+		scopes, rejected := partitionAudienceScopes(numberedAudiences(MaxAudienceCount+2), MaxAudienceCount, nil)
 
 		assert.Len(t, scopes, MaxAudienceCount)
-		assert.Len(t, rejected, 2)
-		assert.Contains(t, rejected[0].Reason, "maximum count")
+		require.Len(t, rejected, 2)
+		assert.Contains(t, rejected[0].Reason, "no room left")
 	})
+
+	t.Run("a limit of zero rejects every audience", func(t *testing.T) {
+		scopes, rejected := partitionAudienceScopes([]string{"first-client", "second-client"}, 0, nil)
+
+		assert.Empty(t, scopes)
+		assert.Len(t, rejected, 2)
+	})
+
+	// A duplicate must not consume a slot the limit would otherwise give to a
+	// distinct audience.
+	t.Run("a duplicate does not consume the limit", func(t *testing.T) {
+		audiences := make([]string, 0, MaxAudienceCount+1)
+		for range MaxAudienceCount {
+			audiences = append(audiences, "same-client")
+		}
+		audiences = append(audiences, "real-client")
+
+		scopes, rejected := partitionAudienceScopes(audiences, MaxAudienceCount, nil)
+
+		assert.Equal(t, []string{
+			AudienceScopePrefix + "same-client",
+			AudienceScopePrefix + "real-client",
+		}, scopes)
+		assert.Empty(t, rejected)
+	})
+
+	t.Run("an audience already present does not consume the limit", func(t *testing.T) {
+		present := map[string]struct{}{AudienceScopePrefix + "first-client": {}}
+
+		scopes, rejected := partitionAudienceScopes([]string{"first-client", "second-client"}, 1, present)
+
+		assert.Equal(t, []string{AudienceScopePrefix + "second-client"}, scopes)
+		assert.Empty(t, rejected)
+	})
+
+	t.Run("a repeated invalid audience is reported once", func(t *testing.T) {
+		scopes, rejected := partitionAudienceScopes([]string{"has space", "has space"}, MaxAudienceCount, nil)
+
+		assert.Empty(t, scopes)
+		assert.Len(t, rejected, 1)
+	})
+}
+
+// TestEffectiveScopesStaysWithinTheScopeBound pins the merged bound. NewProvider
+// rejects a configured set larger than oidc.MaxScopeCount, so the resolver path
+// must not push an authorization request past it either.
+func TestEffectiveScopesStaysWithinTheScopeBound(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	configured := []string{"openid", "email"}
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Scopes = configured
+		cfg.AudienceResolver = func() []string { return numberedAudiences(oidc.MaxScopeCount) }
+	}))
+	require.NoError(t, err)
+
+	scopes := provider.DefaultScopes()
+
+	assert.Len(t, scopes, oidc.MaxScopeCount)
+	assert.Equal(t, configured, scopes[:len(configured)])
+	assert.NoError(t, oidc.ValidateScopes(scopes))
+	assert.NoError(t, oidc.ValidateScopes(authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))))
 }
 
 func TestTruncateAudienceForLog(t *testing.T) {

--- a/providers/dex/audience_resolver_test.go
+++ b/providers/dex/audience_resolver_test.go
@@ -1,0 +1,276 @@
+package dex
+
+import (
+	"context"
+	"log/slog"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const k8sAudienceScope = AudienceScopePrefix + "dex-k8s-authenticator"
+
+// authURLScopes returns the scope values the authorization URL carries.
+func authURLScopes(t *testing.T, authURL string) []string {
+	t.Helper()
+
+	parsed, err := url.Parse(authURL)
+	require.NoError(t, err)
+
+	return strings.Fields(parsed.Query().Get("scope"))
+}
+
+// TestAudienceResolverCoversLateAudiences covers an audience that the caller
+// learns about after the provider is built. It must reach the next
+// authorization request, through DefaultScopes and through AuthorizationURL.
+func TestAudienceResolverCoversLateAudiences(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	var mu sync.Mutex
+	audiences := []string{}
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.AudienceResolver = func() []string {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]string(nil), audiences...)
+		}
+	}))
+	require.NoError(t, err)
+
+	assert.NotContains(t, provider.DefaultScopes(), k8sAudienceScope)
+	assert.NotContains(t, authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil)), k8sAudienceScope)
+
+	mu.Lock()
+	audiences = append(audiences, "dex-k8s-authenticator")
+	mu.Unlock()
+
+	assert.Contains(t, provider.DefaultScopes(), k8sAudienceScope)
+
+	t.Run("the audience reaches an explicit scope request too", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"openid", "email"}, nil))
+
+		assert.Contains(t, scopes, k8sAudienceScope)
+		assert.Contains(t, scopes, "openid")
+		assert.Contains(t, scopes, "email")
+	})
+
+	t.Run("the audience reaches a request without scopes", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
+
+		assert.Contains(t, scopes, k8sAudienceScope)
+		assert.Contains(t, scopes, "groups")
+		assert.Contains(t, scopes, "offline_access")
+	})
+}
+
+func TestAudienceResolverScopeMerging(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	newProvider := func(t *testing.T, resolver func() []string, options ...func(*Config)) *Provider {
+		t.Helper()
+
+		all := append([]func(*Config){func(cfg *Config) { cfg.AudienceResolver = resolver }}, options...)
+		provider, err := NewProvider(testConfig(server, all...))
+		require.NoError(t, err)
+
+		return provider
+	}
+
+	t.Run("a nil resolver keeps the configured scopes", func(t *testing.T) {
+		provider := newProvider(t, nil)
+
+		assert.Equal(t, defaultDexScopes, provider.DefaultScopes())
+	})
+
+	t.Run("an empty audience set keeps the configured scopes", func(t *testing.T) {
+		provider := newProvider(t, func() []string { return nil })
+
+		assert.Equal(t, defaultDexScopes, provider.DefaultScopes())
+	})
+
+	t.Run("every audience contributes one scope", func(t *testing.T) {
+		provider := newProvider(t, func() []string { return []string{"first-client", "second-client"} })
+
+		scopes := provider.DefaultScopes()
+
+		assert.Equal(t, append(append([]string(nil), defaultDexScopes...),
+			AudienceScopePrefix+"first-client",
+			AudienceScopePrefix+"second-client",
+		), scopes)
+	})
+
+	t.Run("an audience already in Scopes is not duplicated", func(t *testing.T) {
+		provider := newProvider(t,
+			func() []string { return []string{"dex-k8s-authenticator"} },
+			func(cfg *Config) { cfg.Scopes = []string{"openid", k8sAudienceScope} },
+		)
+
+		assert.Equal(t, []string{"openid", k8sAudienceScope}, provider.DefaultScopes())
+	})
+
+	t.Run("the result is a fresh slice on every call", func(t *testing.T) {
+		provider := newProvider(t, func() []string { return []string{"dex-k8s-authenticator"} })
+
+		first := provider.DefaultScopes()
+		first[0] = "mutated"
+
+		assert.Equal(t, "openid", provider.DefaultScopes()[0])
+		assert.Equal(t, "openid", provider.Scopes[0])
+	})
+}
+
+// TestAudienceResolverSkipsInvalidAudiences pins the failure mode: one
+// malformed audience costs only its own scope, and every valid audience in the
+// same set still reaches the request.
+func TestAudienceResolverSkipsInvalidAudiences(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Scopes = []string{"openid"}
+		cfg.AudienceResolver = func() []string {
+			return []string{"has space", "", "dex-k8s-authenticator", "no/slashes"}
+		}
+	}))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"openid", k8sAudienceScope}, provider.DefaultScopes())
+}
+
+func TestPartitionAudienceScopes(t *testing.T) {
+	t.Run("no audiences", func(t *testing.T) {
+		scopes, rejected := partitionAudienceScopes(nil)
+
+		assert.Empty(t, scopes)
+		assert.Empty(t, rejected)
+	})
+
+	t.Run("an empty entry is skipped without a rejection", func(t *testing.T) {
+		scopes, rejected := partitionAudienceScopes([]string{"", "valid-client"})
+
+		assert.Equal(t, []string{AudienceScopePrefix + "valid-client"}, scopes)
+		assert.Empty(t, rejected)
+	})
+
+	t.Run("an invalid entry is reported with its reason", func(t *testing.T) {
+		scopes, rejected := partitionAudienceScopes([]string{"valid-client", "has space"})
+
+		assert.Equal(t, []string{AudienceScopePrefix + "valid-client"}, scopes)
+		require.Len(t, rejected, 1)
+		assert.Equal(t, "has space", rejected[0].Audience)
+		assert.Contains(t, rejected[0].Reason, "invalid characters")
+	})
+
+	t.Run("an over-long entry is reported, not truncated into a scope", func(t *testing.T) {
+		long := strings.Repeat("a", MaxAudienceLength+1)
+
+		scopes, rejected := partitionAudienceScopes([]string{long})
+
+		assert.Empty(t, scopes)
+		require.Len(t, rejected, 1)
+		assert.Contains(t, rejected[0].Reason, "maximum length")
+	})
+
+	t.Run("audiences past the count cap are reported", func(t *testing.T) {
+		audiences := make([]string, 0, MaxAudienceCount+2)
+		for i := range MaxAudienceCount + 2 {
+			audiences = append(audiences, "client-"+strings.Repeat("x", i%3)+string(rune('a'+i%26))+string(rune('a'+i/26)))
+		}
+
+		scopes, rejected := partitionAudienceScopes(audiences)
+
+		assert.Len(t, scopes, MaxAudienceCount)
+		assert.Len(t, rejected, 2)
+		assert.Contains(t, rejected[0].Reason, "maximum count")
+	})
+}
+
+func TestTruncateAudienceForLog(t *testing.T) {
+	assert.Equal(t, "short", truncateAudienceForLog("short"))
+
+	long := strings.Repeat("a", maxLoggedAudienceLength+10)
+	truncated := truncateAudienceForLog(long)
+
+	assert.True(t, strings.HasSuffix(truncated, "...(truncated)"))
+	assert.Len(t, truncated, maxLoggedAudienceLength+len("...(truncated)"))
+}
+
+// TestWarnRejectedAudiencesLogsOncePerAudience pins the log-once behaviour. The
+// resolver runs on every authorization request, so a repeated log line would
+// let one malformed value flood the log.
+func TestWarnRejectedAudiencesLogsOncePerAudience(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	handler := &countingHandler{}
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Logger = slog.New(handler)
+		cfg.AudienceResolver = func() []string { return []string{"has space"} }
+	}))
+	require.NoError(t, err)
+
+	for range 5 {
+		provider.DefaultScopes()
+	}
+
+	assert.Equal(t, 1, handler.count(slog.LevelWarn))
+}
+
+func TestWarnRejectedAudiencesStopsAtTheMemoCap(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	handler := &countingHandler{}
+	audiences := make([]string, 0, maxWarnedAudiences+10)
+	for i := range maxWarnedAudiences + 10 {
+		audiences = append(audiences, strings.Repeat("a", i+1)+" invalid")
+	}
+
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Logger = slog.New(handler)
+		cfg.AudienceResolver = func() []string { return audiences }
+	}))
+	require.NoError(t, err)
+
+	provider.DefaultScopes()
+	provider.DefaultScopes()
+
+	assert.Equal(t, maxWarnedAudiences, handler.count(slog.LevelWarn))
+}
+
+// countingHandler counts the records a logger emits, per level.
+type countingHandler struct {
+	mu     sync.Mutex
+	counts map[slog.Level]int
+}
+
+func (h *countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *countingHandler) Handle(_ context.Context, record slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.counts == nil {
+		h.counts = map[slog.Level]int{}
+	}
+	h.counts[record.Level]++
+
+	return nil
+}
+
+func (h *countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h *countingHandler) WithGroup(string) slog.Handler { return h }
+
+func (h *countingHandler) count(level slog.Level) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.counts[level]
+}

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -68,19 +68,24 @@ type Config struct {
 	Scopes []string
 
 	// AudienceResolver reports the Dex cross-client audiences to request, as
-	// plain client IDs. The provider calls it on every authorization request and
-	// merges one AudienceScopePrefix scope per audience into both
-	// DefaultScopes() and AuthorizationURL(), so an audience that the caller
-	// learns about after startup still reaches the next login. Nil keeps the
-	// static Scopes set.
+	// plain client IDs. The provider merges one AudienceScopePrefix scope per
+	// audience into both DefaultScopes() and AuthorizationURL(), so an audience
+	// that the caller learns about after startup still reaches the next login.
+	// Nil keeps the static Scopes set.
 	//
 	// Prefer this over audience scopes in Scopes whenever the audience set is
 	// not known at construction time, for example when it comes from Kubernetes
 	// resources that reconcile after the process starts.
 	//
-	// The provider calls it from request goroutines: it must be safe for
-	// concurrent use, and it must not block. Invalid audiences are skipped and
-	// logged once each, so one bad value costs only its own scope.
+	// The provider calls it from request goroutines, so it must be safe for
+	// concurrent use. It can also run more than once for a single authorization
+	// request, because both DefaultScopes() and AuthorizationURL() consult it,
+	// and it takes no context: read cached state and return, do not block on a
+	// network call. Duplicates cost nothing, and invalid audiences are skipped
+	// and logged once each, so one bad value costs only its own scope.
+	//
+	// The merged set stays within oidc.MaxScopeCount. An audience that does not
+	// fit is skipped and logged.
 	//
 	// A server that restricts scopes must list the resulting audience scopes in
 	// its supported-scopes configuration, because DefaultScopes() feeds that
@@ -310,6 +315,8 @@ func (p *Provider) Name() string {
 // scopes so callers cannot mutate the provider's slice. When
 // Config.AudienceResolver is set, the cross-client audience scopes it reports
 // are merged in, so the result can differ between calls.
+//
+// This calls the resolver, which logs any audience it skips.
 func (p *Provider) DefaultScopes() []string {
 	return p.effectiveScopes()
 }
@@ -317,32 +324,35 @@ func (p *Provider) DefaultScopes() []string {
 // effectiveScopes returns the configured scopes plus one cross-client audience
 // scope per audience that Config.AudienceResolver reports. The result is always
 // a fresh slice, so callers cannot mutate the provider's own.
+//
+// The merged set stays within oidc.MaxScopeCount, the bound NewProvider
+// enforces on the configured set, so the resolver cannot grow an authorization
+// request past what the constructor would accept. Audiences that do not fit are
+// reported as rejected.
 func (p *Provider) effectiveScopes() []string {
 	scopes := providers.CloneScopes(p.Scopes)
 	if p.audienceResolver == nil {
 		return scopes
 	}
 
-	audienceScopes, rejected := partitionAudienceScopes(p.audienceResolver())
-	p.warnRejectedAudiences(rejected)
-	if len(audienceScopes) == 0 {
+	audiences := p.audienceResolver()
+	if len(audiences) == 0 {
 		return scopes
 	}
 
-	present := make(map[string]struct{}, len(scopes)+len(audienceScopes))
+	present := make(map[string]struct{}, len(scopes)+len(audiences))
 	for _, scope := range scopes {
 		present[scope] = struct{}{}
 	}
 
-	for _, scope := range audienceScopes {
-		if _, exists := present[scope]; exists {
-			continue
-		}
-		present[scope] = struct{}{}
-		scopes = append(scopes, scope)
-	}
+	audienceScopes, rejected := partitionAudienceScopes(
+		audiences,
+		min(MaxAudienceCount, oidc.MaxScopeCount-len(scopes)),
+		present,
+	)
+	p.warnRejectedAudiences(rejected)
 
-	return scopes
+	return append(scopes, audienceScopes...)
 }
 
 // maxWarnedAudiences bounds the warnedAudiences memo. A resolver that returns
@@ -351,8 +361,9 @@ func (p *Provider) effectiveScopes() []string {
 const maxWarnedAudiences = 64
 
 // maxLoggedAudienceLength caps the audience value in a log line. A rejected
-// audience can be arbitrarily long, since length is one of the reasons to
-// reject it.
+// audience can be arbitrarily long: length is one of the reasons to reject an
+// audience, and partitionAudienceScopes rejects an over-budget audience without
+// validating it at all.
 const maxLoggedAudienceLength = 64
 
 // warnRejectedAudiences logs each rejected audience once. The resolver runs on

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -31,6 +33,16 @@ type Provider struct {
 	requestTimeout  time.Duration
 	maxGroups       int
 	logger          *slog.Logger
+
+	// audienceResolver is Config.AudienceResolver. Nil means only the static
+	// Scopes set applies.
+	audienceResolver func() []string
+
+	// warnedAudiences memoises the audiences warnRejectedAudiences has already
+	// logged, so a malformed value cannot flood the log from the per-request
+	// path. warnedAudienceCount bounds that memo.
+	warnedAudiences     sync.Map
+	warnedAudienceCount atomic.Int64
 }
 
 // Config holds Dex OAuth configuration
@@ -54,6 +66,26 @@ type Config struct {
 	// Scopes are optional custom scopes (defaults to Dex-optimized scopes if empty)
 	// Default: ["openid", "profile", "email", "groups", "offline_access"]
 	Scopes []string
+
+	// AudienceResolver reports the Dex cross-client audiences to request, as
+	// plain client IDs. The provider calls it on every authorization request and
+	// merges one AudienceScopePrefix scope per audience into both
+	// DefaultScopes() and AuthorizationURL(), so an audience that the caller
+	// learns about after startup still reaches the next login. Nil keeps the
+	// static Scopes set.
+	//
+	// Prefer this over audience scopes in Scopes whenever the audience set is
+	// not known at construction time, for example when it comes from Kubernetes
+	// resources that reconcile after the process starts.
+	//
+	// The provider calls it from request goroutines: it must be safe for
+	// concurrent use, and it must not block. Invalid audiences are skipped and
+	// logged once each, so one bad value costs only its own scope.
+	//
+	// A server that restricts scopes must list the resulting audience scopes in
+	// its supported-scopes configuration, because DefaultScopes() feeds that
+	// allowlist.
+	AudienceResolver func() []string
 
 	// HTTPClient is an optional custom HTTP client
 	HTTPClient *http.Client
@@ -153,6 +185,8 @@ func NewProvider(cfg *Config) (*Provider, error) {
 		requestTimeout:  requestTimeout,
 		maxGroups:       maxGroups,
 		logger:          logger,
+
+		audienceResolver: cfg.AudienceResolver,
 	}, nil
 }
 
@@ -273,9 +307,80 @@ func (p *Provider) Name() string {
 }
 
 // DefaultScopes returns a deep copy of the provider's configured default
-// scopes so callers cannot mutate the provider's slice.
+// scopes so callers cannot mutate the provider's slice. When
+// Config.AudienceResolver is set, the cross-client audience scopes it reports
+// are merged in, so the result can differ between calls.
 func (p *Provider) DefaultScopes() []string {
-	return providers.CloneScopes(p.Scopes)
+	return p.effectiveScopes()
+}
+
+// effectiveScopes returns the configured scopes plus one cross-client audience
+// scope per audience that Config.AudienceResolver reports. The result is always
+// a fresh slice, so callers cannot mutate the provider's own.
+func (p *Provider) effectiveScopes() []string {
+	scopes := providers.CloneScopes(p.Scopes)
+	if p.audienceResolver == nil {
+		return scopes
+	}
+
+	audienceScopes, rejected := partitionAudienceScopes(p.audienceResolver())
+	p.warnRejectedAudiences(rejected)
+	if len(audienceScopes) == 0 {
+		return scopes
+	}
+
+	present := make(map[string]struct{}, len(scopes)+len(audienceScopes))
+	for _, scope := range scopes {
+		present[scope] = struct{}{}
+	}
+
+	for _, scope := range audienceScopes {
+		if _, exists := present[scope]; exists {
+			continue
+		}
+		present[scope] = struct{}{}
+		scopes = append(scopes, scope)
+	}
+
+	return scopes
+}
+
+// maxWarnedAudiences bounds the warnedAudiences memo. A resolver that returns
+// changing invalid values stops producing warnings at this point instead of
+// growing the memo without bound.
+const maxWarnedAudiences = 64
+
+// maxLoggedAudienceLength caps the audience value in a log line. A rejected
+// audience can be arbitrarily long, since length is one of the reasons to
+// reject it.
+const maxLoggedAudienceLength = 64
+
+// warnRejectedAudiences logs each rejected audience once. The resolver runs on
+// every authorization request, so an unconditional log would let one malformed
+// value flood the log.
+func (p *Provider) warnRejectedAudiences(rejected []audienceRejection) {
+	for _, rejection := range rejected {
+		if p.warnedAudienceCount.Load() >= maxWarnedAudiences {
+			return
+		}
+		if _, loaded := p.warnedAudiences.LoadOrStore(rejection.Audience, struct{}{}); loaded {
+			continue
+		}
+		p.warnedAudienceCount.Add(1)
+
+		p.logger.Warn("Skipping invalid cross-client audience reported by AudienceResolver",
+			"audience", truncateAudienceForLog(rejection.Audience),
+			"reason", rejection.Reason)
+	}
+}
+
+// truncateAudienceForLog shortens an audience to maxLoggedAudienceLength and
+// marks the result when it cut something off.
+func truncateAudienceForLog(audience string) string {
+	if len(audience) <= maxLoggedAudienceLength {
+		return audience
+	}
+	return audience[:maxLoggedAudienceLength] + "...(truncated)"
 }
 
 // AuthorizationURL generates the Dex OAuth authorization URL with PKCE support.
@@ -306,7 +411,9 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// FilterScopes drops scopes Dex would reject ("Unrecognized scope(s)"),
 	// deep-copies the input, and force-merges mandatory scopes (openid,
 	// audience:server:client_id:*) from defaults via CopyScopes internally.
-	scopesToUse := providers.FilterScopes(scopes, p.Scopes, isDexSupportedScope)
+	// The defaults come from effectiveScopes, not from the Scopes field, so an
+	// audience that Config.AudienceResolver reports after startup is merged too.
+	scopesToUse := providers.FilterScopes(scopes, p.effectiveScopes(), isDexSupportedScope)
 
 	// Create a config with the determined scopes
 	config := *p.Config

--- a/providers/dex/doc.go
+++ b/providers/dex/doc.go
@@ -113,6 +113,33 @@
 // With this configuration, even if a client requests only ["openid", "email"], the
 // resulting authorization request will include "audience:server:client_id:dex-k8s-authenticator".
 //
+// # Audiences That Are Not Known At Startup
+//
+// Scopes is a snapshot: the provider reads it when NewProvider runs, and never
+// again. An audience that the caller learns about later never reaches an
+// authorization request, so the minted ID token carries only the provider's own
+// client and every downstream service that expects the missing audience rejects
+// it.
+//
+// Set Config.AudienceResolver for such an audience set. The provider calls it on
+// every authorization request and merges the audiences it reports into both
+// DefaultScopes() and AuthorizationURL():
+//
+//	provider, err := dex.NewProvider(&dex.Config{
+//	    IssuerURL:    "https://dex.example.com",
+//	    ClientID:     "mcp-oauth",
+//	    ClientSecret: "secret",
+//	    RedirectURL:  "http://localhost:8080/oauth/callback",
+//	    // Reads the current backend registry on every login.
+//	    AudienceResolver: registry.RequiredAudiences,
+//	})
+//
+// The resolver runs on request goroutines: it must be safe for concurrent use,
+// and it must not block. Invalid audiences are skipped and logged once each, so
+// one bad value costs only its own scope. A server that sets a supported-scopes
+// allowlist must list the resulting audience scopes, because DefaultScopes()
+// feeds that allowlist.
+//
 // Use the audience helper functions to format these scopes:
 //
 //	// Format a single audience scope (returns error for invalid input)

--- a/providers/dex/doc.go
+++ b/providers/dex/doc.go
@@ -121,8 +121,8 @@
 // client and every downstream service that expects the missing audience rejects
 // it.
 //
-// Set Config.AudienceResolver for such an audience set. The provider calls it on
-// every authorization request and merges the audiences it reports into both
+// Set Config.AudienceResolver for such an audience set. The provider calls it
+// per authorization request and merges the audiences it reports into both
 // DefaultScopes() and AuthorizationURL():
 //
 //	provider, err := dex.NewProvider(&dex.Config{
@@ -134,11 +134,20 @@
 //	    AudienceResolver: registry.RequiredAudiences,
 //	})
 //
-// The resolver runs on request goroutines: it must be safe for concurrent use,
-// and it must not block. Invalid audiences are skipped and logged once each, so
-// one bad value costs only its own scope. A server that sets a supported-scopes
-// allowlist must list the resulting audience scopes, because DefaultScopes()
-// feeds that allowlist.
+// The resolver runs on request goroutines, so it must be safe for concurrent
+// use. It can also run more than once for a single authorization request,
+// because both DefaultScopes() and AuthorizationURL() consult it, and it takes
+// no context: read cached state and return, do not block on a network call.
+//
+// Duplicates cost nothing. Invalid audiences are skipped and logged once each,
+// so one bad value costs only its own scope. The merged scope set stays within
+// oidc.MaxScopeCount, the bound NewProvider enforces on Scopes, and an audience
+// that does not fit is skipped and logged.
+//
+// A server that sets a supported-scopes allowlist must list the resulting
+// audience scopes, because DefaultScopes() feeds that allowlist. The server
+// validates that allowlist against provider defaults at startup, so an audience
+// the resolver reports later is not covered by that check.
 //
 // Use the audience helper functions to format these scopes:
 //

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -151,6 +151,13 @@ func validateStringSlice(items []string, context string, maxCount, maxLength int
 	return nil
 }
 
+// MaxScopeCount is the maximum number of scopes ValidateScopes accepts. It
+// bounds the scope set a single authorization request can carry.
+const MaxScopeCount = 50
+
+// MaxScopeLength is the maximum length ValidateScopes accepts for one scope.
+const MaxScopeLength = 256
+
 // ValidateScopes validates OAuth scopes.
 //
 // Security Considerations:
@@ -173,7 +180,7 @@ func ValidateScopes(scopes []string) error {
 	}
 
 	// Validate size and length constraints
-	return validateStringSlice(scopes, "scopes", 50, 256)
+	return validateStringSlice(scopes, "scopes", MaxScopeCount, MaxScopeLength)
 }
 
 // Default limits for groups validation.


### PR DESCRIPTION
## Description

`dex.Config.Scopes` is a construction-time snapshot. An audience the caller learns about after `NewProvider` never reached an authorization request, so the minted ID token carried only the provider's own client, and any downstream service that expects the missing audience rejected it. muster hit this on gazelle: the process started before its MCPServer resources reconciled, so every login for the rest of the process lifetime lacked the Kubernetes audience.

`Config.AudienceResolver func() []string` reports the cross-client audiences at call time. The provider merges them into `DefaultScopes()` and into `AuthorizationURL()`. Both are required: the mandatory-scope force-merge in `AuthorizationURL` reads the defaults field directly and never goes through `DefaultScopes()`, and `server.resolveScopes` reads `DefaultScopes()` when the client sends no `scope`. Nil keeps the current behaviour.

Rejection is per audience. `FormatAudienceScopes` fails the whole set when one value is malformed, which would let a single bad audience drop the audiences every other consumer depends on. The resolver path skips the invalid values, keeps the rest, and logs each rejected value once, because it runs on every authorization request.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Related to giantswarm/muster#1053

## Changes Made

- `Config.AudienceResolver`, called per authorization request; `effectiveScopes` merges and dedupes its result into the configured scopes.
- `partitionAudienceScopes` validates per entry, dedupes before it applies its limit, and reports what it skipped. Only a scope the result actually carries counts against the limit, so a duplicate cannot displace a distinct audience.
- The merged set stays within `oidc.MaxScopeCount`, the bound `NewProvider` already enforces on `Scopes`. `MaxScopeCount` and `MaxScopeLength` are now exported instead of literals inside `validateStringSlice`.
- Warnings are memoised per audience, bounded at 64 entries, with the logged value truncated at 64 characters.

## Testing

`go test ./... -race` and `go vet ./...` are clean. Tests cover the late audience through both entry points, merge and dedupe, the nil and empty resolver, invalid and over-long and over-limit entries, duplicates that would otherwise consume the limit, the merged bound against `oidc.ValidateScopes`, log-once, and the memo cap. `make lint` could not run here: golangci-lint is built with go1.26 and the repo targets 1.27.0.

## Security Considerations

- [x] Sensitive data properly handled

Validation stays in `providers/dex`, so the scope-injection guard on audience strings is unchanged. Three bounds on a per-request path: the warning memo cannot grow without bound, a rejected audience is truncated before it reaches a log line, and the merged scope set cannot exceed what the constructor accepts.

## Documentation

- [x] Updated godoc comments
- [x] Updated CHANGELOG.md

## Breaking Changes

**None**

## Additional Notes

Consumers should pass audiences through the resolver rather than pre-formatted audience scopes in `Scopes`. muster drops its local provider wrapper once this is released.

Two known limits, both out of scope here. The resolver takes no context, because neither `DefaultScopes()` nor `AuthorizationURL()` carries one on the `providers.Provider` interface; a context-aware resolver needs that interface to change first. And `validateProviderDefaultScopes` runs at startup, so a server that sets `SupportedScopes` gets no warning for an audience the resolver reports later, and a client that requests that scope explicitly still gets `unsupported scope`. Treating audience scopes as always supported would fix that in the server.
