### PR TITLE
feat(dex): send the configured scope set to the IdP, and make audience scopes optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dex.Config.AudienceResolver`, an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it per authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` reaches the next login. Nil keeps the previous behaviour. Duplicates are dropped, invalid audiences are skipped and logged once each, and the merged set stays within `oidc.MaxScopeCount`.
 - `oidc.MaxScopeCount` and `oidc.MaxScopeLength`, the bounds `oidc.ValidateScopes` already applied.
+- `dex.Config.AllowedScopes`, which replaces the scopes the provider forwards to the IdP. Empty keeps the built-in allowlist (`openid`, `profile`, `email`, `offline_access`, `groups`, `federated:id`). `openid` always passes.
+- `dex.Config.DisableScopeFilter`, which forwards every requested scope unchanged.
+- `dex.Config.DisableCrossClientAudienceScopes`, which drops every `audience:server:client_id:` scope from `Scopes`, from every requested set, and turns off `AudienceResolver`. Unset keeps the previous behaviour.
+- `dex.DefaultScopes` and `dex.DefaultAllowedScopes`, which return the built-in requested set and the built-in allowlist, so a caller can extend either instead of restating it.
 
 ## [1.1.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dex.Config.AudienceResolver`, an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it per authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` reaches the next login. Nil keeps the previous behaviour. Duplicates are dropped, invalid audiences are skipped and logged once each, and the merged set stays within `oidc.MaxScopeCount`.
 - `oidc.MaxScopeCount` and `oidc.MaxScopeLength`, the bounds `oidc.ValidateScopes` already applied.
 - `dex.Config.AllowedScopes`, which replaces the scopes the provider forwards to the IdP. Empty keeps the built-in allowlist (`openid`, `profile`, `email`, `offline_access`, `groups`, `federated:id`). `openid` always passes.
-- `dex.Config.DisableScopeFilter`, which forwards every requested scope unchanged.
+- `dex.Config.MandatoryScopes`, which replaces the entries of `Scopes` merged into a request that names scopes of its own. Empty keeps the built-in set (`openid`, `profile`, `email`, `groups`, `offline_access`). `openid` and cross-client audience scopes are always mandatory.
 - `dex.Config.DisableCrossClientAudienceScopes`, which drops every `audience:server:client_id:` scope from `Scopes`, from every requested set, and turns off `AudienceResolver`. Unset keeps the previous behaviour.
-- `dex.DefaultScopes` and `dex.DefaultAllowedScopes`, which return the built-in requested set and the built-in allowlist, so a caller can extend either instead of restating it.
+- `providers.FilterScopesFunc`, which is `FilterScopes` with a caller-supplied mandatory-scope predicate. A nil predicate keeps the built-in set, so `FilterScopes` and `CopyScopes` are unchanged.
 
 ## [1.1.0] - 2026-07-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `dex.Config.AudienceResolver`, an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it per authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` reaches the next login. Nil keeps the previous behaviour. Duplicates are dropped, invalid audiences are skipped and logged once each, and the merged set stays within `oidc.MaxScopeCount`.
 - `oidc.MaxScopeCount` and `oidc.MaxScopeLength`, the bounds `oidc.ValidateScopes` already applied.
-- `dex.Config.AllowedScopes`, which replaces the scopes the provider forwards to the IdP. Empty keeps the built-in allowlist (`openid`, `profile`, `email`, `offline_access`, `groups`, `federated:id`). `openid` always passes.
-- `dex.Config.MandatoryScopes`, which replaces the entries of `Scopes` merged into a request that names scopes of its own. Empty keeps the built-in set (`openid`, `profile`, `email`, `groups`, `offline_access`). `openid` and cross-client audience scopes are always mandatory.
 - `dex.Config.DisableCrossClientAudienceScopes`, which drops every `audience:server:client_id:` scope from `Scopes`, from every requested set, and turns off `AudienceResolver`. Unset keeps the previous behaviour.
 - `providers.FilterScopesFunc`, which is `FilterScopes` with a caller-supplied mandatory-scope predicate. A nil predicate keeps the built-in set, so `FilterScopes` and `CopyScopes` are unchanged.
+
+### Changed
+
+- `dex.Config.Scopes` is now the complete set the Dex provider sends. Every entry reaches the IdP on every authorization request, and a scope a client asks for that the set does not hold is dropped. Previously two hardcoded lists decided this: a configured scope outside `openid`, `profile`, `email`, `groups` and `offline_access` reached the IdP only for a client that named no scopes at all, and `federated:id` was accepted from any client whether or not `Scopes` held it. Configure `federated:id` in `Scopes` to keep sending it. A caller that leaves `Scopes` at the default is otherwise unaffected.
+- `dex.DefaultScopes()` now reports exactly the set the provider forwards, so a scope it names can no longer be recorded as granted while the IdP never receives it.
+
+### Fixed
+
+- The Dex provider now adds `openid` to an authorization request whose scope set omits it. `ensureOpenIDScope` was never called on that path, so a `Config.Scopes` without `openid` produced a request that was not an OIDC request.
 
 ## [1.1.0] - 2026-07-16
 

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -38,9 +38,12 @@ type Provider struct {
 	// Scopes set applies.
 	audienceResolver func() []string
 
-	// scopeFilter reports whether a scope reaches the IdP. Nil forwards every
-	// scope.
+	// scopeFilter reports whether a scope reaches the IdP.
 	scopeFilter func(string) bool
+
+	// mandatoryScopeFilter reports whether a configured scope is merged into
+	// every authorization request. Nil applies the built-in set.
+	mandatoryScopeFilter func(string) bool
 
 	// audienceScopesEnabled reports whether cross-client audience scopes reach
 	// the IdP. False also turns off audienceResolver.
@@ -75,16 +78,16 @@ type Config struct {
 	// Default: ["openid", "profile", "email", "groups", "offline_access"]
 	//
 	// This is the set the provider requests when the client asks for none, and
-	// the set mandatory-scope merging draws from. DefaultScopes returns the
-	// default value. An IdP that rejects one of the defaults (Keycloak has no
-	// groups scope unless an operator adds one) needs a set configured here.
+	// the set MandatoryScopes draws from. An IdP that rejects one of the
+	// defaults (Keycloak has no groups scope unless an operator adds one) needs
+	// a set configured here.
 	Scopes []string
 
 	// AllowedScopes replaces the scopes the provider forwards to the IdP. Every
 	// other scope is dropped from the authorization request, silently, because
 	// an IdP that rejects one unknown scope rejects the whole request.
 	//
-	// Empty uses DefaultAllowedScopes: the standard OIDC scopes plus the
+	// Empty keeps the built-in allowlist: the standard OIDC scopes plus the
 	// Dex-only groups and federated:id. "openid" is always allowed, whatever
 	// this list holds. Cross-client audience scopes are governed by
 	// DisableCrossClientAudienceScopes, not by this list.
@@ -94,15 +97,19 @@ type Config struct {
 	// application scopes.
 	AllowedScopes []string
 
-	// DisableScopeFilter forwards every requested scope to the IdP unchanged,
-	// so no allowlist applies. Use it when the caller already restricts the
-	// scopes it accepts and the IdP vocabulary is not known in advance.
-	// NewProvider rejects it together with AllowedScopes, because one of the
-	// two would have no effect.
+	// MandatoryScopes are the entries of Scopes the provider merges into every
+	// authorization request, whatever the client asks for. A configured scope
+	// outside this set reaches the IdP only when the client requests no scopes
+	// of its own.
 	//
-	// Cross-client audience scopes are still dropped when
-	// DisableCrossClientAudienceScopes is set.
-	DisableScopeFilter bool
+	// Empty keeps the built-in set: openid, profile, email, groups and
+	// offline_access. "openid" and cross-client audience scopes are always
+	// mandatory, whatever this list holds.
+	//
+	// Set this alongside AllowedScopes, or an IdP scope the built-in set does
+	// not name (a Keycloak "roles") reaches the IdP only for a client that
+	// names no scopes at all.
+	MandatoryScopes []string
 
 	// DisableCrossClientAudienceScopes stops the provider from sending Dex
 	// cross-client audience scopes (AudienceScopePrefix). It drops them from
@@ -197,7 +204,12 @@ func NewProvider(cfg *Config) (*Provider, error) {
 
 	audienceScopesEnabled := !cfg.DisableCrossClientAudienceScopes
 
-	scopeFilter, err := newScopeFilter(cfg.AllowedScopes, cfg.DisableScopeFilter, audienceScopesEnabled)
+	scopeFilter, err := newScopeFilter(cfg.AllowedScopes, audienceScopesEnabled)
+	if err != nil {
+		return nil, err
+	}
+
+	mandatoryScopeFilter, err := newMandatoryScopeFilter(cfg.MandatoryScopes)
 	if err != nil {
 		return nil, err
 	}
@@ -249,6 +261,7 @@ func NewProvider(cfg *Config) (*Provider, error) {
 
 		audienceResolver:      cfg.AudienceResolver,
 		scopeFilter:           scopeFilter,
+		mandatoryScopeFilter:  mandatoryScopeFilter,
 		audienceScopesEnabled: audienceScopesEnabled,
 	}, nil
 }
@@ -308,51 +321,19 @@ var defaultAllowedScopes = []string{
 	"federated:id",
 }
 
-// DefaultScopes returns the scopes NewProvider requests when Config.Scopes is
-// empty. Use it to build a custom set on top of the defaults.
-//
-// Provider.DefaultScopes returns what one provider actually requests, which
-// includes any cross-client audience scope.
-func DefaultScopes() []string {
-	return providers.CloneScopes(defaultDexScopes)
-}
-
-// DefaultAllowedScopes returns the scope allowlist the provider applies when
-// Config.AllowedScopes is empty. Use it to extend the defaults instead of
-// replacing them.
-func DefaultAllowedScopes() []string {
-	return providers.CloneScopes(defaultAllowedScopes)
-}
-
-// newScopeFilter builds the predicate AuthorizationURL applies to the merged
-// scope set. A nil predicate forwards every scope.
+// newScopeFilter builds the predicate that decides which scopes reach the IdP.
 //
 // "openid" always passes, whatever allowedScopes holds: OIDC requires it on
 // every authorization request.
-func newScopeFilter(allowedScopes []string, disableFilter bool, audienceScopesEnabled bool) (func(string) bool, error) {
+func newScopeFilter(allowedScopes []string, audienceScopesEnabled bool) (func(string) bool, error) {
 	if err := oidc.ValidateScopes(allowedScopes); err != nil {
 		return nil, fmt.Errorf("invalid allowed scopes: %w", err)
-	}
-	if disableFilter && len(allowedScopes) > 0 {
-		return nil, fmt.Errorf("AllowedScopes and DisableScopeFilter are mutually exclusive")
-	}
-
-	if disableFilter {
-		if audienceScopesEnabled {
-			return nil, nil
-		}
-		return func(scope string) bool {
-			return !strings.HasPrefix(scope, AudienceScopePrefix)
-		}, nil
 	}
 
 	if len(allowedScopes) == 0 {
 		allowedScopes = defaultAllowedScopes
 	}
-	allowed := make(map[string]struct{}, len(allowedScopes))
-	for _, scope := range allowedScopes {
-		allowed[scope] = struct{}{}
-	}
+	allowed := scopeSet(allowedScopes)
 
 	return func(scope string) bool {
 		if scope == scopeOpenID {
@@ -364,6 +345,41 @@ func newScopeFilter(allowedScopes []string, disableFilter bool, audienceScopesEn
 		_, ok := allowed[scope]
 		return ok
 	}, nil
+}
+
+// newMandatoryScopeFilter builds the predicate that decides which configured
+// scopes are merged into every authorization request. A nil result applies the
+// built-in set that providers.FilterScopesFunc takes for a nil predicate.
+//
+// Audience scopes stay mandatory: effectiveScopes has already dropped them when
+// Config.DisableCrossClientAudienceScopes is set, so none reaches this point
+// unless the caller wants it forwarded.
+func newMandatoryScopeFilter(mandatoryScopes []string) (func(string) bool, error) {
+	if err := oidc.ValidateScopes(mandatoryScopes); err != nil {
+		return nil, fmt.Errorf("invalid mandatory scopes: %w", err)
+	}
+	if len(mandatoryScopes) == 0 {
+		return nil, nil
+	}
+
+	mandatory := scopeSet(mandatoryScopes)
+
+	return func(scope string) bool {
+		if scope == scopeOpenID || strings.HasPrefix(scope, AudienceScopePrefix) {
+			return true
+		}
+		_, ok := mandatory[scope]
+		return ok
+	}, nil
+}
+
+// scopeSet indexes scopes for membership tests.
+func scopeSet(scopes []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		set[scope] = struct{}{}
+	}
+	return set
 }
 
 // resolveScopes returns validated scopes, using defaults if none provided.
@@ -559,8 +575,8 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// audience:server:client_id:*) from defaults via CopyScopes internally.
 	// The defaults come from effectiveScopes, not from the Scopes field, so an
 	// audience that Config.AudienceResolver reports after startup is merged too.
-	// A nil p.scopeFilter forwards every merged scope.
-	scopesToUse := providers.FilterScopes(scopes, p.effectiveScopes(), p.scopeFilter)
+	// A nil p.mandatoryScopeFilter applies the built-in mandatory set.
+	scopesToUse := providers.FilterScopesFunc(scopes, p.effectiveScopes(), p.scopeFilter, p.mandatoryScopeFilter)
 
 	// Create a config with the determined scopes
 	config := *p.Config

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -38,12 +39,10 @@ type Provider struct {
 	// Scopes set applies.
 	audienceResolver func() []string
 
-	// scopeFilter reports whether a scope reaches the IdP.
+	// scopeFilter reports whether a scope reaches the IdP. It accepts every
+	// entry of Scopes, so DefaultScopes() never reports a scope the filter
+	// would drop.
 	scopeFilter func(string) bool
-
-	// mandatoryScopeFilter reports whether a configured scope is merged into
-	// every authorization request. Nil applies the built-in set.
-	mandatoryScopeFilter func(string) bool
 
 	// audienceScopesEnabled reports whether cross-client audience scopes reach
 	// the IdP. False also turns off audienceResolver.
@@ -74,46 +73,29 @@ type Config struct {
 	// When set, bypasses the Dex connector selection UI
 	ConnectorID string
 
-	// Scopes are optional custom scopes (defaults to Dex-optimized scopes if empty)
-	// Default: ["openid", "profile", "email", "groups", "offline_access"]
+	// Scopes is the complete set the provider forwards to the IdP. Empty keeps
+	// the Dex-optimized default: ["openid", "profile", "email", "groups",
+	// "offline_access"].
 	//
-	// This is the set the provider requests when the client asks for none, and
-	// the set MandatoryScopes draws from. An IdP that rejects one of the
-	// defaults (Keycloak has no groups scope unless an operator adds one) needs
-	// a set configured here.
+	// Every entry is sent on every authorization request, whatever the client
+	// asks for, because the provider consumes the claims itself: email
+	// identifies the user and groups drives RBAC, so a client that asked for
+	// less would leave authorization deciding on missing claims. A scope a
+	// client names that this set does not hold is dropped, silently, because an
+	// IdP that receives one scope it does not know rejects the whole request.
+	//
+	// "openid" is always sent. Cross-client audience scopes are governed by
+	// AudienceResolver and DisableCrossClientAudienceScopes.
+	//
+	// An IdP that rejects one of the defaults needs a set configured here.
+	// Keycloak has no groups scope until an operator adds a client scope of
+	// that name, and Entra ID has no equivalent at all.
 	Scopes []string
-
-	// AllowedScopes replaces the scopes the provider forwards to the IdP. Every
-	// other scope is dropped from the authorization request, silently, because
-	// an IdP that rejects one unknown scope rejects the whole request.
-	//
-	// Empty keeps the built-in allowlist: the standard OIDC scopes plus the
-	// Dex-only groups and federated:id. "openid" is always allowed, whatever
-	// this list holds. Cross-client audience scopes are governed by
-	// DisableCrossClientAudienceScopes, not by this list.
-	//
-	// Set this for an IdP whose scope vocabulary differs from Dex's, for
-	// example Keycloak realm scopes (roles, organization) or Entra ID
-	// application scopes.
-	AllowedScopes []string
-
-	// MandatoryScopes are the entries of Scopes the provider merges into every
-	// authorization request, whatever the client asks for. A configured scope
-	// outside this set reaches the IdP only when the client requests no scopes
-	// of its own.
-	//
-	// Empty keeps the built-in set: openid, profile, email, groups and
-	// offline_access. "openid" and cross-client audience scopes are always
-	// mandatory, whatever this list holds.
-	//
-	// Set this alongside AllowedScopes, or an IdP scope the built-in set does
-	// not name (a Keycloak "roles") reaches the IdP only for a client that
-	// names no scopes at all.
-	MandatoryScopes []string
 
 	// DisableCrossClientAudienceScopes stops the provider from sending Dex
 	// cross-client audience scopes (AudienceScopePrefix). It drops them from
 	// Scopes, from every requested set, and it turns off AudienceResolver.
+	// DefaultScopes() drops them too, so it keeps reporting what is forwarded.
 	//
 	// Set it for any issuer that is not Dex. The scope shape is a Dex
 	// extension: Keycloak and Entra ID reject the whole authorization request
@@ -204,15 +186,7 @@ func NewProvider(cfg *Config) (*Provider, error) {
 
 	audienceScopesEnabled := !cfg.DisableCrossClientAudienceScopes
 
-	scopeFilter, err := newScopeFilter(cfg.AllowedScopes, audienceScopesEnabled)
-	if err != nil {
-		return nil, err
-	}
-
-	mandatoryScopeFilter, err := newMandatoryScopeFilter(cfg.MandatoryScopes)
-	if err != nil {
-		return nil, err
-	}
+	scopeFilter := newScopeFilter(scopes, audienceScopesEnabled)
 
 	logger := cfg.Logger
 	if logger == nil {
@@ -261,7 +235,6 @@ func NewProvider(cfg *Config) (*Provider, error) {
 
 		audienceResolver:      cfg.AudienceResolver,
 		scopeFilter:           scopeFilter,
-		mandatoryScopeFilter:  mandatoryScopeFilter,
 		audienceScopesEnabled: audienceScopesEnabled,
 	}, nil
 }
@@ -309,31 +282,18 @@ var defaultDexScopes = []string{
 	"offline_access", // Required for refresh tokens
 }
 
-// defaultAllowedScopes are the scopes the provider forwards when
-// Config.AllowedScopes is empty: the standard OIDC scopes plus the Dex-only
-// groups and federated:id.
-var defaultAllowedScopes = []string{
-	scopeOpenID,
-	"profile",
-	"email",
-	"offline_access",
-	"groups",
-	"federated:id",
-}
-
 // newScopeFilter builds the predicate that decides which scopes reach the IdP.
+// It accepts the configured set and nothing else, so DefaultScopes() reports
+// exactly what the provider forwards and a client cannot add a scope the
+// operator did not configure.
 //
-// "openid" always passes, whatever allowedScopes holds: OIDC requires it on
+// "openid" always passes, whatever Config.Scopes holds: OIDC requires it on
 // every authorization request.
-func newScopeFilter(allowedScopes []string, audienceScopesEnabled bool) (func(string) bool, error) {
-	if err := oidc.ValidateScopes(allowedScopes); err != nil {
-		return nil, fmt.Errorf("invalid allowed scopes: %w", err)
+func newScopeFilter(configuredScopes []string, audienceScopesEnabled bool) func(string) bool {
+	allowed := make(map[string]struct{}, len(configuredScopes))
+	for _, scope := range configuredScopes {
+		allowed[scope] = struct{}{}
 	}
-
-	if len(allowedScopes) == 0 {
-		allowedScopes = defaultAllowedScopes
-	}
-	allowed := scopeSet(allowedScopes)
 
 	return func(scope string) bool {
 		if scope == scopeOpenID {
@@ -344,45 +304,17 @@ func newScopeFilter(allowedScopes []string, audienceScopesEnabled bool) (func(st
 		}
 		_, ok := allowed[scope]
 		return ok
-	}, nil
+	}
 }
 
-// newMandatoryScopeFilter builds the predicate that decides which configured
-// scopes are merged into every authorization request. A nil result applies the
-// built-in set that providers.FilterScopesFunc takes for a nil predicate.
-//
-// Audience scopes stay mandatory: effectiveScopes has already dropped them when
-// Config.DisableCrossClientAudienceScopes is set, so none reaches this point
-// unless the caller wants it forwarded.
-func newMandatoryScopeFilter(mandatoryScopes []string) (func(string) bool, error) {
-	if err := oidc.ValidateScopes(mandatoryScopes); err != nil {
-		return nil, fmt.Errorf("invalid mandatory scopes: %w", err)
-	}
-	if len(mandatoryScopes) == 0 {
-		return nil, nil
-	}
+// alwaysMandatory reports every scope as mandatory, so FilterScopesFunc merges
+// the whole configured set into a request that names scopes of its own. The
+// provider consumes the claims those scopes carry, so a client cannot narrow
+// the set below what the operator configured.
+func alwaysMandatory(string) bool { return true }
 
-	mandatory := scopeSet(mandatoryScopes)
-
-	return func(scope string) bool {
-		if scope == scopeOpenID || strings.HasPrefix(scope, AudienceScopePrefix) {
-			return true
-		}
-		_, ok := mandatory[scope]
-		return ok
-	}, nil
-}
-
-// scopeSet indexes scopes for membership tests.
-func scopeSet(scopes []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(scopes))
-	for _, scope := range scopes {
-		set[scope] = struct{}{}
-	}
-	return set
-}
-
-// resolveScopes returns validated scopes, using defaults if none provided.
+// resolveScopes returns the validated always-sent scope set, falling back to
+// defaultDexScopes when the caller configured none.
 func resolveScopes(configScopes []string) ([]string, error) {
 	scopes := configScopes
 	if len(scopes) == 0 {
@@ -497,13 +429,9 @@ func (p *Provider) effectiveScopes() []string {
 // withoutAudienceScopes returns scopes with every cross-client audience scope
 // removed. It filters in place, so the caller must pass a slice it owns.
 func withoutAudienceScopes(scopes []string) []string {
-	kept := scopes[:0]
-	for _, scope := range scopes {
-		if !strings.HasPrefix(scope, AudienceScopePrefix) {
-			kept = append(kept, scope)
-		}
-	}
-	return kept
+	return slices.DeleteFunc(scopes, func(scope string) bool {
+		return strings.HasPrefix(scope, AudienceScopePrefix)
+	})
 }
 
 // maxWarnedAudiences bounds the warnedAudiences memo. A resolver that returns
@@ -570,13 +498,12 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// Apply optional OIDC parameters (Dex supports standard OIDC params)
 	authCodeOpts = append(authCodeOpts, providers.ApplyAuthorizationURLOptions(authOpts)...)
 
-	// FilterScopes drops scopes the IdP would reject ("Unrecognized scope(s)"),
-	// deep-copies the input, and force-merges mandatory scopes (openid,
-	// audience:server:client_id:*) from defaults via CopyScopes internally.
-	// The defaults come from effectiveScopes, not from the Scopes field, so an
-	// audience that Config.AudienceResolver reports after startup is merged too.
-	// A nil p.mandatoryScopeFilter applies the built-in mandatory set.
-	scopesToUse := providers.FilterScopesFunc(scopes, p.effectiveScopes(), p.scopeFilter, p.mandatoryScopeFilter)
+	// FilterScopesFunc deep-copies the input, merges the always-sent set into
+	// it, then drops what the IdP would reject ("Unrecognized scope(s)").
+	// The always-sent set comes from effectiveScopes, not from the Scopes
+	// field, so an audience that Config.AudienceResolver reports after startup
+	// is merged too.
+	scopesToUse := ensureOpenIDScope(providers.FilterScopesFunc(scopes, p.effectiveScopes(), p.scopeFilter, alwaysMandatory))
 
 	// Create a config with the determined scopes
 	config := *p.Config
@@ -589,10 +516,8 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 // and this ensures it is always included even if both the client and provider
 // defaults somehow omit it.
 func ensureOpenIDScope(scopes []string) []string {
-	for _, s := range scopes {
-		if s == scopeOpenID {
-			return scopes
-		}
+	if slices.Contains(scopes, scopeOpenID) {
+		return scopes
 	}
 	return append(scopes, scopeOpenID)
 }

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -38,6 +38,14 @@ type Provider struct {
 	// Scopes set applies.
 	audienceResolver func() []string
 
+	// scopeFilter reports whether a scope reaches the IdP. Nil forwards every
+	// scope.
+	scopeFilter func(string) bool
+
+	// audienceScopesEnabled reports whether cross-client audience scopes reach
+	// the IdP. False also turns off audienceResolver.
+	audienceScopesEnabled bool
+
 	// warnedAudiences memoises the audiences warnRejectedAudiences has already
 	// logged, so a malformed value cannot flood the log from the per-request
 	// path. warnedAudienceCount bounds that memo.
@@ -65,7 +73,45 @@ type Config struct {
 
 	// Scopes are optional custom scopes (defaults to Dex-optimized scopes if empty)
 	// Default: ["openid", "profile", "email", "groups", "offline_access"]
+	//
+	// This is the set the provider requests when the client asks for none, and
+	// the set mandatory-scope merging draws from. DefaultScopes returns the
+	// default value. An IdP that rejects one of the defaults (Keycloak has no
+	// groups scope unless an operator adds one) needs a set configured here.
 	Scopes []string
+
+	// AllowedScopes replaces the scopes the provider forwards to the IdP. Every
+	// other scope is dropped from the authorization request, silently, because
+	// an IdP that rejects one unknown scope rejects the whole request.
+	//
+	// Empty uses DefaultAllowedScopes: the standard OIDC scopes plus the
+	// Dex-only groups and federated:id. "openid" is always allowed, whatever
+	// this list holds. Cross-client audience scopes are governed by
+	// DisableCrossClientAudienceScopes, not by this list.
+	//
+	// Set this for an IdP whose scope vocabulary differs from Dex's, for
+	// example Keycloak realm scopes (roles, organization) or Entra ID
+	// application scopes.
+	AllowedScopes []string
+
+	// DisableScopeFilter forwards every requested scope to the IdP unchanged,
+	// so no allowlist applies. Use it when the caller already restricts the
+	// scopes it accepts and the IdP vocabulary is not known in advance.
+	// NewProvider rejects it together with AllowedScopes, because one of the
+	// two would have no effect.
+	//
+	// Cross-client audience scopes are still dropped when
+	// DisableCrossClientAudienceScopes is set.
+	DisableScopeFilter bool
+
+	// DisableCrossClientAudienceScopes stops the provider from sending Dex
+	// cross-client audience scopes (AudienceScopePrefix). It drops them from
+	// Scopes, from every requested set, and it turns off AudienceResolver.
+	//
+	// Set it for any issuer that is not Dex. The scope shape is a Dex
+	// extension: Keycloak and Entra ID reject the whole authorization request
+	// when they receive one.
+	DisableCrossClientAudienceScopes bool
 
 	// AudienceResolver reports the Dex cross-client audiences to request, as
 	// plain client IDs. The provider merges one AudienceScopePrefix scope per
@@ -83,6 +129,9 @@ type Config struct {
 	// and it takes no context: read cached state and return, do not block on a
 	// network call. Duplicates cost nothing, and invalid audiences are skipped
 	// and logged once each, so one bad value costs only its own scope.
+	//
+	// DisableCrossClientAudienceScopes turns the resolver off: the provider
+	// never calls it and no audience scope reaches the IdP.
 	//
 	// The merged set stays within oidc.MaxScopeCount. An audience that does not
 	// fit is skipped and logged.
@@ -146,6 +195,13 @@ func NewProvider(cfg *Config) (*Provider, error) {
 		return nil, err
 	}
 
+	audienceScopesEnabled := !cfg.DisableCrossClientAudienceScopes
+
+	scopeFilter, err := newScopeFilter(cfg.AllowedScopes, cfg.DisableScopeFilter, audienceScopesEnabled)
+	if err != nil {
+		return nil, err
+	}
+
 	logger := cfg.Logger
 	if logger == nil {
 		logger = slog.Default()
@@ -191,7 +247,9 @@ func NewProvider(cfg *Config) (*Provider, error) {
 		maxGroups:       maxGroups,
 		logger:          logger,
 
-		audienceResolver: cfg.AudienceResolver,
+		audienceResolver:      cfg.AudienceResolver,
+		scopeFilter:           scopeFilter,
+		audienceScopesEnabled: audienceScopesEnabled,
 	}, nil
 }
 
@@ -238,15 +296,74 @@ var defaultDexScopes = []string{
 	"offline_access", // Required for refresh tokens
 }
 
-// isDexSupportedScope returns true if the scope is recognized by Dex.
-// Supported: standard OIDC scopes, Dex-specific scopes, and cross-client audience scopes.
-func isDexSupportedScope(scope string) bool {
-	switch scope {
-	case scopeOpenID, "profile", "email", "offline_access", "groups", "federated:id":
-		return true
-	default:
-		return strings.HasPrefix(scope, AudienceScopePrefix)
+// defaultAllowedScopes are the scopes the provider forwards when
+// Config.AllowedScopes is empty: the standard OIDC scopes plus the Dex-only
+// groups and federated:id.
+var defaultAllowedScopes = []string{
+	scopeOpenID,
+	"profile",
+	"email",
+	"offline_access",
+	"groups",
+	"federated:id",
+}
+
+// DefaultScopes returns the scopes NewProvider requests when Config.Scopes is
+// empty. Use it to build a custom set on top of the defaults.
+//
+// Provider.DefaultScopes returns what one provider actually requests, which
+// includes any cross-client audience scope.
+func DefaultScopes() []string {
+	return providers.CloneScopes(defaultDexScopes)
+}
+
+// DefaultAllowedScopes returns the scope allowlist the provider applies when
+// Config.AllowedScopes is empty. Use it to extend the defaults instead of
+// replacing them.
+func DefaultAllowedScopes() []string {
+	return providers.CloneScopes(defaultAllowedScopes)
+}
+
+// newScopeFilter builds the predicate AuthorizationURL applies to the merged
+// scope set. A nil predicate forwards every scope.
+//
+// "openid" always passes, whatever allowedScopes holds: OIDC requires it on
+// every authorization request.
+func newScopeFilter(allowedScopes []string, disableFilter bool, audienceScopesEnabled bool) (func(string) bool, error) {
+	if err := oidc.ValidateScopes(allowedScopes); err != nil {
+		return nil, fmt.Errorf("invalid allowed scopes: %w", err)
 	}
+	if disableFilter && len(allowedScopes) > 0 {
+		return nil, fmt.Errorf("AllowedScopes and DisableScopeFilter are mutually exclusive")
+	}
+
+	if disableFilter {
+		if audienceScopesEnabled {
+			return nil, nil
+		}
+		return func(scope string) bool {
+			return !strings.HasPrefix(scope, AudienceScopePrefix)
+		}, nil
+	}
+
+	if len(allowedScopes) == 0 {
+		allowedScopes = defaultAllowedScopes
+	}
+	allowed := make(map[string]struct{}, len(allowedScopes))
+	for _, scope := range allowedScopes {
+		allowed[scope] = struct{}{}
+	}
+
+	return func(scope string) bool {
+		if scope == scopeOpenID {
+			return true
+		}
+		if strings.HasPrefix(scope, AudienceScopePrefix) {
+			return audienceScopesEnabled
+		}
+		_, ok := allowed[scope]
+		return ok
+	}, nil
 }
 
 // resolveScopes returns validated scopes, using defaults if none provided.
@@ -329,8 +446,14 @@ func (p *Provider) DefaultScopes() []string {
 // enforces on the configured set, so the resolver cannot grow an authorization
 // request past what the constructor would accept. Audiences that do not fit are
 // reported as rejected.
+//
+// Config.DisableCrossClientAudienceScopes drops every audience scope instead,
+// the configured ones included, and the resolver never runs.
 func (p *Provider) effectiveScopes() []string {
 	scopes := providers.CloneScopes(p.Scopes)
+	if !p.audienceScopesEnabled {
+		return withoutAudienceScopes(scopes)
+	}
 	if p.audienceResolver == nil {
 		return scopes
 	}
@@ -353,6 +476,18 @@ func (p *Provider) effectiveScopes() []string {
 	p.warnRejectedAudiences(rejected)
 
 	return append(scopes, audienceScopes...)
+}
+
+// withoutAudienceScopes returns scopes with every cross-client audience scope
+// removed. It filters in place, so the caller must pass a slice it owns.
+func withoutAudienceScopes(scopes []string) []string {
+	kept := scopes[:0]
+	for _, scope := range scopes {
+		if !strings.HasPrefix(scope, AudienceScopePrefix) {
+			kept = append(kept, scope)
+		}
+	}
+	return kept
 }
 
 // maxWarnedAudiences bounds the warnedAudiences memo. A resolver that returns
@@ -419,12 +554,13 @@ func (p *Provider) AuthorizationURL(state string, codeChallenge string, codeChal
 	// Apply optional OIDC parameters (Dex supports standard OIDC params)
 	authCodeOpts = append(authCodeOpts, providers.ApplyAuthorizationURLOptions(authOpts)...)
 
-	// FilterScopes drops scopes Dex would reject ("Unrecognized scope(s)"),
+	// FilterScopes drops scopes the IdP would reject ("Unrecognized scope(s)"),
 	// deep-copies the input, and force-merges mandatory scopes (openid,
 	// audience:server:client_id:*) from defaults via CopyScopes internally.
 	// The defaults come from effectiveScopes, not from the Scopes field, so an
 	// audience that Config.AudienceResolver reports after startup is merged too.
-	scopesToUse := providers.FilterScopes(scopes, p.effectiveScopes(), isDexSupportedScope)
+	// A nil p.scopeFilter forwards every merged scope.
+	scopesToUse := providers.FilterScopes(scopes, p.effectiveScopes(), p.scopeFilter)
 
 	// Create a config with the determined scopes
 	config := *p.Config

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -464,7 +464,7 @@ func TestEnsureOpenIDScope(t *testing.T) {
 
 // TestDefaultScopeFilter tests the default scope classification.
 func TestDefaultScopeFilter(t *testing.T) {
-	supported, err := newScopeFilter(nil, false, true)
+	supported, err := newScopeFilter(nil, true)
 	if err != nil {
 		t.Fatalf("newScopeFilter() error = %v", err)
 	}

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -462,8 +462,13 @@ func TestEnsureOpenIDScope(t *testing.T) {
 	}
 }
 
-// TestIsDexSupportedScope tests the scope classification function.
-func TestIsDexSupportedScope(t *testing.T) {
+// TestDefaultScopeFilter tests the default scope classification.
+func TestDefaultScopeFilter(t *testing.T) {
+	supported, err := newScopeFilter(nil, false, true)
+	if err != nil {
+		t.Fatalf("newScopeFilter() error = %v", err)
+	}
+
 	tests := []struct {
 		scope    string
 		expected bool
@@ -483,8 +488,8 @@ func TestIsDexSupportedScope(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.scope, func(t *testing.T) {
-			if got := isDexSupportedScope(tt.scope); got != tt.expected {
-				t.Errorf("isDexSupportedScope(%q) = %v, want %v", tt.scope, got, tt.expected)
+			if got := supported(tt.scope); got != tt.expected {
+				t.Errorf("scope filter(%q) = %v, want %v", tt.scope, got, tt.expected)
 			}
 		})
 	}

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -464,10 +464,7 @@ func TestEnsureOpenIDScope(t *testing.T) {
 
 // TestDefaultScopeFilter tests the default scope classification.
 func TestDefaultScopeFilter(t *testing.T) {
-	supported, err := newScopeFilter(nil, true)
-	if err != nil {
-		t.Fatalf("newScopeFilter() error = %v", err)
-	}
+	supported := newScopeFilter(defaultDexScopes, true)
 
 	tests := []struct {
 		scope    string
@@ -478,7 +475,8 @@ func TestDefaultScopeFilter(t *testing.T) {
 		{"email", true},
 		{"offline_access", true},
 		{"groups", true},
-		{"federated:id", true},
+		// Dex accepts federated:id, but Config.Scopes has to name it.
+		{"federated:id", false},
 		{"audience:server:client_id:test", true},
 		{"audience:server:client_id:k8s-auth", true},
 		{"claudeai", false},

--- a/providers/dex/doc.go
+++ b/providers/dex/doc.go
@@ -80,22 +80,19 @@
 //
 // # Scope Filtering
 //
-// The provider drops every scope outside an allowlist before it builds the
-// authorization request, because an IdP that receives one scope it does not
-// know rejects the whole request. The built-in allowlist is openid, profile,
-// email, offline_access, groups and federated:id. Cross-client audience scopes
-// pass as well.
+// Config.Scopes is the complete set that reaches the IdP. Every entry is sent
+// on every authorization request, whatever the client asks for, and a scope a
+// client names that the set does not hold is dropped, silently, because an IdP
+// that receives one scope it does not know rejects the whole request.
 //
-// The drop is silent, so a scope an IdP needs but the allowlist does not hold
-// never reaches it. Config.AllowedScopes replaces the list. "openid" always
-// passes.
+// The provider forwards the whole set because it consumes the claims itself:
+// email identifies the user and groups drives RBAC. A client that narrowed the
+// set would leave authorization deciding on missing claims.
 //
-// A second set decides which entries of Scopes are merged into a request that
-// names scopes of its own. It is openid, profile, email, groups,
-// offline_access and the audience scopes, and Config.MandatoryScopes replaces
-// it. Configure the two together: an IdP scope outside the built-in mandatory
-// set, a Keycloak "roles" for example, otherwise reaches the IdP only for a
-// client that names no scopes at all.
+// So the forwarded set is Config.Scopes, plus openid, plus the cross-client
+// audience scopes when they are enabled. DefaultScopes() reports the same set,
+// so it never advertises a scope the IdP does not receive. To add a scope,
+// configure it. There is no list a client can draw on beyond Config.Scopes.
 //
 // # Other OIDC Issuers
 //
@@ -106,9 +103,10 @@
 //
 //   - The groups scope. Dex defines it. A Keycloak realm needs a client scope
 //     named groups with a group-membership mapper before it accepts the scope
-//     at all, and Entra ID has no equivalent. Set Config.Scopes,
-//     Config.AllowedScopes and Config.MandatoryScopes to the vocabulary of the
-//     issuer.
+//     at all, and Entra ID has no equivalent. Set Config.Scopes to the
+//     vocabulary of the issuer.
+//   - The federated:id scope. Dex defines it, and Config.Scopes has to name it
+//     for it to reach any IdP.
 //   - Cross-client audience scopes. The audience:server:client_id: shape is a
 //     Dex extension. Keycloak and Entra ID reject an authorization request that
 //     carries one. Set Config.DisableCrossClientAudienceScopes.
@@ -188,7 +186,9 @@
 // A server that sets a supported-scopes allowlist must list the resulting
 // audience scopes, because DefaultScopes() feeds that allowlist. The server
 // validates that allowlist against provider defaults at startup, so an audience
-// the resolver reports later is not covered by that check.
+// the resolver reports later is not covered by that check. None of this applies
+// under Config.DisableCrossClientAudienceScopes, which leaves no audience scope
+// to list.
 //
 // Use the audience helper functions to format these scopes:
 //

--- a/providers/dex/doc.go
+++ b/providers/dex/doc.go
@@ -77,6 +77,40 @@
 //   - offline_access: Refresh token support
 //
 // You can override these by providing custom Scopes in the Config.
+// DefaultScopes returns the list above, so a custom set can extend it.
+//
+// # Scope Filtering
+//
+// The provider drops every scope outside an allowlist before it builds the
+// authorization request, because an IdP that receives one scope it does not
+// know rejects the whole request. DefaultAllowedScopes returns the built-in
+// allowlist: the standard OIDC scopes plus the Dex-only groups and
+// federated:id. Cross-client audience scopes pass as well.
+//
+// The drop is silent, so a scope an IdP needs but the allowlist does not hold
+// never reaches it. Config.AllowedScopes replaces the list, and
+// Config.DisableScopeFilter turns the allowlist off. "openid" always passes.
+//
+// # Other OIDC Issuers
+//
+// This provider is generic OIDC discovery plus a set of Dex conventions, so it
+// also drives an issuer that is not Dex: Keycloak and Entra ID complete the
+// authorization-code flow through it. The Dex conventions are the part to
+// configure away:
+//
+//   - The groups scope. Dex defines it. A Keycloak realm needs a client scope
+//     named groups with a group-membership mapper before it accepts the scope
+//     at all, and Entra ID has no equivalent. Set Config.Scopes and
+//     Config.AllowedScopes to the vocabulary of the issuer.
+//   - Cross-client audience scopes. The audience:server:client_id: shape is a
+//     Dex extension. Keycloak and Entra ID reject an authorization request that
+//     carries one. Set Config.DisableCrossClientAudienceScopes.
+//   - The connector_id parameter. Dex reads it, other issuers ignore it. Leave
+//     Config.ConnectorID empty.
+//
+// Everything else is standard OIDC: discovery, PKCE, the userinfo endpoint, and
+// refresh. The user identity is the sub claim from userinfo, whatever the
+// issuer.
 //
 // # Cross-Client Audience Scopes
 //

--- a/providers/dex/doc.go
+++ b/providers/dex/doc.go
@@ -77,19 +77,25 @@
 //   - offline_access: Refresh token support
 //
 // You can override these by providing custom Scopes in the Config.
-// DefaultScopes returns the list above, so a custom set can extend it.
 //
 // # Scope Filtering
 //
 // The provider drops every scope outside an allowlist before it builds the
 // authorization request, because an IdP that receives one scope it does not
-// know rejects the whole request. DefaultAllowedScopes returns the built-in
-// allowlist: the standard OIDC scopes plus the Dex-only groups and
-// federated:id. Cross-client audience scopes pass as well.
+// know rejects the whole request. The built-in allowlist is openid, profile,
+// email, offline_access, groups and federated:id. Cross-client audience scopes
+// pass as well.
 //
 // The drop is silent, so a scope an IdP needs but the allowlist does not hold
-// never reaches it. Config.AllowedScopes replaces the list, and
-// Config.DisableScopeFilter turns the allowlist off. "openid" always passes.
+// never reaches it. Config.AllowedScopes replaces the list. "openid" always
+// passes.
+//
+// A second set decides which entries of Scopes are merged into a request that
+// names scopes of its own. It is openid, profile, email, groups,
+// offline_access and the audience scopes, and Config.MandatoryScopes replaces
+// it. Configure the two together: an IdP scope outside the built-in mandatory
+// set, a Keycloak "roles" for example, otherwise reaches the IdP only for a
+// client that names no scopes at all.
 //
 // # Other OIDC Issuers
 //
@@ -100,8 +106,9 @@
 //
 //   - The groups scope. Dex defines it. A Keycloak realm needs a client scope
 //     named groups with a group-membership mapper before it accepts the scope
-//     at all, and Entra ID has no equivalent. Set Config.Scopes and
-//     Config.AllowedScopes to the vocabulary of the issuer.
+//     at all, and Entra ID has no equivalent. Set Config.Scopes,
+//     Config.AllowedScopes and Config.MandatoryScopes to the vocabulary of the
+//     issuer.
 //   - Cross-client audience scopes. The audience:server:client_id: shape is a
 //     Dex extension. Keycloak and Entra ID reject an authorization request that
 //     carries one. Set Config.DisableCrossClientAudienceScopes.

--- a/providers/dex/scopes_test.go
+++ b/providers/dex/scopes_test.go
@@ -19,11 +19,11 @@ func TestScopeDefaultsAreUnchanged(t *testing.T) {
 
 	assert.Equal(t, []string{"openid", "profile", "email", "groups", "offline_access"}, provider.DefaultScopes())
 
-	t.Run("an unsupported scope is dropped and a Dex-only scope survives", func(t *testing.T) {
+	t.Run("a scope the configuration does not name is dropped", func(t *testing.T) {
 		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"openid", "claudeai", "federated:id"}, nil))
 
 		assert.NotContains(t, scopes, "claudeai")
-		assert.Contains(t, scopes, "federated:id")
+		assert.NotContains(t, scopes, "federated:id")
 		assert.Contains(t, scopes, "groups")
 	})
 
@@ -34,54 +34,110 @@ func TestScopeDefaultsAreUnchanged(t *testing.T) {
 	})
 }
 
-func TestAllowedScopes(t *testing.T) {
+// TestConfiguredScopesAreAlwaysSent covers the reason a separate mandatory set
+// is not needed: the provider consumes email and groups itself, so a client
+// cannot narrow the configured set by naming scopes of its own.
+func TestConfiguredScopesAreAlwaysSent(t *testing.T) {
 	server := setupMockDexServer(t)
 	defer server.Close()
 
-	// A Keycloak realm: no groups scope, but roles and organization exist.
+	// A Keycloak realm: no groups scope, but roles exists.
 	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
 		cfg.Scopes = []string{"openid", "profile", "email", "offline_access", "roles"}
-		cfg.AllowedScopes = []string{"profile", "email", "offline_access", "roles", "organization"}
 	}))
 	require.NoError(t, err)
 
-	t.Run("a scope the IdP knows reaches it", func(t *testing.T) {
-		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"organization"}, nil))
+	scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"profile"}, nil))
 
-		assert.Contains(t, scopes, "organization")
+	t.Run("a configured scope outside the Dex vocabulary is sent", func(t *testing.T) {
+		assert.Contains(t, scopes, "roles")
 	})
 
-	// Without MandatoryScopes, a configured scope outside the built-in
-	// mandatory set reaches the IdP only for a client that names no scopes.
-	t.Run("a configured scope outside the built-in mandatory set is not merged", func(t *testing.T) {
-		explicit := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"organization"}, nil))
-		implicit := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
-
-		assert.NotContains(t, explicit, "roles")
-		assert.Contains(t, implicit, "roles")
-	})
-
-	t.Run("a scope outside the list is dropped", func(t *testing.T) {
-		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"groups", "federated:id"}, nil))
-
-		assert.NotContains(t, scopes, "groups")
-		assert.NotContains(t, scopes, "federated:id")
-	})
-
-	t.Run("openid survives a list that omits it", func(t *testing.T) {
-		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
-
+	t.Run("the rest of the configured set is sent", func(t *testing.T) {
+		assert.Contains(t, scopes, "email")
+		assert.Contains(t, scopes, "offline_access")
 		assert.Contains(t, scopes, "openid")
 	})
 
-	t.Run("an invalid list is rejected at construction", func(t *testing.T) {
-		_, err := NewProvider(testConfig(server, func(cfg *Config) {
-			cfg.AllowedScopes = []string{"openid", ""}
-		}))
+	t.Run("a scope the configuration does not name is dropped", func(t *testing.T) {
+		narrowed := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"groups", "federated:id"}, nil))
 
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid allowed scopes")
+		assert.NotContains(t, narrowed, "groups")
+		assert.NotContains(t, narrowed, "federated:id")
 	})
+}
+
+// TestConfiguredScopesAreTheOnlyWayIn pins the rule that replaced the old
+// allowlist: a scope reaches the IdP because Config.Scopes names it, never
+// because a client asked for it.
+func TestConfiguredScopesAreTheOnlyWayIn(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Scopes = []string{"openid", "email", "federated:id"}
+	}))
+	require.NoError(t, err)
+
+	t.Run("a configured Dex-only scope is sent to every client", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"email"}, nil))
+
+		assert.Contains(t, scopes, "federated:id")
+	})
+
+	t.Run("a scope the configuration drops cannot be requested back", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"profile", "groups"}, nil))
+
+		assert.NotContains(t, scopes, "profile")
+		assert.NotContains(t, scopes, "groups")
+	})
+
+	t.Run("openid is sent whatever the configuration holds", func(t *testing.T) {
+		other, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.Scopes = []string{"email"}
+		}))
+		require.NoError(t, err)
+
+		assert.Contains(t, authURLScopes(t, other.AuthorizationURL("state", "", "", []string{"email"}, nil)), "openid")
+	})
+}
+
+// TestDefaultScopesMatchWhatIsForwarded pins the invariant the server depends
+// on. server.resolveScopes turns DefaultScopes() into the granted scope string
+// for a client that names none, so a scope reported here but dropped by the
+// filter would be recorded as granted while the IdP never received it.
+func TestDefaultScopesMatchWhatIsForwarded(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	configs := map[string]func(*Config){
+		"defaults": func(*Config) {},
+		"a Keycloak vocabulary": func(cfg *Config) {
+			cfg.Scopes = []string{"openid", "profile", "email", "offline_access", "roles"}
+			cfg.DisableCrossClientAudienceScopes = true
+		},
+		"a configured audience scope": func(cfg *Config) {
+			cfg.Scopes = []string{"openid", "email", k8sAudienceScope}
+		},
+		"a configured audience scope with audience scopes disabled": func(cfg *Config) {
+			cfg.Scopes = []string{"openid", "email", k8sAudienceScope}
+			cfg.DisableCrossClientAudienceScopes = true
+		},
+	}
+
+	for name, option := range configs {
+		t.Run(name, func(t *testing.T) {
+			provider, err := NewProvider(testConfig(server, option))
+			require.NoError(t, err)
+
+			defaults := provider.DefaultScopes()
+			forwarded := authURLScopes(t, provider.AuthorizationURL("state", "", "", defaults, nil))
+
+			for _, scope := range defaults {
+				assert.Contains(t, forwarded, scope, "DefaultScopes() reports %q but the IdP never receives it", scope)
+			}
+		})
+	}
 }
 
 // TestDisableCrossClientAudienceScopes covers the invariant an issuer that is
@@ -119,60 +175,5 @@ func TestDisableCrossClientAudienceScopes(t *testing.T) {
 			assert.False(t, strings.HasPrefix(scope, AudienceScopePrefix), "unexpected audience scope %q", scope)
 		}
 		assert.Contains(t, scopes, "openid")
-	})
-}
-
-// TestMandatoryScopes covers the set the provider merges into a request that
-// names scopes of its own, which is where an IdP vocabulary outside the
-// built-in mandatory set would otherwise be dropped.
-func TestMandatoryScopes(t *testing.T) {
-	server := setupMockDexServer(t)
-	defer server.Close()
-
-	// A Keycloak realm again: roles must survive a client that names one scope.
-	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
-		cfg.Scopes = []string{"openid", "profile", "email", "offline_access", "roles", "organization"}
-		cfg.AllowedScopes = []string{"profile", "email", "offline_access", "roles", "organization"}
-		cfg.MandatoryScopes = []string{"email", "offline_access", "roles"}
-	}))
-	require.NoError(t, err)
-
-	scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"profile"}, nil))
-
-	t.Run("a mandatory scope is merged", func(t *testing.T) {
-		assert.Contains(t, scopes, "roles")
-		assert.Contains(t, scopes, "email")
-		assert.Contains(t, scopes, "offline_access")
-	})
-
-	t.Run("a configured scope outside the set is not merged", func(t *testing.T) {
-		assert.NotContains(t, scopes, "organization")
-	})
-
-	t.Run("openid is merged whatever the set holds", func(t *testing.T) {
-		assert.Contains(t, scopes, "openid")
-	})
-
-	t.Run("the requested scope survives", func(t *testing.T) {
-		assert.Contains(t, scopes, "profile")
-	})
-
-	t.Run("an audience scope is merged whatever the set holds", func(t *testing.T) {
-		provider, err := NewProvider(testConfig(server, func(cfg *Config) {
-			cfg.Scopes = []string{"openid", "email", k8sAudienceScope}
-			cfg.MandatoryScopes = []string{"email"}
-		}))
-		require.NoError(t, err)
-
-		assert.Contains(t, authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"profile"}, nil)), k8sAudienceScope)
-	})
-
-	t.Run("an invalid set is rejected at construction", func(t *testing.T) {
-		_, err := NewProvider(testConfig(server, func(cfg *Config) {
-			cfg.MandatoryScopes = []string{"email", ""}
-		}))
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid mandatory scopes")
 	})
 }

--- a/providers/dex/scopes_test.go
+++ b/providers/dex/scopes_test.go
@@ -51,12 +51,14 @@ func TestAllowedScopes(t *testing.T) {
 		assert.Contains(t, scopes, "organization")
 	})
 
-	// A configured scope outside the mandatory set (providers.CopyScopes) only
-	// reaches the IdP when the client requests no scopes of its own.
-	t.Run("a configured scope reaches a request that names none", func(t *testing.T) {
-		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
+	// Without MandatoryScopes, a configured scope outside the built-in
+	// mandatory set reaches the IdP only for a client that names no scopes.
+	t.Run("a configured scope outside the built-in mandatory set is not merged", func(t *testing.T) {
+		explicit := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"organization"}, nil))
+		implicit := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
 
-		assert.Contains(t, scopes, "roles")
+		assert.NotContains(t, explicit, "roles")
+		assert.Contains(t, implicit, "roles")
 	})
 
 	t.Run("a scope outside the list is dropped", func(t *testing.T) {
@@ -79,47 +81,6 @@ func TestAllowedScopes(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid allowed scopes")
-	})
-}
-
-func TestDisableScopeFilter(t *testing.T) {
-	server := setupMockDexServer(t)
-	defer server.Close()
-
-	t.Run("every requested scope reaches the IdP", func(t *testing.T) {
-		provider, err := NewProvider(testConfig(server, func(cfg *Config) {
-			cfg.DisableScopeFilter = true
-		}))
-		require.NoError(t, err)
-
-		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"claudeai", "urn:example:scope"}, nil))
-
-		assert.Contains(t, scopes, "claudeai")
-		assert.Contains(t, scopes, "urn:example:scope")
-		assert.Contains(t, scopes, "openid")
-	})
-
-	t.Run("an allowlist alongside it is rejected at construction", func(t *testing.T) {
-		_, err := NewProvider(testConfig(server, func(cfg *Config) {
-			cfg.DisableScopeFilter = true
-			cfg.AllowedScopes = []string{"openid", "email"}
-		}))
-
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "mutually exclusive")
-	})
-
-	t.Run("audience scopes are still dropped when they are disabled", func(t *testing.T) {
-		provider, err := NewProvider(testConfig(server, func(cfg *Config) {
-			cfg.DisableScopeFilter = true
-			cfg.DisableCrossClientAudienceScopes = true
-		}))
-		require.NoError(t, err)
-
-		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"claudeai", k8sAudienceScope}, nil))
-
-		assert.Contains(t, scopes, "claudeai")
-		assert.NotContains(t, scopes, k8sAudienceScope)
 	})
 }
 
@@ -161,20 +122,57 @@ func TestDisableCrossClientAudienceScopes(t *testing.T) {
 	})
 }
 
-func TestExportedScopeDefaults(t *testing.T) {
-	t.Run("DefaultScopes returns the built-in requested set", func(t *testing.T) {
-		assert.Equal(t, []string{"openid", "profile", "email", "groups", "offline_access"}, DefaultScopes())
+// TestMandatoryScopes covers the set the provider merges into a request that
+// names scopes of its own, which is where an IdP vocabulary outside the
+// built-in mandatory set would otherwise be dropped.
+func TestMandatoryScopes(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	// A Keycloak realm again: roles must survive a client that names one scope.
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Scopes = []string{"openid", "profile", "email", "offline_access", "roles", "organization"}
+		cfg.AllowedScopes = []string{"profile", "email", "offline_access", "roles", "organization"}
+		cfg.MandatoryScopes = []string{"email", "offline_access", "roles"}
+	}))
+	require.NoError(t, err)
+
+	scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"profile"}, nil))
+
+	t.Run("a mandatory scope is merged", func(t *testing.T) {
+		assert.Contains(t, scopes, "roles")
+		assert.Contains(t, scopes, "email")
+		assert.Contains(t, scopes, "offline_access")
 	})
 
-	t.Run("DefaultAllowedScopes returns the built-in allowlist", func(t *testing.T) {
-		assert.Equal(t, []string{"openid", "profile", "email", "offline_access", "groups", "federated:id"}, DefaultAllowedScopes())
+	t.Run("a configured scope outside the set is not merged", func(t *testing.T) {
+		assert.NotContains(t, scopes, "organization")
 	})
 
-	t.Run("each call returns a fresh slice", func(t *testing.T) {
-		DefaultScopes()[0] = "mutated"
-		DefaultAllowedScopes()[0] = "mutated"
+	t.Run("openid is merged whatever the set holds", func(t *testing.T) {
+		assert.Contains(t, scopes, "openid")
+	})
 
-		assert.Equal(t, "openid", DefaultScopes()[0])
-		assert.Equal(t, "openid", DefaultAllowedScopes()[0])
+	t.Run("the requested scope survives", func(t *testing.T) {
+		assert.Contains(t, scopes, "profile")
+	})
+
+	t.Run("an audience scope is merged whatever the set holds", func(t *testing.T) {
+		provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.Scopes = []string{"openid", "email", k8sAudienceScope}
+			cfg.MandatoryScopes = []string{"email"}
+		}))
+		require.NoError(t, err)
+
+		assert.Contains(t, authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"profile"}, nil)), k8sAudienceScope)
+	})
+
+	t.Run("an invalid set is rejected at construction", func(t *testing.T) {
+		_, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.MandatoryScopes = []string{"email", ""}
+		}))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid mandatory scopes")
 	})
 }

--- a/providers/dex/scopes_test.go
+++ b/providers/dex/scopes_test.go
@@ -1,0 +1,180 @@
+package dex
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestScopeDefaultsAreUnchanged pins the behaviour a caller that sets none of
+// the scope knobs gets, because every existing deployment is that caller.
+func TestScopeDefaultsAreUnchanged(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	provider, err := NewProvider(testConfig(server))
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"openid", "profile", "email", "groups", "offline_access"}, provider.DefaultScopes())
+
+	t.Run("an unsupported scope is dropped and a Dex-only scope survives", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"openid", "claudeai", "federated:id"}, nil))
+
+		assert.NotContains(t, scopes, "claudeai")
+		assert.Contains(t, scopes, "federated:id")
+		assert.Contains(t, scopes, "groups")
+	})
+
+	t.Run("a cross-client audience scope survives", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"openid", k8sAudienceScope}, nil))
+
+		assert.Contains(t, scopes, k8sAudienceScope)
+	})
+}
+
+func TestAllowedScopes(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	// A Keycloak realm: no groups scope, but roles and organization exist.
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Scopes = []string{"openid", "profile", "email", "offline_access", "roles"}
+		cfg.AllowedScopes = []string{"profile", "email", "offline_access", "roles", "organization"}
+	}))
+	require.NoError(t, err)
+
+	t.Run("a scope the IdP knows reaches it", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"organization"}, nil))
+
+		assert.Contains(t, scopes, "organization")
+	})
+
+	// A configured scope outside the mandatory set (providers.CopyScopes) only
+	// reaches the IdP when the client requests no scopes of its own.
+	t.Run("a configured scope reaches a request that names none", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
+
+		assert.Contains(t, scopes, "roles")
+	})
+
+	t.Run("a scope outside the list is dropped", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"groups", "federated:id"}, nil))
+
+		assert.NotContains(t, scopes, "groups")
+		assert.NotContains(t, scopes, "federated:id")
+	})
+
+	t.Run("openid survives a list that omits it", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", nil, nil))
+
+		assert.Contains(t, scopes, "openid")
+	})
+
+	t.Run("an invalid list is rejected at construction", func(t *testing.T) {
+		_, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.AllowedScopes = []string{"openid", ""}
+		}))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid allowed scopes")
+	})
+}
+
+func TestDisableScopeFilter(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	t.Run("every requested scope reaches the IdP", func(t *testing.T) {
+		provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.DisableScopeFilter = true
+		}))
+		require.NoError(t, err)
+
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"claudeai", "urn:example:scope"}, nil))
+
+		assert.Contains(t, scopes, "claudeai")
+		assert.Contains(t, scopes, "urn:example:scope")
+		assert.Contains(t, scopes, "openid")
+	})
+
+	t.Run("an allowlist alongside it is rejected at construction", func(t *testing.T) {
+		_, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.DisableScopeFilter = true
+			cfg.AllowedScopes = []string{"openid", "email"}
+		}))
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "mutually exclusive")
+	})
+
+	t.Run("audience scopes are still dropped when they are disabled", func(t *testing.T) {
+		provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+			cfg.DisableScopeFilter = true
+			cfg.DisableCrossClientAudienceScopes = true
+		}))
+		require.NoError(t, err)
+
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"claudeai", k8sAudienceScope}, nil))
+
+		assert.Contains(t, scopes, "claudeai")
+		assert.NotContains(t, scopes, k8sAudienceScope)
+	})
+}
+
+// TestDisableCrossClientAudienceScopes covers the invariant an issuer that is
+// not Dex depends on: no audience:server:client_id: scope reaches it, whichever
+// path put the scope in the set.
+func TestDisableCrossClientAudienceScopes(t *testing.T) {
+	server := setupMockDexServer(t)
+	defer server.Close()
+
+	resolverCalls := 0
+	provider, err := NewProvider(testConfig(server, func(cfg *Config) {
+		cfg.Scopes = []string{"openid", "email", k8sAudienceScope}
+		cfg.DisableCrossClientAudienceScopes = true
+		cfg.AudienceResolver = func() []string {
+			resolverCalls++
+			return []string{"late-client"}
+		}
+	}))
+	require.NoError(t, err)
+
+	t.Run("a configured audience scope is dropped from the defaults", func(t *testing.T) {
+		assert.Equal(t, []string{"openid", "email"}, provider.DefaultScopes())
+	})
+
+	t.Run("the resolver never runs", func(t *testing.T) {
+		provider.AuthorizationURL("state", "", "", nil, nil)
+
+		assert.Zero(t, resolverCalls)
+	})
+
+	t.Run("a requested audience scope is dropped", func(t *testing.T) {
+		scopes := authURLScopes(t, provider.AuthorizationURL("state", "", "", []string{"openid", AudienceScopePrefix + "other-client"}, nil))
+
+		for _, scope := range scopes {
+			assert.False(t, strings.HasPrefix(scope, AudienceScopePrefix), "unexpected audience scope %q", scope)
+		}
+		assert.Contains(t, scopes, "openid")
+	})
+}
+
+func TestExportedScopeDefaults(t *testing.T) {
+	t.Run("DefaultScopes returns the built-in requested set", func(t *testing.T) {
+		assert.Equal(t, []string{"openid", "profile", "email", "groups", "offline_access"}, DefaultScopes())
+	})
+
+	t.Run("DefaultAllowedScopes returns the built-in allowlist", func(t *testing.T) {
+		assert.Equal(t, []string{"openid", "profile", "email", "offline_access", "groups", "federated:id"}, DefaultAllowedScopes())
+	})
+
+	t.Run("each call returns a fresh slice", func(t *testing.T) {
+		DefaultScopes()[0] = "mutated"
+		DefaultAllowedScopes()[0] = "mutated"
+
+		assert.Equal(t, "openid", DefaultScopes()[0])
+		assert.Equal(t, "openid", DefaultAllowedScopes()[0])
+	})
+}

--- a/providers/helpers.go
+++ b/providers/helpers.go
@@ -85,8 +85,9 @@ const CrossClientAudienceScopePrefix = "audience:server:client_id:"
 //   - "offline_access": Required for refresh token issuance.
 //   - CrossClientAudienceScopePrefix: Required for SSO token forwarding scenarios.
 //
-// The set is the Dex and OIDC vocabulary. An IdP with a vocabulary of its own
-// needs a predicate of its own, through FilterScopesFunc.
+// The set is the Dex and OIDC vocabulary, and it is the same five scopes as
+// the Dex provider's own defaults. An IdP with a vocabulary of its own needs a
+// predicate of its own, through FilterScopesFunc.
 func isMandatoryScope(scope string) bool {
 	switch scope {
 	case "openid", "email", "profile", "groups", "offline_access":
@@ -195,10 +196,11 @@ func FilterScopes(requestedScopes, defaultScopes []string, supported func(string
 // predicate. A nil mandatory predicate uses the built-in set, and a nil
 // supported predicate accepts everything.
 //
-// A provider whose IdP has a scope vocabulary of its own needs this: under the
-// built-in set, a configured default such as a Keycloak "roles" reaches the IdP
-// only when the client requests no scopes at all, so a client that names one
-// scope silently drops the rest of the operator's set.
+// A provider whose IdP has a scope vocabulary of its own needs this. The
+// built-in set names the Dex and OIDC scopes only, so a configured default
+// outside it, a Keycloak "roles" for example, reaches the IdP only when the
+// client requests no scopes at all. A client that names one scope would
+// silently drop the rest of the operator's set.
 func FilterScopesFunc(requestedScopes, defaultScopes []string, supported, mandatory func(string) bool) []string {
 	merged := copyScopes(requestedScopes, defaultScopes, mandatory)
 	if supported == nil {

--- a/providers/helpers.go
+++ b/providers/helpers.go
@@ -75,13 +75,18 @@ func ApplyAuthorizationURLOptions(opts *AuthorizationURLOptions) []oauth2.AuthCo
 const CrossClientAudienceScopePrefix = "audience:server:client_id:"
 
 // isMandatoryScope returns true if the scope must always be force-merged into the
-// resolved scope set when present in the provider's defaults. Currently mandatory:
+// resolved scope set when present in the provider's defaults. It is the set
+// CopyScopes and FilterScopes apply, and the one FilterScopesFunc takes for a
+// nil predicate. Currently mandatory:
 //   - "openid": Required by OIDC-compliant providers per the OpenID Connect spec.
 //   - "email": Required for user identification in downstream services.
 //   - "profile": Required for user display name and metadata.
 //   - "groups": Required for RBAC-based authorization.
 //   - "offline_access": Required for refresh token issuance.
 //   - CrossClientAudienceScopePrefix: Required for SSO token forwarding scenarios.
+//
+// The set is the Dex and OIDC vocabulary. An IdP with a vocabulary of its own
+// needs a predicate of its own, through FilterScopesFunc.
 func isMandatoryScope(scope string) bool {
 	switch scope {
 	case "openid", "email", "profile", "groups", "offline_access":
@@ -113,6 +118,16 @@ func isMandatoryScope(scope string) bool {
 // downstream services always receive the claims they need (email, groups, etc.)
 // regardless of what the MCP client explicitly requests.
 func CopyScopes(requestedScopes, defaultScopes []string) []string {
+	return copyScopes(requestedScopes, defaultScopes, nil)
+}
+
+// copyScopes is CopyScopes with a caller-supplied mandatory-scope predicate. A
+// nil predicate uses isMandatoryScope.
+func copyScopes(requestedScopes, defaultScopes []string, mandatory func(string) bool) []string {
+	if mandatory == nil {
+		mandatory = isMandatoryScope
+	}
+
 	// If no requested scopes, use defaults entirely
 	if len(requestedScopes) == 0 {
 		scopesCopy := make([]string, len(defaultScopes))
@@ -133,7 +148,7 @@ func CopyScopes(requestedScopes, defaultScopes []string) []string {
 
 	// Merge mandatory scopes from defaults
 	for _, s := range defaultScopes {
-		if isMandatoryScope(s) {
+		if mandatory(s) {
 			if _, exists := requestedSet[s]; !exists {
 				result = append(result, s)
 			}
@@ -173,7 +188,19 @@ func CloneScopes(scopes []string) []string {
 //
 // A nil predicate is treated as "accept everything".
 func FilterScopes(requestedScopes, defaultScopes []string, supported func(string) bool) []string {
-	merged := CopyScopes(requestedScopes, defaultScopes)
+	return FilterScopesFunc(requestedScopes, defaultScopes, supported, nil)
+}
+
+// FilterScopesFunc is FilterScopes with a caller-supplied mandatory-scope
+// predicate. A nil mandatory predicate uses the built-in set, and a nil
+// supported predicate accepts everything.
+//
+// A provider whose IdP has a scope vocabulary of its own needs this: under the
+// built-in set, a configured default such as a Keycloak "roles" reaches the IdP
+// only when the client requests no scopes at all, so a client that names one
+// scope silently drops the rest of the operator's set.
+func FilterScopesFunc(requestedScopes, defaultScopes []string, supported, mandatory func(string) bool) []string {
+	merged := copyScopes(requestedScopes, defaultScopes, mandatory)
 	if supported == nil {
 		return merged
 	}

--- a/providers/helpers_test.go
+++ b/providers/helpers_test.go
@@ -70,3 +70,32 @@ func TestFilterScopes(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterScopesFunc(t *testing.T) {
+	defaults := []string{"openid", "email", "roles", "organization"}
+
+	t.Run("a nil mandatory predicate applies the built-in set", func(t *testing.T) {
+		result := FilterScopesFunc([]string{"profile"}, defaults, nil, nil)
+
+		require.Equal(t, FilterScopes([]string{"profile"}, defaults, nil), result)
+		require.Contains(t, result, "email")
+		require.NotContains(t, result, "roles")
+	})
+
+	t.Run("a mandatory predicate replaces the built-in set", func(t *testing.T) {
+		mandatory := func(scope string) bool { return scope == "roles" }
+
+		result := FilterScopesFunc([]string{"profile"}, defaults, nil, mandatory)
+
+		require.Equal(t, []string{"profile", "roles"}, result)
+	})
+
+	t.Run("the supported predicate still applies", func(t *testing.T) {
+		mandatory := func(scope string) bool { return scope == "roles" }
+		supported := func(scope string) bool { return scope != "roles" }
+
+		result := FilterScopesFunc([]string{"profile"}, defaults, supported, mandatory)
+
+		require.Equal(t, []string{"profile"}, result)
+	})
+}


### PR DESCRIPTION
## Problem

`providers/dex` is generic OIDC discovery plus a set of Dex conventions, and the conventions are hardcoded in two lists that hold the same five scopes. `isDexSupportedScope` dropped every scope outside them before the authorization request left the process, and `isMandatoryScope` decided which configured scopes survived a request that named scopes of its own.

Together they mean a configured scope outside those five reaches the IdP only for a client that names none. A Keycloak realm scope (`roles`, `organization`) never arrived, so an operator could not fix a rejected login by configuring scopes.

The reverse case is worse. Keycloak and Entra ID return `invalid_scope` for the whole request, not for the offending scope. muster requests `groups` and appends `audience:server:client_id:*` per MCPServer `requiredAudiences`, so a Keycloak login breaks outright. Spike C measured both against Keycloak 26.7.2 (`bumblebee-plans` `agent-platform-vanilla/research/2026-08-26-spike-c-keycloak-muster-dex.md`, traces P1, P2, P6).

## Change

`dex.Config.Scopes` becomes the complete set the provider forwards. Every entry reaches the IdP on every authorization request, and no scope outside it does. The provider consumes the claims itself, so a client cannot narrow the set below what the operator configured.

`dex.Config.DisableCrossClientAudienceScopes` drops every `audience:server:client_id:` scope from `Scopes`, from every requested set, and turns off `AudienceResolver`. One switch covers all three paths, so a non-Dex issuer cannot receive the scope shape through a path the operator forgot.

`providers.FilterScopesFunc` carries the mandatory-scope predicate. `FilterScopes` and `CopyScopes` delegate to it with the built-in set, so `providers/github` and `providers/google` are untouched.

Two consequences worth naming. `DefaultScopes()` now reports exactly the forwarded set: `server.resolveScopes` turns it into the granted scope string, so a scope the filter dropped was previously recorded as granted while the IdP never received it. And `ensureOpenIDScope` is now called from `AuthorizationURL`; it was only ever called from its own test, so a `Config.Scopes` without `openid` produced a request that was not an OIDC request.

`federated:id` is the one behaviour change for an existing caller. It was accepted from any client whether or not `Scopes` held it, and it now has to be configured. No deployment sends it today: `oauthconfig.DexFromEnv` does not set `Scopes` at all, and muster hardcodes the five defaults at `internal/server/oauth_http.go:103`.

## Related Issues

Related to giantswarm/giantswarm#37432

Follow-up on the muster side: giantswarm/muster#1080. Larger than it looks: `dexOAuthScopes` is a package-level `var`, not read from `cfg.Dex`, so `Scopes` needs a config path before the bool can be exposed under `oauth.server.dex.*`.
