### PR TITLE
fix(oauth): honor RootCAs on the SSRF-safe clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `dex.Config.AudienceResolver`, an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it per authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` reaches the next login. Nil keeps the previous behaviour. Duplicates are dropped, invalid audiences are skipped and logged once each, and the merged set stays within `oidc.MaxScopeCount`.
 - `oidc.MaxScopeCount` and `oidc.MaxScopeLength`, the bounds `oidc.ValidateScopes` already applied.
 
+### Changed
+
+- **BREAKING.** `oidc.NewSSRFSafeHTTPClient` takes a `rootCAs *x509.CertPool` second parameter, matching `NewPrivateIPAllowedHTTPClient` and `NewHostScopedPrivateIPHTTPClient`. Pass `nil` for the previous behaviour.
+
+### Fixed
+
+- Every `RootCAs` field now applies whether or not the private-IP flags are set. `oidc.JWKSClientOptions.RootCAs`, `oidc.TokenExchangeClientOptions.RootCAs`, `server.TrustedIssuer.RootCAs` and `dex.Config.RootCAs` were dropped on the SSRF-safe dial posture, so an IdP whose host resolves to a public address but presents an internal-CA certificate failed TLS with no way to fix it short of relaxing the SSRF guard. A `server.TrustedIssuer` that sets only `RootCAs` now gets its own JWKS client instead of the shared system-pool one.
+
 ## [1.1.0] - 2026-07-16
 
 > ### ⚠️ DEPLOY NOTE — one-time re-login required; token-key flush recommended

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `oidc.NewDefaultDialHTTPClient(timeout, rootCAs)`, the client for calls to an operator-configured provider endpoint (OIDC discovery, token endpoint). Standard dialer, cross-host redirects refused, proxy environment honoured, and the endpoint's certificate verified against `rootCAs` (nil uses the system pool). It applies no SSRF dial guard, so use `NewSSRFSafeHTTPClient` whenever the target URL can come from a token or a request.
+- `oidc.DefaultExpectContinueTimeout`, the bound the shared transport applies to a 100-continue response.
 - `dex.Config.AudienceResolver`, an optional `func() []string` that reports the Dex cross-client audiences to request. The provider calls it per authorization request and merges one `audience:server:client_id:` scope per audience into both `DefaultScopes()` and `AuthorizationURL()`, so an audience the caller learns about after `NewProvider` reaches the next login. Nil keeps the previous behaviour. Duplicates are dropped, invalid audiences are skipped and logged once each, and the merged set stays within `oidc.MaxScopeCount`.
 - `oidc.MaxScopeCount` and `oidc.MaxScopeLength`, the bounds `oidc.ValidateScopes` already applied.
 
 ### Changed
 
 - **BREAKING.** `oidc.NewSSRFSafeHTTPClient` takes a `rootCAs *x509.CertPool` second parameter, matching `NewPrivateIPAllowedHTTPClient` and `NewHostScopedPrivateIPHTTPClient`. Pass `nil` for the previous behaviour.
+- Every HTTP client in `providers/oidc` and `providers/dex` is built by one internal constructor, which states the dial guard, the redirect guard and the proxy setting per posture. The transport tuning has a single definition, so a setting can no longer drift on one client only. Two effects on existing clients: HTTP/2 is attempted where the server offers it (`ForceAttemptHTTP2`), and `ExpectContinueTimeout` is bounded.
+- The Dex client on the default (non-permissive) dial posture is now built by `oidc.NewDefaultDialHTTPClient` instead of `&http.Client{Timeout: ...}`. It keeps the standard dialer and the proxy environment variables, and it gains the tuned dial, TLS-handshake, response-header and idle-connection timeouts the other clients already had, plus the cross-host redirect guard. A Dex discovery or token-endpoint redirect to a different host or port is now refused.
 
 ### Fixed
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -750,7 +750,9 @@ pool, err := x509.SystemCertPool()
 if err != nil {
     return err
 }
-pool.AppendCertsFromPEM(caPEM)
+if !pool.AppendCertsFromPEM(caPEM) {
+    return errors.New("no certificate found in the CA bundle")
+}
 
 config := &server.Config{
     Issuer:           "https://dex.example.com",

--- a/docs/security.md
+++ b/docs/security.md
@@ -728,6 +728,41 @@ config := &server.Config{
 - A warning is logged at startup when this option is enabled
 - For Google OAuth, this setting has no effect as Google's JWKS endpoint is always publicly accessible
 
+#### Internal CA trust
+
+`AllowPrivateIPJWKS` controls which IP addresses a fetch may reach. It does not
+control which CA signs the certificate. Those are independent settings: an IdP on
+a public address can still present a certificate from an internal CA.
+
+Pass the CA pool through the `RootCAs` field that fits the fetch. Each one
+applies whether or not the private-IP flags are set:
+
+| Field | Verifies |
+|---|---|
+| `server.Config.JWKSRootCAs` | forwarded SSO ID tokens (`TrustedAudiences`) |
+| `server.TrustedIssuer.RootCAs` | that issuer's JWKS endpoint |
+| `dex.Config.RootCAs` | Dex OIDC discovery and token endpoint |
+| `oidc.JWKSClientOptions.RootCAs` | a JWKS client you build yourself |
+| `oidc.TokenExchangeClientOptions.RootCAs` | an RFC 8693 token endpoint |
+
+```go
+pool, err := x509.SystemCertPool()
+if err != nil {
+    return err
+}
+pool.AppendCertsFromPEM(caPEM)
+
+config := &server.Config{
+    Issuer:           "https://dex.example.com",
+    TrustedAudiences: []string{"muster-client"},
+    JWKSRootCAs:      pool, // no AllowPrivateIPJWKS needed
+}
+```
+
+A pool replaces the system roots rather than extending them. Start from
+`x509.SystemCertPool()` and append, as above, unless you intend to trust the
+internal CA alone.
+
 ### Example YAML Configuration
 
 ```yaml

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -5,6 +5,7 @@ package dex
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
@@ -123,9 +124,11 @@ type Config struct {
 	AllowPrivateIP bool
 
 	// RootCAs is the CA pool used to verify Dex's TLS certificate during OIDC
-	// discovery and token endpoint calls when AllowPrivateIP is set and no
-	// explicit HTTPClient is provided (e.g. an internal-CA Dex). nil uses the
-	// system pool.
+	// discovery and token endpoint calls when no explicit HTTPClient is provided
+	// (e.g. an internal-CA Dex). It applies with or without AllowPrivateIP: a Dex
+	// on a public address can still carry an internal-CA certificate. The pool
+	// replaces the system roots rather than extending them. nil uses the system
+	// pool.
 	RootCAs *x509.CertPool
 
 	// discoveryClient overrides the OIDC discovery client. Nil means
@@ -275,6 +278,9 @@ func resolveTimeout(timeout time.Duration) time.Duration {
 // discovery. When allowPrivateIP is true and no explicit client is provided, a
 // client without SSRF protection is returned so that Dex issuer URLs resolving
 // to RFC 1918 addresses (e.g. internal load balancers) are reachable.
+//
+// rootCAs is applied on both paths. A public-address Dex can present an
+// internal-CA certificate, so trust must not depend on the dial posture.
 func resolveHTTPClient(client *http.Client, allowPrivateIP bool, rootCAs *x509.CertPool, timeout time.Duration) *http.Client {
 	if client != nil {
 		return client
@@ -282,7 +288,37 @@ func resolveHTTPClient(client *http.Client, allowPrivateIP bool, rootCAs *x509.C
 	if allowPrivateIP {
 		return oidc.NewPrivateIPAllowedHTTPClient(timeout, rootCAs)
 	}
+	if rootCAs != nil {
+		return newRootCATrustingClient(rootCAs, timeout)
+	}
 	return &http.Client{Timeout: timeout}
+}
+
+// newRootCATrustingClient clones http.DefaultTransport and pins its trust
+// anchor to rootCAs. Cloning keeps the default transport's proxy, timeout and
+// connection-pool settings.
+func newRootCATrustingClient(rootCAs *x509.CertPool, timeout time.Duration) *http.Client {
+	transport, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		// DefaultTransport is always *http.Transport in the stdlib. Something
+		// replaced it; build a plain transport rather than dropping the pool.
+		return &http.Client{
+			Transport: &http.Transport{
+				Proxy:           http.ProxyFromEnvironment,
+				TLSClientConfig: &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12},
+			},
+			Timeout: timeout,
+		}
+	}
+	cloned := transport.Clone()
+	if cloned.TLSClientConfig == nil {
+		cloned.TLSClientConfig = &tls.Config{}
+	}
+	if cloned.TLSClientConfig.MinVersion == 0 {
+		cloned.TLSClientConfig.MinVersion = tls.VersionTLS12
+	}
+	cloned.TLSClientConfig.RootCAs = rootCAs
+	return &http.Client{Transport: cloned, Timeout: timeout}
 }
 
 // resolveDiscoveryClient returns override when non-nil, otherwise constructs a

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -5,7 +5,6 @@ package dex
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
@@ -279,23 +278,16 @@ func resolveTimeout(timeout time.Duration) time.Duration {
 // to RFC 1918 addresses (e.g. internal load balancers) are reachable.
 //
 // rootCAs applies on both paths: a Dex on a public address can still present an
-// internal-CA certificate, so trust does not depend on the dial posture.
+// internal-CA certificate, so trust does not depend on the dial posture. Both
+// clients come from providers/oidc, which owns the transport tuning.
 func resolveHTTPClient(client *http.Client, allowPrivateIP bool, rootCAs *x509.CertPool, timeout time.Duration) *http.Client {
 	switch {
 	case client != nil:
 		return client
 	case allowPrivateIP:
 		return oidc.NewPrivateIPAllowedHTTPClient(timeout, rootCAs)
-	case rootCAs != nil:
-		return &http.Client{
-			Transport: &http.Transport{
-				Proxy:           http.ProxyFromEnvironment,
-				TLSClientConfig: &tls.Config{RootCAs: rootCAs, MinVersion: tls.VersionTLS12},
-			},
-			Timeout: timeout,
-		}
 	default:
-		return &http.Client{Timeout: timeout}
+		return oidc.NewDefaultDialHTTPClient(timeout, rootCAs)
 	}
 }
 

--- a/providers/dex/dex.go
+++ b/providers/dex/dex.go
@@ -124,11 +124,10 @@ type Config struct {
 	AllowPrivateIP bool
 
 	// RootCAs is the CA pool used to verify Dex's TLS certificate during OIDC
-	// discovery and token endpoint calls when no explicit HTTPClient is provided
-	// (e.g. an internal-CA Dex). It applies with or without AllowPrivateIP: a Dex
-	// on a public address can still carry an internal-CA certificate. The pool
-	// replaces the system roots rather than extending them. nil uses the system
-	// pool.
+	// discovery and token endpoint calls (e.g. an internal-CA Dex). It applies
+	// with or without AllowPrivateIP. The pool replaces the system roots rather
+	// than extending them. nil uses the system pool. Ignored when HTTPClient is
+	// provided.
 	RootCAs *x509.CertPool
 
 	// discoveryClient overrides the OIDC discovery client. Nil means
@@ -279,29 +278,15 @@ func resolveTimeout(timeout time.Duration) time.Duration {
 // client without SSRF protection is returned so that Dex issuer URLs resolving
 // to RFC 1918 addresses (e.g. internal load balancers) are reachable.
 //
-// rootCAs is applied on both paths. A public-address Dex can present an
-// internal-CA certificate, so trust must not depend on the dial posture.
+// rootCAs applies on both paths: a Dex on a public address can still present an
+// internal-CA certificate, so trust does not depend on the dial posture.
 func resolveHTTPClient(client *http.Client, allowPrivateIP bool, rootCAs *x509.CertPool, timeout time.Duration) *http.Client {
-	if client != nil {
+	switch {
+	case client != nil:
 		return client
-	}
-	if allowPrivateIP {
+	case allowPrivateIP:
 		return oidc.NewPrivateIPAllowedHTTPClient(timeout, rootCAs)
-	}
-	if rootCAs != nil {
-		return newRootCATrustingClient(rootCAs, timeout)
-	}
-	return &http.Client{Timeout: timeout}
-}
-
-// newRootCATrustingClient clones http.DefaultTransport and pins its trust
-// anchor to rootCAs. Cloning keeps the default transport's proxy, timeout and
-// connection-pool settings.
-func newRootCATrustingClient(rootCAs *x509.CertPool, timeout time.Duration) *http.Client {
-	transport, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		// DefaultTransport is always *http.Transport in the stdlib. Something
-		// replaced it; build a plain transport rather than dropping the pool.
+	case rootCAs != nil:
 		return &http.Client{
 			Transport: &http.Transport{
 				Proxy:           http.ProxyFromEnvironment,
@@ -309,16 +294,9 @@ func newRootCATrustingClient(rootCAs *x509.CertPool, timeout time.Duration) *htt
 			},
 			Timeout: timeout,
 		}
+	default:
+		return &http.Client{Timeout: timeout}
 	}
-	cloned := transport.Clone()
-	if cloned.TLSClientConfig == nil {
-		cloned.TLSClientConfig = &tls.Config{}
-	}
-	if cloned.TLSClientConfig.MinVersion == 0 {
-		cloned.TLSClientConfig.MinVersion = tls.VersionTLS12
-	}
-	cloned.TLSClientConfig.RootCAs = rootCAs
-	return &http.Client{Transport: cloned, Timeout: timeout}
 }
 
 // resolveDiscoveryClient returns override when non-nil, otherwise constructs a

--- a/providers/dex/dex_test.go
+++ b/providers/dex/dex_test.go
@@ -990,7 +990,7 @@ func TestResolveHTTPClient(t *testing.T) {
 			wantSame:       custom,
 		},
 		{
-			name:           "nil client without allowPrivateIP returns plain client",
+			name:           "nil client without allowPrivateIP returns default-dial client",
 			client:         nil,
 			allowPrivateIP: false,
 			wantTimeout:    timeout,

--- a/providers/dex/httpclient_catrust_test.go
+++ b/providers/dex/httpclient_catrust_test.go
@@ -17,26 +17,28 @@ func TestResolveHTTPClient_RootCAs(t *testing.T) {
 	t.Parallel()
 	pool := x509.NewCertPool()
 
-	t.Run("without AllowPrivateIP", func(t *testing.T) {
-		client := resolveHTTPClient(nil, false, pool, 5*time.Second)
-		transport, ok := client.Transport.(*http.Transport)
-		require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
-		require.NotNil(t, transport.TLSClientConfig)
-		require.Same(t, pool, transport.TLSClientConfig.RootCAs)
-		require.GreaterOrEqual(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
-		require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
-	})
+	for _, allowPrivateIP := range []bool{false, true} {
+		name := "without AllowPrivateIP"
+		if allowPrivateIP {
+			name = "with AllowPrivateIP"
+		}
+		t.Run(name, func(t *testing.T) {
+			client := resolveHTTPClient(nil, allowPrivateIP, pool, 5*time.Second)
+			transport, ok := client.Transport.(*http.Transport)
+			require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
+			require.NotNil(t, transport.TLSClientConfig)
+			require.Same(t, pool, transport.TLSClientConfig.RootCAs)
+			require.GreaterOrEqual(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
+			require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+		})
+	}
 
-	t.Run("with AllowPrivateIP", func(t *testing.T) {
-		client := resolveHTTPClient(nil, true, pool, 5*time.Second)
-		transport, ok := client.Transport.(*http.Transport)
-		require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
-		require.NotNil(t, transport.TLSClientConfig)
-		require.Same(t, pool, transport.TLSClientConfig.RootCAs)
-	})
-
-	t.Run("nil pool keeps the default transport", func(t *testing.T) {
+	t.Run("nil pool keeps system-pool verification on a tuned transport", func(t *testing.T) {
 		client := resolveHTTPClient(nil, false, nil, 5*time.Second)
-		require.Nil(t, client.Transport, "a nil pool must not pin a transport")
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
+		require.Nil(t, transport.TLSClientConfig, "a nil pool must not pin a CA")
+		require.True(t, transport.ForceAttemptHTTP2)
+		require.NotZero(t, transport.IdleConnTimeout)
 	})
 }

--- a/providers/dex/httpclient_catrust_test.go
+++ b/providers/dex/httpclient_catrust_test.go
@@ -1,0 +1,47 @@
+package dex
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveHTTPClient_RootCAs verifies that an explicit CA pool reaches the
+// Dex client on both dial postures. A Dex on a public address can present an
+// internal-CA certificate, so trust must not require AllowPrivateIP.
+func TestResolveHTTPClient_RootCAs(t *testing.T) {
+	t.Parallel()
+	pool := x509.NewCertPool()
+
+	t.Run("without AllowPrivateIP", func(t *testing.T) {
+		client := resolveHTTPClient(nil, false, pool, 5*time.Second)
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
+		require.NotNil(t, transport.TLSClientConfig)
+		require.Same(t, pool, transport.TLSClientConfig.RootCAs)
+		require.GreaterOrEqual(t, transport.TLSClientConfig.MinVersion, uint16(tls.VersionTLS12))
+		require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+	})
+
+	t.Run("with AllowPrivateIP", func(t *testing.T) {
+		client := resolveHTTPClient(nil, true, pool, 5*time.Second)
+		transport, ok := client.Transport.(*http.Transport)
+		require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
+		require.NotNil(t, transport.TLSClientConfig)
+		require.Same(t, pool, transport.TLSClientConfig.RootCAs)
+	})
+
+	t.Run("nil pool keeps the default transport", func(t *testing.T) {
+		client := resolveHTTPClient(nil, false, nil, 5*time.Second)
+		require.Nil(t, client.Transport, "a nil pool must not pin a transport")
+	})
+
+	t.Run("explicit client wins", func(t *testing.T) {
+		explicit := &http.Client{}
+		require.Same(t, explicit, resolveHTTPClient(explicit, false, pool, 5*time.Second))
+	})
+}

--- a/providers/dex/httpclient_catrust_test.go
+++ b/providers/dex/httpclient_catrust_test.go
@@ -39,9 +39,4 @@ func TestResolveHTTPClient_RootCAs(t *testing.T) {
 		client := resolveHTTPClient(nil, false, nil, 5*time.Second)
 		require.Nil(t, client.Transport, "a nil pool must not pin a transport")
 	})
-
-	t.Run("explicit client wins", func(t *testing.T) {
-		explicit := &http.Client{}
-		require.Same(t, explicit, resolveHTTPClient(explicit, false, pool, 5*time.Second))
-	})
 }

--- a/providers/dex/httpclient_catrust_test.go
+++ b/providers/dex/httpclient_catrust_test.go
@@ -33,12 +33,10 @@ func TestResolveHTTPClient_RootCAs(t *testing.T) {
 		})
 	}
 
-	t.Run("nil pool keeps system-pool verification on a tuned transport", func(t *testing.T) {
+	t.Run("nil pool keeps system-pool verification", func(t *testing.T) {
 		client := resolveHTTPClient(nil, false, nil, 5*time.Second)
 		transport, ok := client.Transport.(*http.Transport)
 		require.True(t, ok, "expected *http.Transport, got %T", client.Transport)
 		require.Nil(t, transport.TLSClientConfig, "a nil pool must not pin a CA")
-		require.True(t, transport.ForceAttemptHTTP2)
-		require.NotZero(t, transport.IdleConnTimeout)
 	})
 }

--- a/providers/oidc/exchange.go
+++ b/providers/oidc/exchange.go
@@ -109,8 +109,10 @@ type TokenExchangeClientOptions struct {
 	AllowPrivateIP bool
 
 	// RootCAs is the CA pool used to verify the token endpoint's TLS certificate
-	// when AllowPrivateIP is set (e.g. an internal-CA Dex). nil uses the system
-	// pool. Ignored when HTTPClient is provided.
+	// (e.g. an internal-CA Dex). It applies whether or not AllowPrivateIP is set:
+	// a token endpoint on a public address can still carry an internal-CA
+	// certificate. The pool replaces the system roots rather than extending them.
+	// nil uses the system pool. Ignored when HTTPClient is provided.
 	RootCAs *x509.CertPool
 }
 
@@ -221,8 +223,10 @@ func NewTokenExchangeClientWithOptions(opts TokenExchangeClientOptions) *TokenEx
 			// Use client without SSRF protection for private IdP deployments
 			httpClient = NewPrivateIPAllowedHTTPClient(DefaultHTTPTimeout, opts.RootCAs)
 		} else {
-			// SECURITY: Use SSRF-safe client with DNS rebinding protection
-			httpClient = NewSSRFSafeHTTPClient(DefaultHTTPTimeout)
+			// SECURITY: Use SSRF-safe client with DNS rebinding protection.
+			// RootCAs still applies: a token endpoint on a public address can
+			// carry an internal-CA certificate.
+			httpClient = NewSSRFSafeHTTPClient(DefaultHTTPTimeout, opts.RootCAs)
 		}
 	}
 

--- a/providers/oidc/exchange.go
+++ b/providers/oidc/exchange.go
@@ -109,10 +109,9 @@ type TokenExchangeClientOptions struct {
 	AllowPrivateIP bool
 
 	// RootCAs is the CA pool used to verify the token endpoint's TLS certificate
-	// (e.g. an internal-CA Dex). It applies whether or not AllowPrivateIP is set:
-	// a token endpoint on a public address can still carry an internal-CA
-	// certificate. The pool replaces the system roots rather than extending them.
-	// nil uses the system pool. Ignored when HTTPClient is provided.
+	// (e.g. an internal-CA Dex). It applies with or without AllowPrivateIP. The
+	// pool replaces the system roots rather than extending them. nil uses the
+	// system pool. Ignored when HTTPClient is provided.
 	RootCAs *x509.CertPool
 }
 
@@ -223,9 +222,7 @@ func NewTokenExchangeClientWithOptions(opts TokenExchangeClientOptions) *TokenEx
 			// Use client without SSRF protection for private IdP deployments
 			httpClient = NewPrivateIPAllowedHTTPClient(DefaultHTTPTimeout, opts.RootCAs)
 		} else {
-			// SECURITY: Use SSRF-safe client with DNS rebinding protection.
-			// RootCAs still applies: a token endpoint on a public address can
-			// carry an internal-CA certificate.
+			// SECURITY: Use SSRF-safe client with DNS rebinding protection
 			httpClient = NewSSRFSafeHTTPClient(DefaultHTTPTimeout, opts.RootCAs)
 		}
 	}

--- a/providers/oidc/exchange_test.go
+++ b/providers/oidc/exchange_test.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -56,6 +57,29 @@ func TestNewTokenExchangeClientWithOptions(t *testing.T) {
 		})
 		if client.httpClient != customHTTPClient {
 			t.Error("httpClient should use custom value")
+		}
+	})
+
+	// A token endpoint on a public address can present an internal-CA
+	// certificate, so RootCAs must reach the transport on both dial postures.
+	t.Run("RootCAs on every dial posture", func(t *testing.T) {
+		pool := x509.NewCertPool()
+
+		for _, allowPrivateIP := range []bool{false, true} {
+			client := NewTokenExchangeClientWithOptions(TokenExchangeClientOptions{
+				AllowPrivateIP: allowPrivateIP,
+				RootCAs:        pool,
+			})
+			transport, ok := client.httpClient.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("expected *http.Transport, got %T", client.httpClient.Transport)
+			}
+			if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs != pool {
+				t.Errorf("AllowPrivateIP=%v: expected the transport to verify against the supplied pool", allowPrivateIP)
+			}
+			if transport.TLSClientConfig != nil && transport.TLSClientConfig.InsecureSkipVerify {
+				t.Errorf("AllowPrivateIP=%v: InsecureSkipVerify must never be set", allowPrivateIP)
+			}
 		}
 	})
 }

--- a/providers/oidc/jwks_client_test.go
+++ b/providers/oidc/jwks_client_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	josejwt "github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/require"
 )
 
 // testKeyID is a constant for the test key ID used across tests.
@@ -888,4 +890,36 @@ func TestFetchJWKS_SecurityLimits(t *testing.T) {
 			t.Errorf("Expected %d keys, got %d", maxJWKSKeyCount, len(jwks.Keys))
 		}
 	})
+}
+
+// TestNewJWKSClientWithOptions_RootCAsOnEveryDialPosture verifies that
+// JWKSClientOptions.RootCAs reaches the transport whether or not the SSRF guard
+// is relaxed. A JWKS host on a public address can still present an internal-CA
+// certificate.
+func TestNewJWKSClientWithOptions_RootCAsOnEveryDialPosture(t *testing.T) {
+	t.Parallel()
+	pool := x509.NewCertPool()
+
+	cases := []struct {
+		name string
+		opts JWKSClientOptions
+	}{
+		{name: "ssrf-safe default", opts: JWKSClientOptions{RootCAs: pool}},
+		{name: "private IP allowed", opts: JWKSClientOptions{AllowPrivateIP: true, RootCAs: pool}},
+		{
+			name: "host scoped",
+			opts: JWKSClientOptions{AllowPrivateIPHosts: []string{"dex.example.com"}, RootCAs: pool},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client := NewJWKSClientWithOptions(tc.opts)
+			transport, ok := client.httpClient.Transport.(*http.Transport)
+			require.True(t, ok, "expected *http.Transport, got %T", client.httpClient.Transport)
+			require.NotNil(t, transport.TLSClientConfig)
+			require.Same(t, pool, transport.TLSClientConfig.RootCAs)
+			require.False(t, transport.TLSClientConfig.InsecureSkipVerify)
+		})
+	}
 }

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -102,10 +102,9 @@ type JWKSClientOptions struct {
 
 	// RootCAs is the CA pool used to verify the JWKS endpoint's TLS certificate
 	// (e.g. an internal-CA Dex). It applies on every dial posture, including the
-	// default SSRF-safe one: reachability and trust anchor are independent, so a
-	// JWKS host on a public address can still carry an internal-CA certificate.
-	// The pool replaces the system roots rather than extending them. nil uses the
-	// system pool. Ignored when HTTPClient is provided.
+	// default SSRF-safe one. The pool replaces the system roots rather than
+	// extending them. nil uses the system pool. Ignored when HTTPClient is
+	// provided.
 	RootCAs *x509.CertPool
 }
 
@@ -161,8 +160,7 @@ func NewJWKSClientWithOptions(opts JWKSClientOptions) *JWKSClient {
 		default:
 			// SECURITY: SSRF-safe client validates resolved IPs at connection
 			// time (DNS rebinding protection) and blocks private, loopback, and
-			// link-local addresses. RootCAs is honored here too: a JWKS host on a
-			// public address can still carry an internal-CA certificate.
+			// link-local addresses.
 			httpClient = NewSSRFSafeHTTPClient(DefaultHTTPTimeout, opts.RootCAs)
 		}
 	}

--- a/providers/oidc/jwt.go
+++ b/providers/oidc/jwt.go
@@ -101,8 +101,11 @@ type JWKSClientOptions struct {
 	AllowPrivateIPHosts []string
 
 	// RootCAs is the CA pool used to verify the JWKS endpoint's TLS certificate
-	// when AllowPrivateIP or AllowPrivateIPHosts is set (e.g. an internal-CA
-	// Dex). nil uses the system pool. Ignored when HTTPClient is provided.
+	// (e.g. an internal-CA Dex). It applies on every dial posture, including the
+	// default SSRF-safe one: reachability and trust anchor are independent, so a
+	// JWKS host on a public address can still carry an internal-CA certificate.
+	// The pool replaces the system roots rather than extending them. nil uses the
+	// system pool. Ignored when HTTPClient is provided.
 	RootCAs *x509.CertPool
 }
 
@@ -135,9 +138,8 @@ func NewJWKSClient(httpClient *http.Client, cacheTTL time.Duration, logger *slog
 //   - A warning is logged about reduced security
 //
 // Security Features:
-//   - TLS Verification: enforced (never InsecureSkipVerify); permissive and
-//     host-scoped clients verify against opts.RootCAs when provided, otherwise
-//     the system pool
+//   - TLS Verification: enforced (never InsecureSkipVerify); every client
+//     verifies against opts.RootCAs when provided, otherwise the system pool
 //   - Response Size Limit: Limits response body to 1MB
 //   - Key Count Limit: Limits JWKS to 100 keys
 //
@@ -159,8 +161,9 @@ func NewJWKSClientWithOptions(opts JWKSClientOptions) *JWKSClient {
 		default:
 			// SECURITY: SSRF-safe client validates resolved IPs at connection
 			// time (DNS rebinding protection) and blocks private, loopback, and
-			// link-local addresses.
-			httpClient = NewSSRFSafeHTTPClient(DefaultHTTPTimeout)
+			// link-local addresses. RootCAs is honored here too: a JWKS host on a
+			// public address can still carry an internal-CA certificate.
+			httpClient = NewSSRFSafeHTTPClient(DefaultHTTPTimeout, opts.RootCAs)
 		}
 	}
 

--- a/providers/oidc/time_provider.go
+++ b/providers/oidc/time_provider.go
@@ -43,6 +43,10 @@ const (
 
 	// DefaultDialerKeepAlive is the keep-alive period for TCP connections.
 	DefaultDialerKeepAlive = 30 * time.Second
+
+	// DefaultExpectContinueTimeout bounds the wait for a 100-continue response
+	// after the request headers are sent.
+	DefaultExpectContinueTimeout = 1 * time.Second
 )
 
 // timeProvider is an interface for time operations to enable deterministic testing.

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -307,23 +307,31 @@ func SSRFSafeDialContext(dialer *net.Dialer) func(ctx context.Context, network, 
 // This client validates that resolved IP addresses are not private/restricted
 // at connection time, preventing DNS rebinding attacks.
 //
+// Which IP addresses the client may reach and which CA signs the certificate it
+// trusts are independent: an IdP on a public address can still present a
+// certificate from an internal CA, so rootCAs applies here exactly as it does on
+// the permissive clients.
+//
 // Parameters:
 //   - timeout: HTTP client timeout (0 uses default 10 seconds)
+//   - rootCAs: CA pool the certificate is verified against; nil uses the system
+//     pool. The pool replaces the system roots, so a caller that needs both must
+//     pass a pool that already contains them.
 //
 // Security Features:
 //   - DNS Rebinding Protection: Validates resolved IPs at connection time
 //   - SSRF Protection: Blocks private, loopback, and link-local addresses
-//   - TLS Verification: Uses default TLS settings (no InsecureSkipVerify)
+//   - TLS Verification: enforced (never InsecureSkipVerify)
 //
 // Example:
 //
-//	client := NewSSRFSafeHTTPClient(30 * time.Second)
+//	client := NewSSRFSafeHTTPClient(30*time.Second, nil)
 //	resp, err := client.Get("https://example.com/jwks")
-func NewSSRFSafeHTTPClient(timeout time.Duration) *http.Client {
+func NewSSRFSafeHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
 	return newJWKSHTTPClient(timeout,
 		func(d *net.Dialer) dialContextFunc { return SSRFSafeDialContext(d) },
 		false, // pinHost: SSRF dial guard already blocks cross-host redirects to private IPs
-		nil,   // rootCAs: system pool only
+		rootCAs,
 	)
 }
 

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -323,26 +323,47 @@ func SSRFSafeDialContext(dialer *net.Dialer) func(ctx context.Context, network, 
 //	client := NewSSRFSafeHTTPClient(30*time.Second, nil)
 //	resp, err := client.Get("https://example.com/jwks")
 func NewSSRFSafeHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newJWKSHTTPClient(timeout,
-		func(d *net.Dialer) dialContextFunc { return SSRFSafeDialContext(d) },
-		false, // pinHost: SSRF dial guard already blocks cross-host redirects to private IPs
-		rootCAs,
-	)
+	return newHTTPClient(timeout, httpClientPosture{
+		dialFor: func(d *net.Dialer) dialContextFunc { return SSRFSafeDialContext(d) },
+		// pinHost: the SSRF dial guard already blocks cross-host redirects to
+		// private IPs.
+		pinHost: false,
+		// proxy: a proxied request would bypass the dial guard.
+		proxy: false,
+	}, rootCAs)
 }
 
-// dialContextFunc is the DialContext signature shared by the JWKS HTTP clients.
+// dialContextFunc is the DialContext signature shared by the package's HTTP
+// clients.
 type dialContextFunc = func(ctx context.Context, network, addr string) (net.Conn, error)
 
-// newJWKSHTTPClient builds the JWKS HTTP clients from their three differing
-// dimensions, keeping the transport/timeout block and the TLS decision in one
-// place. dialFor selects the dial posture (SSRF-safe, private-IP, host-scoped);
-// pinHost adds the cross-host redirect guard (needed when the dialer cannot
-// itself filter private IPs); rootCAs, when non-nil, is the explicit CA pool the
-// client verifies against (for an internal-CA IdP) — nil keeps the default
-// (system pool) verification. Only RootCAs is set on the TLS config, never
-// InsecureSkipVerify, so the "never InsecureSkipVerify" invariant holds even on
-// the permissive clients where the SSRF dial guard is relaxed.
-func newJWKSHTTPClient(timeout time.Duration, dialFor func(*net.Dialer) dialContextFunc, pinHost bool, rootCAs *x509.CertPool) *http.Client {
+// httpClientPosture holds the only dimensions on which the package's HTTP
+// clients differ. Every exported constructor states one posture and hands it to
+// newHTTPClient, so the transport tuning and the TLS decision have a single
+// definition.
+type httpClientPosture struct {
+	// dialFor selects the dial guard: SSRF-safe, private-IP, or host-scoped.
+	dialFor func(*net.Dialer) dialContextFunc
+
+	// pinHost adds the cross-host redirect guard. Required whenever the dialer
+	// cannot itself filter private IPs, so a redirect cannot pivot the fetch to
+	// an internal target the dialer would have to allow.
+	pinHost bool
+
+	// proxy honors the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables. Only a
+	// posture whose dialer applies no SSRF guard sets it: a proxied request
+	// dials the proxy, so the guard would inspect the proxy address instead of
+	// the target and the protection would be silently lost.
+	proxy bool
+}
+
+// newHTTPClient builds every HTTP client in this package. rootCAs, when
+// non-nil, is the explicit CA pool the client verifies against (for an
+// internal-CA IdP); nil keeps the default (system pool) verification. Only
+// RootCAs is set on the TLS config, never InsecureSkipVerify, so the "never
+// InsecureSkipVerify" invariant holds on every posture, including the
+// permissive ones where the SSRF dial guard is relaxed.
+func newHTTPClient(timeout time.Duration, posture httpClientPosture, rootCAs *x509.CertPool) *http.Client {
 	if timeout == 0 {
 		timeout = DefaultHTTPTimeout
 	}
@@ -353,11 +374,16 @@ func newJWKSHTTPClient(timeout time.Duration, dialFor func(*net.Dialer) dialCont
 	}
 
 	transport := &http.Transport{
-		DialContext:           dialFor(dialer),
+		DialContext:           posture.dialFor(dialer),
+		ForceAttemptHTTP2:     true,
 		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
 		ResponseHeaderTimeout: timeout,
+		ExpectContinueTimeout: DefaultExpectContinueTimeout,
 		MaxIdleConns:          DefaultMaxIdleConns,
 		IdleConnTimeout:       DefaultIdleConnTimeout,
+	}
+	if posture.proxy {
+		transport.Proxy = http.ProxyFromEnvironment
 	}
 	if rootCAs != nil {
 		transport.TLSClientConfig = &tls.Config{
@@ -370,11 +396,15 @@ func newJWKSHTTPClient(timeout time.Duration, dialFor func(*net.Dialer) dialCont
 		Transport: transport,
 		Timeout:   timeout,
 	}
-	if pinHost {
+	if posture.pinHost {
 		client.CheckRedirect = blockCrossHostRedirect
 	}
 	return client
 }
+
+// defaultDialContext returns the standard DialContext, which reaches private
+// IPs.
+func defaultDialContext(d *net.Dialer) dialContextFunc { return d.DialContext }
 
 // NewPrivateIPAllowedHTTPClient creates an HTTP client without SSRF protection.
 // This client allows connections to private IP addresses, which is necessary
@@ -385,6 +415,9 @@ func newJWKSHTTPClient(timeout time.Duration, dialFor func(*net.Dialer) dialCont
 //
 // Parameters:
 //   - timeout: HTTP client timeout (0 uses default 10 seconds)
+//   - rootCAs: CA pool to verify the IdP's certificate against; nil uses the
+//     system pool. Pass the internal CA when the private IdP presents a
+//     certificate from a CA not in the system pool.
 //
 // Security Features:
 //   - TLS Verification: enforced (never InsecureSkipVerify). Verifies against
@@ -401,23 +434,52 @@ func newJWKSHTTPClient(timeout time.Duration, dialFor func(*net.Dialer) dialCont
 //   - Air-gapped environments
 //   - Enterprise deployments with private IdPs
 //
-// Parameters:
-//   - timeout: HTTP client timeout (0 uses default 10 seconds)
-//   - rootCAs: CA pool to verify the IdP's certificate against; nil uses the
-//     system pool. Pass the internal CA when the private IdP presents a
-//     certificate from a CA not in the system pool.
-//
 // Example:
 //
 //	client := NewPrivateIPAllowedHTTPClient(30 * time.Second, dexCAPool)
 //	resp, err := client.Get("https://dex.internal/keys")
 func NewPrivateIPAllowedHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newJWKSHTTPClient(timeout,
+	return newHTTPClient(timeout, httpClientPosture{
 		// Standard dialer without SSRF protection (allows private IPs).
-		func(d *net.Dialer) dialContextFunc { return d.DialContext },
-		true, // pinHost: dialer cannot filter private IPs, so guard cross-host redirects
-		rootCAs,
-	)
+		dialFor: defaultDialContext,
+		// pinHost: the dialer cannot filter private IPs, so guard cross-host
+		// redirects.
+		pinHost: true,
+		// proxy: an operator who points this client at a private IdP expects a
+		// direct connection, and NO_PROXY handling belongs to the environment.
+		proxy: false,
+	}, rootCAs)
+}
+
+// NewDefaultDialHTTPClient creates an HTTP client for calls to an
+// operator-configured provider endpoint (OIDC discovery and the token
+// endpoint). It dials with the standard dialer, so the endpoint may resolve to
+// a private address, and it honors the proxy environment variables, so an
+// egress-proxied deployment keeps working.
+//
+// Use NewSSRFSafeHTTPClient instead whenever the target URL can come from a
+// token or a request. This client applies no dial guard.
+//
+// Parameters:
+//   - timeout: HTTP client timeout (0 uses default 10 seconds)
+//   - rootCAs: CA pool to verify the endpoint's certificate against; nil uses
+//     the system pool.
+//
+// Security Features:
+//   - TLS Verification: enforced (never InsecureSkipVerify)
+//   - Host-pinned redirects: a redirect to a different host or port is refused
+//   - No SSRF Protection: private, loopback, and link-local addresses are
+//     ALLOWED
+func NewDefaultDialHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
+	return newHTTPClient(timeout, httpClientPosture{
+		dialFor: defaultDialContext,
+		// pinHost: the dialer cannot filter private IPs, so guard cross-host
+		// redirects.
+		pinHost: true,
+		// proxy: the endpoint is operator-configured, and the dial guard this
+		// would bypass is not applied on this posture anyway.
+		proxy: true,
+	}, rootCAs)
 }
 
 func guardSSRF(host string, ips []net.IP) error {
@@ -472,11 +534,17 @@ func HostScopedPrivateIPDialContext(dialer *net.Dialer, allowedHosts []string) f
 // rootCAs, when non-nil, is the CA pool the client verifies the IdP's
 // certificate against; nil uses the system pool.
 func NewHostScopedPrivateIPHTTPClient(allowedHosts []string, timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newJWKSHTTPClient(timeout,
-		func(d *net.Dialer) dialContextFunc { return HostScopedPrivateIPDialContext(d, allowedHosts) },
-		true, // pinHost: private IPs allowed for the listed hosts, so guard cross-host redirects
-		rootCAs,
-	)
+	return newHTTPClient(timeout, httpClientPosture{
+		dialFor: func(d *net.Dialer) dialContextFunc {
+			return HostScopedPrivateIPDialContext(d, allowedHosts)
+		},
+		// pinHost: private IPs are allowed for the listed hosts, so guard
+		// cross-host redirects.
+		pinHost: true,
+		// proxy: a proxied request would bypass the dial guard that protects
+		// every host outside the list.
+		proxy: false,
+	}, rootCAs)
 }
 
 // blockCrossHostRedirect refuses a redirect whose target host or port differs

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -307,33 +307,26 @@ func SSRFSafeDialContext(dialer *net.Dialer) func(ctx context.Context, network, 
 // clients.
 type dialContextFunc = func(ctx context.Context, network, addr string) (net.Conn, error)
 
-// httpClientPosture holds the only dimensions on which the package's HTTP
-// clients differ. Every exported constructor states one posture and hands it to
-// newHTTPClient, so the transport tuning and the TLS decision have a single
-// definition.
-type httpClientPosture struct {
-	// dialFor selects the dial guard: SSRF-safe, private-IP, or host-scoped.
-	dialFor func(*net.Dialer) dialContextFunc
-
-	// pinHost refuses a redirect to another host. Set it whenever dialFor
-	// cannot filter private IPs for every host, so a redirect cannot pivot the
-	// fetch to an internal target the dialer would have to allow.
-	pinHost bool
-
-	// proxy honors the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables. Set it
-	// only where dialFor guards nothing: a proxied request dials the proxy, so
-	// a guard would inspect the proxy address instead of the target and the
-	// protection would be silently lost.
-	proxy bool
-}
-
-// newHTTPClient builds every HTTP client in this package. rootCAs, when
-// non-nil, is the explicit CA pool the client verifies against (for an
-// internal-CA IdP); nil keeps the default (system pool) verification. Only
-// RootCAs is set on the TLS config, never InsecureSkipVerify, so the "never
-// InsecureSkipVerify" invariant holds on every posture, including the
+// newHTTPClient builds every HTTP client in this package, so the transport
+// tuning and the TLS decision have a single definition. The clients differ on
+// four arguments only:
+//
+//   - dialFor selects the dial guard: SSRF-safe, private-IP, or host-scoped.
+//   - pinHost refuses a redirect to another host. Set it whenever dialFor
+//     cannot filter private IPs for every host, so a redirect cannot pivot the
+//     fetch to an internal target the dialer would have to allow.
+//   - proxy honors the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables. Set it
+//     only where dialFor guards nothing: a proxied request dials the proxy, so
+//     a guard would inspect the proxy address instead of the target and the
+//     protection would be silently lost.
+//   - rootCAs, when non-nil, is the explicit CA pool the client verifies
+//     against (for an internal-CA IdP); nil keeps the default (system pool)
+//     verification.
+//
+// Only RootCAs is set on the TLS config, never InsecureSkipVerify, so the
+// "never InsecureSkipVerify" invariant holds on every client, including the
 // permissive ones where the SSRF dial guard is relaxed.
-func newHTTPClient(timeout time.Duration, posture httpClientPosture, rootCAs *x509.CertPool) *http.Client {
+func newHTTPClient(timeout time.Duration, dialFor func(*net.Dialer) dialContextFunc, pinHost, proxy bool, rootCAs *x509.CertPool) *http.Client {
 	if timeout == 0 {
 		timeout = DefaultHTTPTimeout
 	}
@@ -344,7 +337,7 @@ func newHTTPClient(timeout time.Duration, posture httpClientPosture, rootCAs *x5
 	}
 
 	transport := &http.Transport{
-		DialContext:           posture.dialFor(dialer),
+		DialContext:           dialFor(dialer),
 		ForceAttemptHTTP2:     true,
 		TLSHandshakeTimeout:   DefaultTLSHandshakeTimeout,
 		ResponseHeaderTimeout: timeout,
@@ -352,7 +345,7 @@ func newHTTPClient(timeout time.Duration, posture httpClientPosture, rootCAs *x5
 		MaxIdleConns:          DefaultMaxIdleConns,
 		IdleConnTimeout:       DefaultIdleConnTimeout,
 	}
-	if posture.proxy {
+	if proxy {
 		transport.Proxy = http.ProxyFromEnvironment
 	}
 	if rootCAs != nil {
@@ -366,7 +359,7 @@ func newHTTPClient(timeout time.Duration, posture httpClientPosture, rootCAs *x5
 		Transport: transport,
 		Timeout:   timeout,
 	}
-	if posture.pinHost {
+	if pinHost {
 		client.CheckRedirect = blockCrossHostRedirect
 	}
 	return client
@@ -396,7 +389,10 @@ func defaultDialContext(dialer *net.Dialer) dialContextFunc { return dialer.Dial
 //	client := NewSSRFSafeHTTPClient(30*time.Second, nil)
 //	resp, err := client.Get("https://example.com/jwks")
 func NewSSRFSafeHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{dialFor: SSRFSafeDialContext}, rootCAs)
+	return newHTTPClient(timeout, SSRFSafeDialContext,
+		false, // pinHost: the dial guard already blocks redirects to private IPs
+		false, // proxy: a proxied request would bypass the dial guard
+		rootCAs)
 }
 
 // NewPrivateIPAllowedHTTPClient creates an HTTP client without SSRF protection.
@@ -432,7 +428,10 @@ func NewSSRFSafeHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.
 //	client := NewPrivateIPAllowedHTTPClient(30 * time.Second, dexCAPool)
 //	resp, err := client.Get("https://dex.internal/keys")
 func NewPrivateIPAllowedHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{dialFor: defaultDialContext, pinHost: true}, rootCAs)
+	return newHTTPClient(timeout, defaultDialContext,
+		true,  // pinHost: the dialer cannot filter private IPs
+		false, // proxy: a private IdP is reached directly
+		rootCAs)
 }
 
 // NewDefaultDialHTTPClient creates an HTTP client for calls to an
@@ -455,7 +454,10 @@ func NewPrivateIPAllowedHTTPClient(timeout time.Duration, rootCAs *x509.CertPool
 //   - No SSRF Protection: private, loopback, and link-local addresses are
 //     ALLOWED
 func NewDefaultDialHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{dialFor: defaultDialContext, pinHost: true, proxy: true}, rootCAs)
+	return newHTTPClient(timeout, defaultDialContext,
+		true, // pinHost: the dialer cannot filter private IPs
+		true, // proxy: the endpoint is operator-configured
+		rootCAs)
 }
 
 func guardSSRF(host string, ips []net.IP) error {
@@ -510,12 +512,13 @@ func HostScopedPrivateIPDialContext(dialer *net.Dialer, allowedHosts []string) f
 // rootCAs, when non-nil, is the CA pool the client verifies the IdP's
 // certificate against; nil uses the system pool.
 func NewHostScopedPrivateIPHTTPClient(allowedHosts []string, timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{
-		dialFor: func(d *net.Dialer) dialContextFunc {
-			return HostScopedPrivateIPDialContext(d, allowedHosts)
-		},
-		pinHost: true,
-	}, rootCAs)
+	dialFor := func(dialer *net.Dialer) dialContextFunc {
+		return HostScopedPrivateIPDialContext(dialer, allowedHosts)
+	}
+	return newHTTPClient(timeout, dialFor,
+		true,  // pinHost: private IPs are allowed for the listed hosts
+		false, // proxy: a proxied request would bypass the dial guard
+		rootCAs)
 }
 
 // blockCrossHostRedirect refuses a redirect whose target host or port differs

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -307,16 +307,11 @@ func SSRFSafeDialContext(dialer *net.Dialer) func(ctx context.Context, network, 
 // This client validates that resolved IP addresses are not private/restricted
 // at connection time, preventing DNS rebinding attacks.
 //
-// Which IP addresses the client may reach and which CA signs the certificate it
-// trusts are independent: an IdP on a public address can still present a
-// certificate from an internal CA, so rootCAs applies here exactly as it does on
-// the permissive clients.
-//
 // Parameters:
 //   - timeout: HTTP client timeout (0 uses default 10 seconds)
-//   - rootCAs: CA pool the certificate is verified against; nil uses the system
-//     pool. The pool replaces the system roots, so a caller that needs both must
-//     pass a pool that already contains them.
+//   - rootCAs: CA pool the certificate is verified against (e.g. an internal-CA
+//     IdP on a public address). It replaces the system roots rather than
+//     extending them. nil uses the system pool.
 //
 // Security Features:
 //   - DNS Rebinding Protection: Validates resolved IPs at connection time

--- a/providers/oidc/validation.go
+++ b/providers/oidc/validation.go
@@ -303,36 +303,6 @@ func SSRFSafeDialContext(dialer *net.Dialer) func(ctx context.Context, network, 
 	}
 }
 
-// NewSSRFSafeHTTPClient creates an HTTP client with DNS rebinding protection.
-// This client validates that resolved IP addresses are not private/restricted
-// at connection time, preventing DNS rebinding attacks.
-//
-// Parameters:
-//   - timeout: HTTP client timeout (0 uses default 10 seconds)
-//   - rootCAs: CA pool the certificate is verified against (e.g. an internal-CA
-//     IdP on a public address). It replaces the system roots rather than
-//     extending them. nil uses the system pool.
-//
-// Security Features:
-//   - DNS Rebinding Protection: Validates resolved IPs at connection time
-//   - SSRF Protection: Blocks private, loopback, and link-local addresses
-//   - TLS Verification: enforced (never InsecureSkipVerify)
-//
-// Example:
-//
-//	client := NewSSRFSafeHTTPClient(30*time.Second, nil)
-//	resp, err := client.Get("https://example.com/jwks")
-func NewSSRFSafeHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{
-		dialFor: func(d *net.Dialer) dialContextFunc { return SSRFSafeDialContext(d) },
-		// pinHost: the SSRF dial guard already blocks cross-host redirects to
-		// private IPs.
-		pinHost: false,
-		// proxy: a proxied request would bypass the dial guard.
-		proxy: false,
-	}, rootCAs)
-}
-
 // dialContextFunc is the DialContext signature shared by the package's HTTP
 // clients.
 type dialContextFunc = func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -345,15 +315,15 @@ type httpClientPosture struct {
 	// dialFor selects the dial guard: SSRF-safe, private-IP, or host-scoped.
 	dialFor func(*net.Dialer) dialContextFunc
 
-	// pinHost adds the cross-host redirect guard. Required whenever the dialer
-	// cannot itself filter private IPs, so a redirect cannot pivot the fetch to
-	// an internal target the dialer would have to allow.
+	// pinHost refuses a redirect to another host. Set it whenever dialFor
+	// cannot filter private IPs for every host, so a redirect cannot pivot the
+	// fetch to an internal target the dialer would have to allow.
 	pinHost bool
 
-	// proxy honors the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables. Only a
-	// posture whose dialer applies no SSRF guard sets it: a proxied request
-	// dials the proxy, so the guard would inspect the proxy address instead of
-	// the target and the protection would be silently lost.
+	// proxy honors the HTTP_PROXY, HTTPS_PROXY and NO_PROXY variables. Set it
+	// only where dialFor guards nothing: a proxied request dials the proxy, so
+	// a guard would inspect the proxy address instead of the target and the
+	// protection would be silently lost.
 	proxy bool
 }
 
@@ -404,7 +374,30 @@ func newHTTPClient(timeout time.Duration, posture httpClientPosture, rootCAs *x5
 
 // defaultDialContext returns the standard DialContext, which reaches private
 // IPs.
-func defaultDialContext(d *net.Dialer) dialContextFunc { return d.DialContext }
+func defaultDialContext(dialer *net.Dialer) dialContextFunc { return dialer.DialContext }
+
+// NewSSRFSafeHTTPClient creates an HTTP client with DNS rebinding protection.
+// This client validates that resolved IP addresses are not private/restricted
+// at connection time, preventing DNS rebinding attacks.
+//
+// Parameters:
+//   - timeout: HTTP client timeout (0 uses default 10 seconds)
+//   - rootCAs: CA pool the certificate is verified against (e.g. an internal-CA
+//     IdP on a public address). It replaces the system roots rather than
+//     extending them. nil uses the system pool.
+//
+// Security Features:
+//   - DNS Rebinding Protection: Validates resolved IPs at connection time
+//   - SSRF Protection: Blocks private, loopback, and link-local addresses
+//   - TLS Verification: enforced (never InsecureSkipVerify)
+//
+// Example:
+//
+//	client := NewSSRFSafeHTTPClient(30*time.Second, nil)
+//	resp, err := client.Get("https://example.com/jwks")
+func NewSSRFSafeHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
+	return newHTTPClient(timeout, httpClientPosture{dialFor: SSRFSafeDialContext}, rootCAs)
+}
 
 // NewPrivateIPAllowedHTTPClient creates an HTTP client without SSRF protection.
 // This client allows connections to private IP addresses, which is necessary
@@ -439,16 +432,7 @@ func defaultDialContext(d *net.Dialer) dialContextFunc { return d.DialContext }
 //	client := NewPrivateIPAllowedHTTPClient(30 * time.Second, dexCAPool)
 //	resp, err := client.Get("https://dex.internal/keys")
 func NewPrivateIPAllowedHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{
-		// Standard dialer without SSRF protection (allows private IPs).
-		dialFor: defaultDialContext,
-		// pinHost: the dialer cannot filter private IPs, so guard cross-host
-		// redirects.
-		pinHost: true,
-		// proxy: an operator who points this client at a private IdP expects a
-		// direct connection, and NO_PROXY handling belongs to the environment.
-		proxy: false,
-	}, rootCAs)
+	return newHTTPClient(timeout, httpClientPosture{dialFor: defaultDialContext, pinHost: true}, rootCAs)
 }
 
 // NewDefaultDialHTTPClient creates an HTTP client for calls to an
@@ -471,15 +455,7 @@ func NewPrivateIPAllowedHTTPClient(timeout time.Duration, rootCAs *x509.CertPool
 //   - No SSRF Protection: private, loopback, and link-local addresses are
 //     ALLOWED
 func NewDefaultDialHTTPClient(timeout time.Duration, rootCAs *x509.CertPool) *http.Client {
-	return newHTTPClient(timeout, httpClientPosture{
-		dialFor: defaultDialContext,
-		// pinHost: the dialer cannot filter private IPs, so guard cross-host
-		// redirects.
-		pinHost: true,
-		// proxy: the endpoint is operator-configured, and the dial guard this
-		// would bypass is not applied on this posture anyway.
-		proxy: true,
-	}, rootCAs)
+	return newHTTPClient(timeout, httpClientPosture{dialFor: defaultDialContext, pinHost: true, proxy: true}, rootCAs)
 }
 
 func guardSSRF(host string, ips []net.IP) error {
@@ -538,12 +514,7 @@ func NewHostScopedPrivateIPHTTPClient(allowedHosts []string, timeout time.Durati
 		dialFor: func(d *net.Dialer) dialContextFunc {
 			return HostScopedPrivateIPDialContext(d, allowedHosts)
 		},
-		// pinHost: private IPs are allowed for the listed hosts, so guard
-		// cross-host redirects.
 		pinHost: true,
-		// proxy: a proxied request would bypass the dial guard that protects
-		// every host outside the list.
-		proxy: false,
 	}, rootCAs)
 }
 

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -2,7 +2,6 @@ package oidc
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -985,55 +984,6 @@ func TestPrivateIPAllowedHTTPClient_CATrust(t *testing.T) {
 		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			t.Errorf("expected 200, got %d", resp.StatusCode)
-		}
-	})
-}
-
-// TestSSRFSafeHTTPClient_TrustsExplicitCA verifies that the SSRF-safe client
-// verifies against the rootCAs argument, so an IdP on a public address can
-// present an internal-CA certificate.
-//
-// The SSRF dialer blocks loopback, so the handshake is driven from the
-// transport's TLS config rather than through client.Get.
-func TestSSRFSafeHTTPClient_TrustsExplicitCA(t *testing.T) {
-	t.Parallel()
-	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(srv.Close)
-
-	pool := x509.NewCertPool()
-	pool.AddCert(srv.Certificate())
-	addr := srv.Listener.Addr().String()
-
-	tlsConfigOf := func(client *http.Client) *tls.Config {
-		transport, ok := client.Transport.(*http.Transport)
-		if !ok {
-			t.Fatalf("expected *http.Transport, got %T", client.Transport)
-		}
-		return transport.TLSClientConfig
-	}
-
-	t.Run("explicit pool trusts the internal CA", func(t *testing.T) {
-		tlsConfig := tlsConfigOf(NewSSRFSafeHTTPClient(0, pool))
-		if tlsConfig == nil || tlsConfig.RootCAs != pool {
-			t.Fatal("expected the transport to verify against the supplied pool")
-		}
-		conn, err := tls.Dial("tcp", addr, tlsConfig.Clone())
-		if err != nil {
-			t.Fatalf("expected the handshake to succeed with the explicit CA pool, got: %v", err)
-		}
-		_ = conn.Close()
-	})
-
-	t.Run("nil pool keeps system-pool verification", func(t *testing.T) {
-		if tlsConfig := tlsConfigOf(NewSSRFSafeHTTPClient(0, nil)); tlsConfig != nil && tlsConfig.RootCAs != nil {
-			t.Error("expected no explicit CA pool when rootCAs is nil")
-		}
-		conn, err := tls.Dial("tcp", addr, &tls.Config{MinVersion: tls.VersionTLS12})
-		if err == nil {
-			_ = conn.Close()
-			t.Fatal("expected the self-signed server to be rejected by the system pool")
 		}
 	})
 }

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -990,9 +990,8 @@ func TestPrivateIPAllowedHTTPClient_CATrust(t *testing.T) {
 }
 
 // TestSSRFSafeHTTPClient_TrustsExplicitCA verifies that the SSRF-safe client
-// verifies against the rootCAs argument. Reachability and trust anchor are
-// independent: an IdP on a public address can present an internal-CA
-// certificate, so the pool must apply on the default dial posture too.
+// verifies against the rootCAs argument, so an IdP on a public address can
+// present an internal-CA certificate.
 //
 // The SSRF dialer blocks loopback, so the handshake is driven from the
 // transport's TLS config rather than through client.Get.
@@ -1007,9 +1006,17 @@ func TestSSRFSafeHTTPClient_TrustsExplicitCA(t *testing.T) {
 	pool.AddCert(srv.Certificate())
 	addr := srv.Listener.Addr().String()
 
+	tlsConfigOf := func(client *http.Client) *tls.Config {
+		transport, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport, got %T", client.Transport)
+		}
+		return transport.TLSClientConfig
+	}
+
 	t.Run("explicit pool trusts the internal CA", func(t *testing.T) {
-		tlsConfig := transportTLSConfig(t, NewSSRFSafeHTTPClient(0, pool))
-		if tlsConfig.RootCAs != pool {
+		tlsConfig := tlsConfigOf(NewSSRFSafeHTTPClient(0, pool))
+		if tlsConfig == nil || tlsConfig.RootCAs != pool {
 			t.Fatal("expected the transport to verify against the supplied pool")
 		}
 		conn, err := tls.Dial("tcp", addr, tlsConfig.Clone())
@@ -1020,12 +1027,7 @@ func TestSSRFSafeHTTPClient_TrustsExplicitCA(t *testing.T) {
 	})
 
 	t.Run("nil pool keeps system-pool verification", func(t *testing.T) {
-		client := NewSSRFSafeHTTPClient(0, nil)
-		transport, ok := client.Transport.(*http.Transport)
-		if !ok {
-			t.Fatalf("expected *http.Transport, got %T", client.Transport)
-		}
-		if transport.TLSClientConfig != nil && transport.TLSClientConfig.RootCAs != nil {
+		if tlsConfig := tlsConfigOf(NewSSRFSafeHTTPClient(0, nil)); tlsConfig != nil && tlsConfig.RootCAs != nil {
 			t.Error("expected no explicit CA pool when rootCAs is nil")
 		}
 		conn, err := tls.Dial("tcp", addr, &tls.Config{MinVersion: tls.VersionTLS12})
@@ -1034,17 +1036,4 @@ func TestSSRFSafeHTTPClient_TrustsExplicitCA(t *testing.T) {
 			t.Fatal("expected the self-signed server to be rejected by the system pool")
 		}
 	})
-}
-
-// transportTLSConfig returns the TLS config the client's transport uses.
-func transportTLSConfig(t *testing.T, client *http.Client) *tls.Config {
-	t.Helper()
-	transport, ok := client.Transport.(*http.Transport)
-	if !ok {
-		t.Fatalf("expected *http.Transport, got %T", client.Transport)
-	}
-	if transport.TLSClientConfig == nil {
-		t.Fatal("expected a TLS config on the transport")
-	}
-	return transport.TLSClientConfig
 }

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -1037,3 +1037,109 @@ func TestSSRFSafeHTTPClient_TrustsExplicitCA(t *testing.T) {
 		}
 	})
 }
+
+// TestHTTPClients_ShareOneTransportShape verifies that every exported client
+// constructor goes through the shared builder, so a transport setting cannot
+// drift on one posture only.
+func TestHTTPClients_ShareOneTransportShape(t *testing.T) {
+	t.Parallel()
+	pool := x509.NewCertPool()
+	const timeout = 7 * time.Second
+
+	clients := map[string]*http.Client{
+		"ssrf-safe":          NewSSRFSafeHTTPClient(timeout, pool),
+		"private-IP allowed": NewPrivateIPAllowedHTTPClient(timeout, pool),
+		"host scoped":        NewHostScopedPrivateIPHTTPClient([]string{"dex.example.com"}, timeout, pool),
+		"default dial":       NewDefaultDialHTTPClient(timeout, pool),
+	}
+
+	for name, client := range clients {
+		t.Run(name, func(t *testing.T) {
+			if client.Timeout != timeout {
+				t.Errorf("Timeout = %v, want %v", client.Timeout, timeout)
+			}
+			transport, ok := client.Transport.(*http.Transport)
+			if !ok {
+				t.Fatalf("expected *http.Transport, got %T", client.Transport)
+			}
+			if transport.DialContext == nil {
+				t.Error("expected a DialContext")
+			}
+			if !transport.ForceAttemptHTTP2 {
+				t.Error("expected HTTP/2 to be attempted")
+			}
+			if transport.TLSHandshakeTimeout != DefaultTLSHandshakeTimeout {
+				t.Errorf("TLSHandshakeTimeout = %v, want %v", transport.TLSHandshakeTimeout, DefaultTLSHandshakeTimeout)
+			}
+			if transport.ResponseHeaderTimeout != timeout {
+				t.Errorf("ResponseHeaderTimeout = %v, want %v", transport.ResponseHeaderTimeout, timeout)
+			}
+			if transport.ExpectContinueTimeout != DefaultExpectContinueTimeout {
+				t.Errorf("ExpectContinueTimeout = %v, want %v", transport.ExpectContinueTimeout, DefaultExpectContinueTimeout)
+			}
+			if transport.MaxIdleConns != DefaultMaxIdleConns {
+				t.Errorf("MaxIdleConns = %d, want %d", transport.MaxIdleConns, DefaultMaxIdleConns)
+			}
+			if transport.IdleConnTimeout != DefaultIdleConnTimeout {
+				t.Errorf("IdleConnTimeout = %v, want %v", transport.IdleConnTimeout, DefaultIdleConnTimeout)
+			}
+			if transport.TLSClientConfig == nil || transport.TLSClientConfig.RootCAs != pool {
+				t.Fatal("expected the transport to verify against the supplied pool")
+			}
+			if transport.TLSClientConfig.InsecureSkipVerify {
+				t.Error("InsecureSkipVerify must never be set")
+			}
+		})
+	}
+}
+
+// TestHTTPClients_ProxyOnlyWhereTheDialGuardIsAbsent verifies that a proxy can
+// never bypass a dial guard: a posture that filters resolved IPs must not read
+// the proxy environment, because a proxied request dials the proxy instead of
+// the target.
+func TestHTTPClients_ProxyOnlyWhereTheDialGuardIsAbsent(t *testing.T) {
+	t.Parallel()
+
+	guarded := map[string]*http.Client{
+		"ssrf-safe":   NewSSRFSafeHTTPClient(0, nil),
+		"host scoped": NewHostScopedPrivateIPHTTPClient([]string{"dex.example.com"}, 0, nil),
+	}
+	for name, client := range guarded {
+		t.Run(name, func(t *testing.T) {
+			if client.Transport.(*http.Transport).Proxy != nil {
+				t.Error("a guarded client must not honor the proxy environment")
+			}
+		})
+	}
+
+	t.Run("default dial", func(t *testing.T) {
+		if NewDefaultDialHTTPClient(0, nil).Transport.(*http.Transport).Proxy == nil {
+			t.Error("expected the provider-endpoint client to honor the proxy environment")
+		}
+	})
+}
+
+// TestHTTPClients_RedirectGuard verifies that every client whose dialer cannot
+// filter private IPs pins redirects to the original host.
+func TestHTTPClients_RedirectGuard(t *testing.T) {
+	t.Parallel()
+
+	pinned := map[string]*http.Client{
+		"private-IP allowed": NewPrivateIPAllowedHTTPClient(0, nil),
+		"host scoped":        NewHostScopedPrivateIPHTTPClient([]string{"dex.example.com"}, 0, nil),
+		"default dial":       NewDefaultDialHTTPClient(0, nil),
+	}
+	for name, client := range pinned {
+		t.Run(name, func(t *testing.T) {
+			if client.CheckRedirect == nil {
+				t.Error("expected the cross-host redirect guard")
+			}
+		})
+	}
+
+	t.Run("ssrf-safe relies on the dial guard", func(t *testing.T) {
+		if NewSSRFSafeHTTPClient(0, nil).CheckRedirect != nil {
+			t.Error("expected no redirect guard on the SSRF-safe client")
+		}
+	})
+}

--- a/providers/oidc/validation_test.go
+++ b/providers/oidc/validation_test.go
@@ -2,6 +2,7 @@ package oidc
 
 import (
 	"context"
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net"
@@ -647,7 +648,7 @@ func TestSSRFSafeDialContext(t *testing.T) {
 // TestNewSSRFSafeHTTPClient tests the SSRF-safe HTTP client creation.
 func TestNewSSRFSafeHTTPClient(t *testing.T) {
 	t.Run("creates client with default timeout", func(t *testing.T) {
-		client := NewSSRFSafeHTTPClient(0)
+		client := NewSSRFSafeHTTPClient(0, nil)
 		if client == nil {
 			t.Fatal("Expected non-nil client")
 		}
@@ -657,7 +658,7 @@ func TestNewSSRFSafeHTTPClient(t *testing.T) {
 	})
 
 	t.Run("creates client with custom timeout", func(t *testing.T) {
-		client := NewSSRFSafeHTTPClient(30 * time.Second)
+		client := NewSSRFSafeHTTPClient(30*time.Second, nil)
 		if client == nil {
 			t.Fatal("Expected non-nil client")
 		}
@@ -667,7 +668,7 @@ func TestNewSSRFSafeHTTPClient(t *testing.T) {
 	})
 
 	t.Run("client has custom transport", func(t *testing.T) {
-		client := NewSSRFSafeHTTPClient(0)
+		client := NewSSRFSafeHTTPClient(0, nil)
 		if client.Transport == nil {
 			t.Error("Expected client to have custom transport for DNS rebinding protection")
 		}
@@ -986,4 +987,64 @@ func TestPrivateIPAllowedHTTPClient_CATrust(t *testing.T) {
 			t.Errorf("expected 200, got %d", resp.StatusCode)
 		}
 	})
+}
+
+// TestSSRFSafeHTTPClient_TrustsExplicitCA verifies that the SSRF-safe client
+// verifies against the rootCAs argument. Reachability and trust anchor are
+// independent: an IdP on a public address can present an internal-CA
+// certificate, so the pool must apply on the default dial posture too.
+//
+// The SSRF dialer blocks loopback, so the handshake is driven from the
+// transport's TLS config rather than through client.Get.
+func TestSSRFSafeHTTPClient_TrustsExplicitCA(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(srv.Certificate())
+	addr := srv.Listener.Addr().String()
+
+	t.Run("explicit pool trusts the internal CA", func(t *testing.T) {
+		tlsConfig := transportTLSConfig(t, NewSSRFSafeHTTPClient(0, pool))
+		if tlsConfig.RootCAs != pool {
+			t.Fatal("expected the transport to verify against the supplied pool")
+		}
+		conn, err := tls.Dial("tcp", addr, tlsConfig.Clone())
+		if err != nil {
+			t.Fatalf("expected the handshake to succeed with the explicit CA pool, got: %v", err)
+		}
+		_ = conn.Close()
+	})
+
+	t.Run("nil pool keeps system-pool verification", func(t *testing.T) {
+		client := NewSSRFSafeHTTPClient(0, nil)
+		transport, ok := client.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport, got %T", client.Transport)
+		}
+		if transport.TLSClientConfig != nil && transport.TLSClientConfig.RootCAs != nil {
+			t.Error("expected no explicit CA pool when rootCAs is nil")
+		}
+		conn, err := tls.Dial("tcp", addr, &tls.Config{MinVersion: tls.VersionTLS12})
+		if err == nil {
+			_ = conn.Close()
+			t.Fatal("expected the self-signed server to be rejected by the system pool")
+		}
+	})
+}
+
+// transportTLSConfig returns the TLS config the client's transport uses.
+func transportTLSConfig(t *testing.T, client *http.Client) *tls.Config {
+	t.Helper()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("expected a TLS config on the transport")
+	}
+	return transport.TLSClientConfig
 }

--- a/server/config.go
+++ b/server/config.go
@@ -623,8 +623,10 @@ type Config struct {
 	// signed by a private CA). nil uses the system pool.
 	//
 	// The consuming process must build and pass this pool explicitly; mcp-oauth
-	// no longer reads a CA installed on http.DefaultTransport. Typically set
-	// alongside AllowPrivateIPJWKS for a private-IP, internal-CA IdP.
+	// no longer reads a CA installed on http.DefaultTransport. It applies with or
+	// without AllowPrivateIPJWKS, so an internal-CA IdP on a public address is
+	// trusted without relaxing the SSRF guard. The pool replaces the system roots
+	// rather than extending them.
 	JWKSRootCAs *x509.CertPool
 
 	// BlockedRedirectSchemes lists URI schemes that are always rejected for security.

--- a/server/config.go
+++ b/server/config.go
@@ -624,9 +624,8 @@ type Config struct {
 	//
 	// The consuming process must build and pass this pool explicitly; mcp-oauth
 	// no longer reads a CA installed on http.DefaultTransport. It applies with or
-	// without AllowPrivateIPJWKS, so an internal-CA IdP on a public address is
-	// trusted without relaxing the SSRF guard. The pool replaces the system roots
-	// rather than extending them.
+	// without AllowPrivateIPJWKS. The pool replaces the system roots rather than
+	// extending them.
 	JWKSRootCAs *x509.CertPool
 
 	// BlockedRedirectSchemes lists URI schemes that are always rejected for security.

--- a/server/sso.go
+++ b/server/sso.go
@@ -134,11 +134,9 @@ func (s *Server) findMatchingTrustedAudience(tokenAudiences []string) string {
 //   - When true: Private IPs are allowed for internal IdP deployments
 func (s *Server) getJWKSClient() *oidc.JWKSClient {
 	s.jwksClientOnce.Do(func() {
-		// When AllowPrivateIPJWKS is set, NewJWKSClientWithOptions builds the
-		// permissive client via NewPrivateIPAllowedHTTPClient, which keeps the
-		// cross-host redirect guard and tuned timeouts. An internal-CA Dex
-		// forwarding SSO ID tokens is trusted by passing the configured
-		// JWKSRootCAs pool explicitly (nil = system pool).
+		// AllowPrivateIPJWKS selects the dial posture; JWKSRootCAs pins the
+		// trust anchor and applies on either one (nil = system pool). An
+		// internal-CA Dex is trusted without relaxing the SSRF guard.
 		s.jwksClient = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
 			Logger:         s.Logger,
 			AllowPrivateIP: s.Config.AllowPrivateIPJWKS,

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -168,11 +168,9 @@ type TrustedIssuer struct {
 	AllowPrivateIPJWKSHosts []string
 
 	// RootCAs is the CA pool used to verify this issuer's JWKS endpoint TLS
-	// certificate when the endpoint presents a certificate from an internal CA.
-	// It applies with or without AllowPrivateIPJWKS / AllowPrivateIPJWKSHosts:
-	// a JWKS host on a public address can still carry an internal-CA
-	// certificate. The pool replaces the system roots rather than extending
-	// them. nil uses the system pool.
+	// certificate (e.g. an internal-CA Dex). It applies with or without
+	// AllowPrivateIPJWKS / AllowPrivateIPJWKSHosts. The pool replaces the system
+	// roots rather than extending them. nil uses the system pool.
 	RootCAs *x509.CertPool
 	// AcceptedTypHeaders lists the JWT typ header values accepted when a
 	// Bearer token from this issuer is presented to the resource server.
@@ -222,10 +220,8 @@ func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 				RootCAs:             ti.RootCAs,
 			})
 		} else if ti.RootCAs != nil {
-			// An issuer whose JWKS host resolves to a public address can still
-			// present an internal-CA certificate. Give it its own SSRF-safe
-			// client pinned to its pool instead of the shared system-pool one,
-			// so trust never depends on relaxing the SSRF guard.
+			// Own SSRF-safe client pinned to this issuer's pool, rather than the
+			// shared system-pool one.
 			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
 				RootCAs: ti.RootCAs,
 			})

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -202,30 +202,17 @@ func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 	safe := oidc.NewJWKSClient(nil, 0, nil)
 	issuerClients := map[string]*oidc.JWKSClient{}
 	for _, ti := range issuers {
-		if ti.AllowPrivateIPJWKS {
-			// AllowPrivateIPJWKS targets a controlled in-cluster endpoint,
-			// which commonly presents a certificate from an internal CA.
-			// NewJWKSClientWithOptions builds the permissive client via
-			// NewPrivateIPAllowedHTTPClient, which keeps the cross-host
-			// redirect guard and tuned timeouts and verifies against the
-			// issuer's RootCAs pool (nil = system pool). Each issuer gets its
-			// own client so per-issuer RootCAs are honored.
-			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
-				AllowPrivateIP: true,
-				RootCAs:        ti.RootCAs,
-			})
-		} else if len(ti.AllowPrivateIPJWKSHosts) > 0 {
-			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
-				AllowPrivateIPHosts: ti.AllowPrivateIPJWKSHosts,
-				RootCAs:             ti.RootCAs,
-			})
-		} else if ti.RootCAs != nil {
-			// Own SSRF-safe client pinned to this issuer's pool, rather than the
-			// shared system-pool one.
-			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
-				RootCAs: ti.RootCAs,
-			})
+		if !ti.AllowPrivateIPJWKS && len(ti.AllowPrivateIPJWKSHosts) == 0 && ti.RootCAs == nil {
+			continue
 		}
+		// NewJWKSClientWithOptions applies the same precedence: AllowPrivateIP,
+		// then AllowPrivateIPHosts, then the SSRF-safe default. A pool alone
+		// therefore yields an SSRF-safe client pinned to that pool.
+		issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+			AllowPrivateIP:      ti.AllowPrivateIPJWKS,
+			AllowPrivateIPHosts: ti.AllowPrivateIPJWKSHosts,
+			RootCAs:             ti.RootCAs,
+		})
 	}
 	return newOIDCValidatorWithClients(issuers, safe, issuerClients)
 }

--- a/server/subject_validator.go
+++ b/server/subject_validator.go
@@ -168,9 +168,11 @@ type TrustedIssuer struct {
 	AllowPrivateIPJWKSHosts []string
 
 	// RootCAs is the CA pool used to verify this issuer's JWKS endpoint TLS
-	// certificate when AllowPrivateIPJWKS or AllowPrivateIPJWKSHosts is set and
-	// the endpoint presents a certificate from an internal CA. nil uses the
-	// system pool.
+	// certificate when the endpoint presents a certificate from an internal CA.
+	// It applies with or without AllowPrivateIPJWKS / AllowPrivateIPJWKSHosts:
+	// a JWKS host on a public address can still carry an internal-CA
+	// certificate. The pool replaces the system roots rather than extending
+	// them. nil uses the system pool.
 	RootCAs *x509.CertPool
 	// AcceptedTypHeaders lists the JWT typ header values accepted when a
 	// Bearer token from this issuer is presented to the resource server.
@@ -195,6 +197,9 @@ type OIDCValidator struct {
 // SSRF-safe JWKS fetches are the default; set AllowPrivateIPJWKSHosts on an
 // issuer to allow private-IP JWKS only for the listed hostnames, or
 // AllowPrivateIPJWKS to disable SSRF protection entirely for that issuer.
+//
+// An issuer gets its own JWKS client whenever it sets either of those flags or
+// a RootCAs pool. Reachability and trust anchor are independent settings.
 func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 	safe := oidc.NewJWKSClient(nil, 0, nil)
 	issuerClients := map[string]*oidc.JWKSClient{}
@@ -215,6 +220,14 @@ func NewOIDCValidator(issuers []TrustedIssuer) (*OIDCValidator, error) {
 			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
 				AllowPrivateIPHosts: ti.AllowPrivateIPJWKSHosts,
 				RootCAs:             ti.RootCAs,
+			})
+		} else if ti.RootCAs != nil {
+			// An issuer whose JWKS host resolves to a public address can still
+			// present an internal-CA certificate. Give it its own SSRF-safe
+			// client pinned to its pool instead of the shared system-pool one,
+			// so trust never depends on relaxing the SSRF guard.
+			issuerClients[ti.Issuer] = oidc.NewJWKSClientWithOptions(oidc.JWKSClientOptions{
+				RootCAs: ti.RootCAs,
 			})
 		}
 	}

--- a/server/subject_validator_catrust_test.go
+++ b/server/subject_validator_catrust_test.go
@@ -179,3 +179,37 @@ func TestNewOIDCValidator_PerIssuerRootCAs(t *testing.T) {
 		require.Equal(t, testSubject, identity.Subject)
 	}
 }
+
+// TestNewOIDCValidator_RootCAsWithoutPrivateIPFlags verifies that an issuer
+// carrying only a RootCAs pool gets its own JWKS client instead of the shared
+// system-pool one. An issuer whose JWKS host resolves to a public address can
+// still present an internal-CA certificate, so trust must not depend on
+// relaxing the SSRF guard.
+//
+// The SSRF-safe dialer blocks the loopback test server, so the assertion is on
+// the client the validator built, not on a fetch.
+func TestNewOIDCValidator_RootCAsWithoutPrivateIPFlags(t *testing.T) {
+	t.Parallel()
+	pool := x509.NewCertPool()
+
+	const plainIssuer = "https://plain.issuer.example.com"
+	v, err := NewOIDCValidator([]TrustedIssuer{
+		{
+			Issuer:           testIssuer,
+			JwksURL:          "https://internal-ca.example.com/keys",
+			AllowedAudiences: []string{testAudience},
+			RootCAs:          pool,
+		},
+		{
+			Issuer:           plainIssuer,
+			JwksURL:          "https://public.example.com/keys",
+			AllowedAudiences: []string{testAudience},
+		},
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, v.issuerClients, testIssuer,
+		"an issuer with RootCAs must get its own client")
+	require.NotContains(t, v.issuerClients, plainIssuer,
+		"an issuer without RootCAs must keep the shared safe client")
+}


### PR DESCRIPTION
## Problem

`RootCAs` was only read on the permissive dial postures. `providers/oidc/jwt.go`, `providers/oidc/exchange.go` and `providers/dex/dex.go` all dropped the configured pool when `AllowPrivateIP` was false, and `NewOIDCValidator` handed every non-permissive issuer a shared client built with `oidc.NewJWKSClient(nil, 0, nil)`.

Reachability and trust anchor are independent. An IdP whose host resolves to a public address can still present an internal-CA certificate. In that case TLS verification failed, and the only workaround was to relax the SSRF guard for a reason that has nothing to do with SSRF.

Found while checking whether muster's `--extra-ca-file` reaches the OIDC discovery and JWKS clients (it does, but only on the permissive paths).

## Change

- `oidc.NewSSRFSafeHTTPClient` takes a `rootCAs *x509.CertPool` parameter, matching `NewPrivateIPAllowedHTTPClient` and `NewHostScopedPrivateIPHTTPClient`. This is a breaking signature change, noted in the CHANGELOG.
- `JWKSClientOptions.RootCAs` and `TokenExchangeClientOptions.RootCAs` are passed through on the default posture.
- A `TrustedIssuer` that sets only `RootCAs` gets its own JWKS client instead of the shared system-pool one.
- `docs/security.md` gains an "Internal CA trust" subsection stating that the pool replaces the system roots rather than extending them.

No default changes: with a nil pool every client behaves exactly as before.

## One constructor for every client

The first round pinned the CA on a transport the `dex` package built itself, which then carried none of the settings the JWKS clients share. Every client in `providers/oidc` and `providers/dex` now comes from one internal `newHTTPClient`, which takes an `httpClientPosture` holding the only dimensions they differ on: the dial guard, the redirect guard, and whether the proxy environment is read. A guarded posture never reads the proxy environment, because a proxied request dials the proxy and the dial guard would then inspect the proxy address instead of the target.

`oidc.NewDefaultDialHTTPClient` is the posture the Dex provider needs on its non-permissive path: standard dialer, host-pinned redirects, proxy environment honored, `rootCAs` verified. Production code still holds no read of `http.DefaultTransport` (#495).

Two behaviour changes fall out, both in the CHANGELOG: every client attempts HTTP/2 where the server offers it, and a Dex discovery or token-endpoint redirect to a different host or port is now refused.
