### PR TITLE
fix(valkey): disable client-side caching for RESP2-only servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Valkey store connects to RESP2-only servers. It sets `DisableCache` on the valkey-go client, so the client no longer sends `CLIENT TRACKING` at connect and no longer fails with `ErrNoCache` on a server that rejects it. No read path used the client-side cache.
 - Every `RootCAs` field now applies whether or not the private-IP flags are set. `oidc.JWKSClientOptions.RootCAs`, `oidc.TokenExchangeClientOptions.RootCAs`, `server.TrustedIssuer.RootCAs` and `dex.Config.RootCAs` were dropped on the SSRF-safe dial posture, so an IdP whose host resolves to a public address but presents an internal-CA certificate failed TLS with no way to fix it short of relaxing the SSRF guard. A `server.TrustedIssuer` that sets only `RootCAs` now gets its own JWKS client instead of the shared system-pool one.
 
 ## [1.1.0] - 2026-07-16

--- a/storage/valkey/store.go
+++ b/storage/valkey/store.go
@@ -263,6 +263,11 @@ func buildClientOpts(cfg Config) valkeygo.ClientOption {
 	opts := valkeygo.ClientOption{
 		InitAddress: []string{cfg.Address},
 		SelectDB:    cfg.DB,
+		// No read path uses Client.DoCache, so client-side caching buys nothing
+		// here. Leaving it on makes valkey-go send CLIENT TRACKING at connect
+		// and abort with ErrNoCache on servers that reject it (RESP2-only
+		// servers, and proxies that accept HELLO 3 without CLIENT TRACKING).
+		DisableCache: true,
 	}
 	if cfg.Password != "" {
 		opts.Password = cfg.Password

--- a/storage/valkey/store_test.go
+++ b/storage/valkey/store_test.go
@@ -2,6 +2,7 @@ package valkey
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -2345,4 +2346,30 @@ func TestStore_SaveTokenMetadata_WithScopesAndAudience(t *testing.T) {
 	if meta.Audience != testAudienceURL {
 		t.Errorf("Audience = %q, want %q", meta.Audience, testAudienceURL)
 	}
+}
+
+func TestBuildClientOpts(t *testing.T) {
+	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+
+	opts := buildClientOpts(Config{
+		Address:  "valkey.example.com:6379",
+		Password: "s3cret",
+		DB:       3,
+		TLS:      tlsConfig,
+	})
+
+	require.Equal(t, []string{"valkey.example.com:6379"}, opts.InitAddress)
+	require.Equal(t, 3, opts.SelectDB)
+	require.Equal(t, "s3cret", opts.Password)
+	require.Same(t, tlsConfig, opts.TLSConfig)
+	require.True(t, opts.DisableCache, "client-side caching must stay off so RESP2-only servers can connect")
+}
+
+func TestBuildClientOptsMinimal(t *testing.T) {
+	opts := buildClientOpts(Config{Address: "localhost:6379"})
+
+	require.Equal(t, []string{"localhost:6379"}, opts.InitAddress)
+	require.Empty(t, opts.Password)
+	require.Nil(t, opts.TLSConfig)
+	require.True(t, opts.DisableCache)
 }


### PR DESCRIPTION
## Problem

`valkey.New()` fails at startup against a server without RESP3 or without `CLIENT TRACKING` (Redis 5, and proxies that accept `HELLO 3` but reject `CLIENT TRACKING`). valkey-go sends `CLIENT TRACKING ON OPTIN` at connect and aborts with `ErrNoCache` unless `ClientOption.DisableCache` is set, which `buildClientOpts` never did.

The library already falls back to RESP2 when the handshake is rejected, but only when `DisableCache` is true.

## Change

Set `DisableCache: true` in `buildClientOpts`. The store has no `Client.DoCache` call anywhere, so the cache was never read and this costs nothing. Every command the store issues (`SET`, `GET`, `DEL`, `SMEMBERS`, `EVAL`, `SCAN`, `PING`, `EXPIRE`, `TTL`, `SADD`, `INCR`, `EXISTS`) works on Redis 5.

The issue also proposed `Config.DisableCache` and `Config.AlwaysRESP2` fields. Two knobs whose only correct value is `true` would leave the default broken, so this takes the unconditional route instead. `AlwaysRESP2` only saves one failed handshake round trip; it can be added if someone needs it.

Closes #540